### PR TITLE
Categorical labels for classification predict_models()

### DIFF
--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -10630,16 +10630,6 @@ def predict_model(estimator,
     """
     exception checking ends here
     """
-
-    # function to replace encoded labels with their original values
-    # will not run if categorical_labels is false
-    def replace_lables_in_column(label_column):
-        if not categorical_labels:
-            return
-        _, dtypes = next(step for step in prep_pipe.steps if step[0] == "dtypes")
-        if dtypes and hasattr(dtypes, "replacement"):
-            replacement_mapper = {int(v): k for k, v in dtypes.replacement.items()}
-            label_column.replace(replacement_mapper, inplace=True)
     
     estimator = deepcopy(estimator) #lookout for an alternate of deepcopy()
     
@@ -10693,6 +10683,17 @@ def predict_model(estimator,
             
             sys.exit("(Type Error): Transformation Pipe Missing. ")
         
+    _, dtypes = next(step for step in prep_pipe_transformer.steps if step[0] == "dtypes")
+
+    # function to replace encoded labels with their original values
+    # will not run if categorical_labels is false
+    def replace_lables_in_column(label_column):
+        if not categorical_labels:
+            return
+        if dtypes and hasattr(dtypes, "replacement"):
+            replacement_mapper = {int(v): k for k, v in dtypes.replacement.items()}
+            label_column.replace(replacement_mapper, inplace=True)
+
     #dataset
     if data is None:
         

--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -10632,9 +10632,9 @@ def predict_model(estimator,
     """
 
     # function to replace encoded labels with their original values
-    # will not run if replace_labels is false
+    # will not run if categorical_labels is false
     def replace_lables_in_column(label_column):
-        if not replace_labels:
+        if not categorical_labels:
             return
         _, dtypes = next(step for step in prep_pipe.steps if step[0] == "dtypes")
         if dtypes and hasattr(dtypes, "replacement"):


### PR DESCRIPTION
Adds an option to classificaiton `predict_models()` to output labels as original categories, instead of outputting them in an encoded integer form. Default behavior is unchanged.

References https://github.com/pycaret/pycaret/issues/262