### PR TITLE
fix for "cannot convert float infinity to integer"

### DIFF
--- a/classification.py
+++ b/classification.py
@@ -690,6 +690,10 @@ def setup(data,
     #ignore warnings
     import warnings
     warnings.filterwarnings('ignore') 
+
+    # replace infinite numbers with NaN
+    if isinstance(data, pd.DataFrame):
+          data.replace([np.inf, -np.inf], np.nan, inplace = True)
     
     #copy original data for pandas profiler
     data_before_preprocess = data.copy()

--- a/clustering.py
+++ b/clustering.py
@@ -491,6 +491,10 @@ def setup(data,
     #defining global variables
     global data_, X, seed, prep_pipe, prep_param, experiment__
     
+    # replace infinite numbers with NaN
+    if isinstance(data, pd.DataFrame):
+          data.replace([np.inf, -np.inf], np.nan, inplace = True)
+
     #copy original data for pandas profiler
     data_before_preprocess = data.copy()
     

--- a/regression.py
+++ b/regression.py
@@ -709,6 +709,10 @@ def setup(data,
     import warnings
     warnings.filterwarnings('ignore') 
     
+    # replace infinite numbers with NaN
+    if isinstance(data, pd.DataFrame):
+          data.replace([np.inf, -np.inf], np.nan, inplace = True)
+
     #copy original data for pandas profiler
     data_before_preprocess = data.copy()
     


### PR DESCRIPTION
Added replacing of infinite numbers with NaN.

Potential fix for https://github.com/pycaret/pycaret/issues/102

This replacement will happen for data variable (and only in case if data passed has pandas dataframe type, since only it has the replace functionality. All other cases are not taken into account and the problem might still exist for those very rare cases) at the beginning, thus "unmodified" data will be slightly modified. I decided to do it with all data because in the end there is a checking for untouched dataframe for missing values with .isna(), while infinite numbers are still numbers (like float('inf')). They are basically useless in ML and can be considered as missing values. That's why I'm changing it for all variables.

Note: I have not checked it. I'm just pointing to a potential solution.