### PR TITLE
fix for dataframe constructor with 1 feature

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -1956,9 +1956,16 @@ class Remove_100(BaseEstimator,TransformerMixin):
 
   def fit_transform(self,dataset,y=None):
     data = dataset.copy()
-    corr = pd.DataFrame(np.corrcoef(data.drop(self.target,axis=1).T))
-    corr.columns = data.drop(self.target,axis=1).columns
-    corr.index = data.drop(self.target,axis=1).columns
+
+    targetless_data = data.drop(self.target, axis=1)
+
+    # correlation should be calculated between at least two features, if there is only 1, there is nothing to delete
+    if len(targetless_data.columns) <= 1:
+      return dataset
+
+    corr = pd.DataFrame(np.corrcoef(targetless_data.T))
+    corr.columns = targetless_data.columns
+    corr.index = targetless_data.columns
     corr_matrix = abs(corr)
 
     # Now, add a column for variable name and drop index


### PR DESCRIPTION
Fix for https://github.com/pycaret/pycaret/issues/18

Tested on my old big dataframe from the other my pull request + tested on the data from issue above

The problem happens at the stage when highly correlated features are removed.

Correlation between 1 feature is 1, which is not the matrix, so pandas dataframe can not be created and there is no need for further correlation analysis. 
I added extra checking to see if there is only 1 feature and return original frame if there is.

Also, to save some time for very big dataframes (as drop had to be done 3 times +1 with this fix), I added 1 variable and replaced with it those 3 places. Sorry for having 2 fixes in the same place. I know it's a bad practice, but...