### PR TITLE
fix NameError: name 'display' is not defined

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -2,6 +2,7 @@
 # Author: Moez Ali <moez.ali@queensu.ca>
 # License: MIT
 
+from IPython.display import DisplayObject, display
 
 def get_data(dataset, save_copy=False, profile = False):
     


### PR DESCRIPTION
Fix the error:

Traceback (most recent call last):
File "pycaretest.py", line 2, in
juice = get_data('juice')
File "/usr/local/lib/python3.7/site-packages/pycaret/datasets.py", line 77, in get_data
display(data.head())
NameError: name 'display' is not defined