### PR TITLE
Moved setup requirements to requirements.txt only

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.md LICENSE
+include README.md LICENSE requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ def readme():
     return README
 
 
+with open('requirements.txt') as f:
+    required = f.read().splitlines()
+
 setup(
     name="pycaret",
     version="1.0.1",
@@ -42,10 +45,5 @@ setup(
     ],
     packages=["pycaret"],
     include_package_data=True,
-    install_requires=["pandas", "numpy", "seaborn", "matplotlib", "IPython", "joblib", 
-                     "scikit-learn>=0.22", "shap>=0.32.1", "ipywidgets", "yellowbrick>=1.0.1", "xgboost>=0.90",
-                     "wordcloud", "textblob", "plotly>=4.4.1", "cufflinks>=0.17.0", "umap-learn",
-                     "lightgbm>=2.3.1", "pyLDAvis", "gensim", "spacy", "nltk", "mlxtend",
-                     "pyod", "catboost>=0.20.2", "pandas-profiling>=2.3.0", "kmodes>=0.10.1",
-                     "datefinder>=0.7.0", "datetime", "DateTime>=4.3", "awscli"]
+    install_requires=required
 )


### PR DESCRIPTION
Before we had to change requirements in two files, now it's done only in requirements.txt, so that people who do not want to install it as package can just simply load it from git and install with requirements.txt. That's the reason we dont move everything to just setup.py

Though, you might keep it as it is now. I've never been paying attention how it's done, so I just did as it's said in https://github.com/pycaret/pycaret/pull/78