### PR TITLE
Categorical labels, fix predict indices

### DIFF
--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -9597,6 +9597,7 @@ def predict_model(estimator,
         X_test_ = X_test.copy()
         y_test_ = y_test.copy()
         
+        index = None
         Xtest.reset_index(drop=True, inplace=True)
         ytest.reset_index(drop=True, inplace=True)
         X_test_.reset_index(drop=True, inplace=True)
@@ -9618,6 +9619,12 @@ def predict_model(estimator,
             
         Xtest = data.copy()
         X_test_ = data.copy()
+        Xtest.reset_index(drop=True, inplace=True)
+        X_test_.reset_index(inplace=True)
+
+        index = X_test_['index']
+        X_test_.drop('index', axis=1, inplace=True)
+        
         
     #model name
     full_name = str(estimator).split("(")[0]
@@ -9727,6 +9734,10 @@ def predict_model(estimator,
         display_container.append(df_score)
     except:
         pass
+
+    if index is not None:
+        X_test_['index'] = index
+        X_test_.set_index('index', drop=True, inplace=True)
 
     return X_test_
 

--- a/pycaret/regression.py
+++ b/pycaret/regression.py
@@ -8417,6 +8417,7 @@ def predict_model(estimator,
         X_test_ = X_test.copy()
         y_test_ = y_test.copy()
         
+        index = None
         Xtest.reset_index(drop=True, inplace=True)
         ytest.reset_index(drop=True, inplace=True)
         X_test_.reset_index(drop=True, inplace=True)
@@ -8438,6 +8439,11 @@ def predict_model(estimator,
             
         Xtest = data.copy()
         X_test_ = data.copy()
+        Xtest.reset_index(drop=True, inplace=True)
+        X_test_.reset_index(inplace=True)
+
+        index = X_test_['index']
+        X_test_.drop('index', axis=1, inplace=True)
 
     # model name
     full_name = str(estimator).split("(")[0]
@@ -8524,6 +8530,10 @@ def predict_model(estimator,
         display_container.append(df_score)
     except:
         pass
+
+    if index is not None:
+        X_test_['index'] = index
+        X_test_.set_index('index', drop=True, inplace=True)
 
     return X_test_
 


### PR DESCRIPTION
Adds functionality from https://github.com/pycaret/pycaret/pull/348 to `master`, fixes an issue where unseen data passed to `predict_model()` in classification or regression would result in misaligned indices after appending the `Label` column.