### PR TITLE
Fixed installation via setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
     ],
-    packages=["pycaret"],
     include_package_data=True,
     install_requires=required
 )


### PR DESCRIPTION
I tried to install this dev branch via 
`pip install https://github.com/pycaret/pycaret/archive/dev-1.0.1.zip`

But got weird error that pycaret package is not found. So I've loaded stable branch and tried to run installation via setup.py, same error. After deleting the line (this commit) everything installed well.

And it's okay to delete this line? (idk, but it worked and it does not go against  https://docs.python.org/2/distutils/setupscript.html#installing-package-data )

Tested on pip version 19.2.1 and python 3.6.8