### PR TITLE
fix memory issue for features with big numbers (ID column detection)

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -120,15 +120,13 @@ class DataTypes_Auto_infer(BaseEstimator,TransformerMixin):
         if i not in self.numerical_features:
           if sum(data[i].isna()) == 0: 
             if len(data[i].unique()) == len_samples:
-              min_number = min(data[i])
-              max_number = max(data[i])
-              arr = np.arange(min_number,max_number+1,1)
-              try:
-                all_match = sum(data[i].sort_values() == arr)
-                if all_match == len_samples:
-                  self.id_columns.append(i) 
-              except:
-                None 
+              # we extract column and sort it
+              features = data[i].sort_values()
+              # no we subtract i+1-th value from i-th (calculating increments)
+              increments = features.diff()[1:]
+              # if all increments are 0 (with float tolerance), then the column is ID column
+              if sum(np.abs(increments-1) < 1e-7) == len_samples-1:
+                self.id_columns.append(i)
       
     data_len = len(data)                        
         

--- a/preprocess.py
+++ b/preprocess.py
@@ -124,7 +124,7 @@ class DataTypes_Auto_infer(BaseEstimator,TransformerMixin):
               features = data[i].sort_values()
               # no we subtract i+1-th value from i-th (calculating increments)
               increments = features.diff()[1:]
-              # if all increments are 0 (with float tolerance), then the column is ID column
+              # if all increments are 1 (with float tolerance), then the column is ID column
               if sum(np.abs(increments-1) < 1e-7) == len_samples-1:
                 self.id_columns.append(i)
       


### PR DESCRIPTION
Fix for https://github.com/pycaret/pycaret/issues/19

It was caused by ID column detector.

It was creating big ranges for features that had very big numbers and then comparing such ranges with sorted features. Sometimes it results in "out of memory" problem.

Now there are no ranges. ID column is detected by increment checking. If all increments in sorted array are 1, then it's ID column.

Potential way to save more memory and power:
Use loop and compare increment by increment unless there is a difference other than 1.
It will save more memory as there will be no additional array created + when it's not ID column, loop will stop at first stages without having to calculate further increments. While now all the increments are calculated.

But I decided to keep the same "beautiful" style based on numpy and pandas functions.

___

Tested on ID column with int numbers 880:1021, column gets data type "ID Column" as it should.