### PR TITLE
Refactor compare_models()

### DIFF
--- a/pycaret/tests/test_classification.py
+++ b/pycaret/tests/test_classification.py
@@ -28,6 +28,9 @@ def test():
     # stack models
     stacker = pycaret.classification.stack_models(estimator_list = top3)
 
+    # compare created models
+    pycaret.classification.compare_models(estimator_list=top3+tuned_top3+bagged_top3+[blender])
+
     # get config
     X_train = pycaret.classification.get_config('X_train')
     X_test = pycaret.classification.get_config('X_test')

--- a/pycaret/tests/test_regression.py
+++ b/pycaret/tests/test_regression.py
@@ -28,6 +28,9 @@ def test():
     # stack models
     stacker = pycaret.regression.stack_models(estimator_list = top3[1:], meta_model = top3[0])
 
+    # compare created models
+    pycaret.regression.compare_models(estimator_list=top3+tuned_top3+bagged_top3+[blender])
+
     # get config
     X_train = pycaret.regression.get_config('X_train')
     X_test = pycaret.regression.get_config('X_test')


### PR DESCRIPTION
Refactors `compare_models()` in classification and regression modules in order to:
* Use `create_models()` internally, with **unchanged** display (required modification of create_models(), however default functionality is unchanged)
* Accept completed models to be compared with `estimator_list` parameter - it is possible to now run code such as:
```python
top3 = compare_models(n_select=3)
top3_tuned = [tune_model(x) for x in top3)
compare_models(estimator_list=top3+top3_tuned) # will create a score grid of passed models, allowing for easy comparison of untuned and tuned ones. Also works with ensembled and blended models, though stacked models are currently unsupported
```
![image](https://user-images.githubusercontent.com/10364161/89468672-457ba580-d778-11ea-87d6-2c0b636781ca.png) (the index is on purpose, as it is the same as the index of elements in the passed list)
* Cut down on the code, general cleanup of some parts

This will allow maintenance to be much easier, as `compare_models()` will not need to be edited aside from adding some names to dicts (which should be global, to be honest). As a side effect, `compare_models()` is now faster, as it doesn't need to recreate models again for saving best. Later, I would like to add an option to compare models with train set instead of CV.

Also made it so that `create_models()` shows the TT in score grid (so that it can be shown in `compare_models()`. Could probably be extended to other functions.

References https://github.com/pycaret/pycaret/issues/358