### PR TITLE
Preventing CatBoost models from creating files

### DIFF
--- a/classification.py
+++ b/classification.py
@@ -4240,7 +4240,7 @@ def tune_model(estimator = None,
                       #'ctr_border_count':[50,5,10,20,100,200]
                       }
         
-        model_grid = RandomizedSearchCV(estimator=CatBoostClassifier(random_state=seed, silent = True), 
+        model_grid = RandomizedSearchCV(estimator=CatBoostClassifier(random_state=seed, silent=True, allow_writing_files=False), 
                                         param_distributions=param_grid, scoring=optimize, n_iter=n_iter, 
                                         cv=cv, random_state=seed, n_jobs=-1)
 
@@ -4846,7 +4846,7 @@ def blend_models(estimator_list = 'All',
         et = ExtraTreesClassifier(random_state=seed)
         xgboost = XGBClassifier(random_state=seed, n_jobs=-1, verbosity=0)
         lightgbm = lgb.LGBMClassifier(random_state=seed)
-        #catboost = CatBoostClassifier(random_state=seed, silent = True)
+        #catboost = CatBoostClassifier(random_state=seed, silent=True, allow_writing_files=False)
         
         progress.value += 1
         

--- a/classification.py
+++ b/classification.py
@@ -3265,7 +3265,7 @@ def compare_models(blacklist = None,
     et = ExtraTreesClassifier(random_state=seed)
     xgboost = XGBClassifier(random_state=seed, n_jobs=-1, verbosity=0)
     lightgbm = lgb.LGBMClassifier(random_state=seed)
-    catboost = CatBoostClassifier(random_state=seed, silent = True) 
+    catboost = CatBoostClassifier(random_state=seed, silent=True, allow_writing_files=False) 
     
     progress.value += 1
     

--- a/classification.py
+++ b/classification.py
@@ -1861,7 +1861,7 @@ def create_model(estimator = None,
         
     elif estimator == 'catboost':
         from catboost import CatBoostClassifier
-        model = CatBoostClassifier(random_state=seed, silent=True) # Silent is True to suppress CatBoost iteration results 
+        model = CatBoostClassifier(random_state=seed, silent=True, allow_writing_files=False) # Silent is True to suppress CatBoost iteration results 
         full_name = 'CatBoost Classifier'
         
     else:

--- a/regression.py
+++ b/regression.py
@@ -1885,7 +1885,7 @@ def create_model(estimator = None,
         
     elif estimator == 'catboost':
         from catboost import CatBoostRegressor
-        model = CatBoostRegressor(random_state=seed, silent = True)
+        model = CatBoostRegressor(random_state=seed, silent=True, allow_writing_files=False)
         full_name = 'CatBoost Regressor'
         
     else:
@@ -2742,7 +2742,7 @@ def compare_models(blacklist = None,
     mlp = MLPRegressor(random_state=seed)
     xgboost = XGBRegressor(random_state=seed, n_jobs=-1, verbosity=0)
     lightgbm = lgb.LGBMRegressor(random_state=seed)
-    catboost = CatBoostRegressor(random_state=seed, silent = True)
+    catboost = CatBoostRegressor(random_state=seed, silent=True, , allow_writing_files=False)
     
     progress.value += 1
     

--- a/regression.py
+++ b/regression.py
@@ -2742,7 +2742,7 @@ def compare_models(blacklist = None,
     mlp = MLPRegressor(random_state=seed)
     xgboost = XGBRegressor(random_state=seed, n_jobs=-1, verbosity=0)
     lightgbm = lgb.LGBMRegressor(random_state=seed)
-    catboost = CatBoostRegressor(random_state=seed, silent=True, , allow_writing_files=False)
+    catboost = CatBoostRegressor(random_state=seed, silent=True, allow_writing_files=False)
     
     progress.value += 1
     
@@ -3277,7 +3277,7 @@ def blend_models(estimator_list = 'All',
         mlp = MLPRegressor(random_state=seed)
         xgboost = XGBRegressor(random_state=seed, n_jobs=-1, verbosity=0)
         lightgbm = lgb.LGBMRegressor(random_state=seed)
-        catboost = CatBoostRegressor(random_state=seed, silent = True)
+        catboost = CatBoostRegressor(random_state=seed, silent=True, allow_writing_files=False)
 
         progress.value += 1
         
@@ -4322,7 +4322,7 @@ def tune_model(estimator = None,
                       #'ctr_border_count':[50,5,10,20,100,200]
                       }
             
-        model_grid = RandomizedSearchCV(estimator=CatBoostRegressor(random_state=seed, silent=True), 
+        model_grid = RandomizedSearchCV(estimator=CatBoostRegressor(random_state=seed, silent=True, allow_writing_files=False), 
                                         param_distributions=param_grid, scoring=optimize, n_iter=n_iter, 
                                         cv=cv, random_state=seed, n_jobs=-1)
 


### PR DESCRIPTION
Should prevent CatBoostClassifier and CatBoostRegressor from writing files to disk. The downside is that catboost methods and functions for visualisations and snapshots will be unavailable.
"If set to “False”, the snapshot and data visualization tools are unavailable." from docs.