### PR TITLE
fix for "cannot convert float infinity to integer"

### DIFF
--- a/pycaret/preprocess.py
+++ b/pycaret/preprocess.py
@@ -2327,6 +2327,10 @@ def Preprocess_Path_One(train_data,target_variable,ml_usecase=None,test_data =No
       -20) Apply diamension reduction techniques such as pca_liner, pca_kernal, incremental, tsne 
           - except for pca_liner, all other method only takes number of component (as integer) i.e no variance explaination metohd available  
   '''
+  # replacing infinite values with NaN values, because they are practically useless and should be imprinted later
+  if isinstance(train_data, pd.DataFrame):
+          train_data.replace([np.inf, -np.inf], np.nan, inplace = True)
+  
   global c2, subcase
   # WE NEED TO AUTO INFER the ml use case
   c1 = train_data[target_variable].dtype == 'int64'


### PR DESCRIPTION
Added replacing of infinite numbers with NaN.

Potential fix for https://github.com/pycaret/pycaret/issues/102

This replacement will happen for data variable (and only in case if data passed has pandas dataframe type, since only it has the replace functionality. All other cases are not taken into account and the problem might still exist for those very rare cases) at the beginning, thus "unmodified" data will be slightly modified. I decided to do it with all data because in the end there is a checking for untouched dataframe for missing values with .isna(), while infinite numbers are still numbers (like float('inf')). They are basically useless in ML and can be considered as missing values. That's why I'm changing it for all variables.

Note: I have not checked it. I'm just pointing to a potential solution. Please, test before merging