### PR TITLE
Replace python3 command with python command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - pip install codecov
 install:
   - pip install -r requirements.txt
-  - python3 -m spacy download en
+  - python -m spacy download en
 script: pytest # run tests
 after_success:
   - codecov # submit coverage


### PR DESCRIPTION
The purpose is to unify the rules with other command(pip)　.