### PR TITLE
Nightly publish workflow

### DIFF
--- a/.github/CI/check_latest_commit_for_nightly.py
+++ b/.github/CI/check_latest_commit_for_nightly.py
@@ -1,0 +1,77 @@
+from datetime import datetime, timedelta
+import sys
+import traceback
+import requests
+
+# Author: Antoni Baum (Yard1)
+# Helper script to see if it's worth pushing to nightly, to be used in a GitHub Workflow
+# exit code 0 = push to nightly
+# exit code 1 = don't push to nightly
+
+BASE_URL = "https://api.github.com"
+OWNER = "pycaret"
+REPO = "pycaret"
+DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def get_commits_from_repo(owner: str, repo: str):
+    r = requests.get(f"{BASE_URL}/repos/{owner}/{repo}/commits")
+    if r.status_code == 200 and r.text:
+        return r.json()
+    else:
+        r.raise_for_status()
+        return
+
+
+def get_commit_from_repo_sha(owner: str, repo: str, sha: str):
+    commit = {}
+    commit_status = {}
+    r = requests.get(f"{BASE_URL}/repos/{owner}/{repo}/commits/{sha}")
+    if r.status_code == 200 and r.text:
+        commit = r.json()
+    else:
+        r.raise_for_status()
+    # get status too
+    r = requests.get(f"{BASE_URL}/repos/{owner}/{repo}/commits/{sha}/status")
+    if r.status_code == 200 and r.text:
+        commit_status = r.json()
+    else:
+        r.raise_for_status()
+    return (commit, commit_status)
+
+
+def are_there_commits_in_last_day(commit) -> bool:
+    now = datetime.now()
+    last_day = now - timedelta(days=1)
+    last_commit_date = commit["commit"]["committer"]["date"]
+    last_commit_date = datetime.strptime(last_commit_date, DATE_FORMAT)
+    return last_commit_date >= last_day
+
+
+def has_commit_passed_ci(commit_status) -> bool:
+    return commit_status["state"] == "success"
+
+
+def main():
+    try:
+        commits = get_commits_from_repo(OWNER, REPO)
+        latest_commit, latest_commit_status = get_commit_from_repo_sha(
+            OWNER, REPO, commits[0]["sha"]
+        )
+        if are_there_commits_in_last_day(latest_commit) and has_commit_passed_ci(latest_commit_status):
+            print(
+                f"Latest commit {latest_commit['sha']} was made after 24h ago and passed CI, can push to nightly"
+            )
+            return 0
+    except:
+        print(f"There was an exception, push to nightly anyway")
+        traceback.print_exc()
+        return 0
+    print(
+        f"Latest commit {latest_commit['sha']} was either made before 24 ago or didn't pass CI, can't push to nightly"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/CI/check_latest_commit_for_nightly.py
+++ b/.github/CI/check_latest_commit_for_nightly.py
@@ -61,15 +61,14 @@ def main():
         for test_workflow in test_workflows:
             print(f"\"{test_workflow['name']}\" determined as test workflow")
             test_workflow_id = test_workflow["id"]
-            latest_run = get_workflow_runs_for_id_branch(
+            latest_passing_run = next(run for run in get_workflow_runs_for_id_branch(
                 runs, test_workflow_id, BRANCH
-            )[0]
+            ) if has_commit_passed_workflow(run))
             print(
-                f"Latest \"{test_workflow['name']}\" run for branch \"{BRANCH}\" is {latest_run['id']} with conclusion \"{latest_run['conclusion']}\""
+                f"Latest \"{test_workflow['name']}\" passing run for branch \"{BRANCH}\" is {latest_passing_run['id']} with conclusion \"{latest_passing_run['conclusion']}\""
             )
             if not (
-                was_workflow_completed_in_last_day(latest_run)
-                and has_commit_passed_workflow(latest_run)
+                was_workflow_completed_in_last_day(latest_passing_run)
             ):
                 print("Returning 1")
                 return 1

--- a/.github/CI/check_latest_commit_for_nightly.py
+++ b/.github/CI/check_latest_commit_for_nightly.py
@@ -82,12 +82,12 @@ def main():
                 print(latest_passing_run["head_sha"])
                 print("Returning 0", file=sys.stderr)
                 return 0
-        print("Returning 0", file=sys.stderr)
+        print("Returning 1", file=sys.stderr)
         return 1
     except:
         print(f"There was an exception", file=sys.stderr)
         traceback.print_exc(file=sys.stderr)
-    print("Returning 0", file=sys.stderr)
+    print("Returning 1", file=sys.stderr)
     return 1
 
 

--- a/.github/workflows/build_publish_nightly.yml
+++ b/.github/workflows/build_publish_nightly.yml
@@ -4,9 +4,9 @@
 
 name: Build and publish pycaret-nightly
 
-on:
-  schedule:
-  - cron: "0 0 * * *" # every 24 hours on midnight
+on: [push]
+  #schedule:
+  #- cron: "0 0 * * *" # every 24 hours on midnight
 
 jobs:
   build_and_publish:
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
@@ -25,21 +24,27 @@ jobs:
         python -m pip install --user --upgrade setuptools wheel requests
     - name: Check if it's necessary to continiue
       run: |
-        if python ".github/CI/check_latest_commit_for_nightly.py" "$GITHUB_REPOSITORY" "${GITHUB_REF##*/}"; then
-            echo "Proceeding with build and publish"
-            echo "::set-env name=CONTINIUE::1"
+        REF_TO_CHECKOUT=$(python ".github/CI/check_latest_commit_for_nightly.py" "$GITHUB_REPOSITORY" "nightly_publish_workflow")
+        if [[ $? -eq 0 ]] ; then
+            echo "Proceeding with build and publish of commit $REF_TO_CHECKOUT"
+            echo "::set-env name=REF_TO_CHECKOUT::$REF_TO_CHECKOUT"
         else
             echo "No need for build and publish, exiting..."
-            echo "::set-env name=CONTINIUE::0"
+            echo "::set-env name=REF_TO_CHECKOUT::0"
             exit 0
         fi
+    - name: Checkout last passing commit
+      if: env.REF_TO_CHECKOUT != '0'
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ env.REF_TO_CHECKOUT }}
     - name: Build nightly distribution
-      if: env.CONTINIUE == '1'
+      if: env.REF_TO_CHECKOUT != '0'
       run: |
         rm -rf dist/*
         python setup_nightly.py sdist bdist_wheel
     - name: Publish nightly distribution to PyPI
-      if: env.CONTINIUE == '1'
+      if: env.REF_TO_CHECKOUT != '0'
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build_publish_nightly.yml
+++ b/.github/workflows/build_publish_nightly.yml
@@ -1,6 +1,12 @@
+# Written by Antoni Baum (Yard1)
+# Make sure to set pypi_password secret
+# Requires .github/CI/check_latest_commit_for_nightly.py to be present
+
 name: Build and publish pycaret-nightly
 
-on: [push]
+on:
+  schedule:
+  - cron: "0 0 * * *" # every 24 hours on midnight
 
 jobs:
   build_and_publish:

--- a/.github/workflows/build_publish_nightly.yml
+++ b/.github/workflows/build_publish_nightly.yml
@@ -1,6 +1,5 @@
 # Written by Antoni Baum (Yard1)
 # Make sure to set pypi_password secret
-# Requires .github/CI/check_latest_commit_for_nightly.py to be present
 
 name: Build and publish pycaret-nightly
 
@@ -22,9 +21,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install --user --upgrade setuptools wheel requests
+        curl https://raw.githubusercontent.com/Yard1/pycaret/nightly_publish_workflow/.github/CI/check_latest_commit_for_nightly.py --output check_latest_commit_for_nightly.py --silent
     - name: Check if it's necessary to continiue
       run: |
-        REF_TO_CHECKOUT=$(python ".github/CI/check_latest_commit_for_nightly.py" "$GITHUB_REPOSITORY" "nightly_publish_workflow")
+        REF_TO_CHECKOUT=$(python check_latest_commit_for_nightly.py "$GITHUB_REPOSITORY" "nightly_publish_workflow")
         if [[ $? -eq 0 ]] ; then
             echo "Proceeding with build and publish of commit $REF_TO_CHECKOUT"
             echo "::set-env name=REF_TO_CHECKOUT::$REF_TO_CHECKOUT"

--- a/.github/workflows/build_publish_nightly.yml
+++ b/.github/workflows/build_publish_nightly.yml
@@ -1,8 +1,6 @@
 name: Build and publish pycaret-nightly
 
-on:
-  schedule:
-  - cron: "0 0 * * *" # every 24 hours on midnight
+on: [push]
 
 jobs:
   build_and_publish:

--- a/.github/workflows/build_publish_nightly.yml
+++ b/.github/workflows/build_publish_nightly.yml
@@ -1,0 +1,42 @@
+name: Build and publish pycaret-nightly
+
+on:
+  schedule:
+  - cron: "0 0 * * *" # every 24 hours on midnight
+
+jobs:
+  build_and_publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --user --upgrade setuptools wheel requests
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Check if it's necessary to continiue
+      run: |
+        if python ".github/CI/check_latest_commit_for_nightly.py"; then
+            echo "Proceeding with build and publish"
+            echo "::set-env name=CONTINIUE::1"
+        else
+            echo "No need for build and publish, exiting..."
+            echo "::set-env name=CONTINIUE::0"
+            exit 0
+        fi
+    - name: Build nightly distribution
+      if: env.CONTINIUE == '1'
+      run: |
+        rm -rf dist/*
+        python setup_nightly.py sdist bdist_wheel
+    - name: Publish nightly distribution to PyPI
+      if: env.CONTINIUE == '1'
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build_publish_nightly.yml
+++ b/.github/workflows/build_publish_nightly.yml
@@ -17,7 +17,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install --user --upgrade setuptools wheel requests
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Check if it's necessary to continiue
       run: |
         if python ".github/CI/check_latest_commit_for_nightly.py"; then

--- a/.github/workflows/build_publish_nightly.yml
+++ b/.github/workflows/build_publish_nightly.yml
@@ -23,10 +23,10 @@ jobs:
         python -m pip install --user --upgrade setuptools wheel requests
     - name: Get check_latest_commit_for_nightly.py
       run: |
-        curl https://raw.githubusercontent.com/Yard1/pycaret/nightly_publish_workflow/.github/CI/check_latest_commit_for_nightly.py --output check_latest_commit_for_nightly.py --silent
+        curl "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/${GITHUB_REF##*/}/.github/CI/check_latest_commit_for_nightly.py" --output check_latest_commit_for_nightly.py --silent
     - name: Check if it's necessary to continiue
       run: |
-        REF_TO_CHECKOUT=$(python check_latest_commit_for_nightly.py "$GITHUB_REPOSITORY" "nightly_publish_workflow")
+        REF_TO_CHECKOUT=$(python check_latest_commit_for_nightly.py "$GITHUB_REPOSITORY" "${GITHUB_REF##*/}")
         if [[ $? -eq 0 ]] ; then
             echo "Proceeding with build and publish of commit $REF_TO_CHECKOUT"
             echo "::set-env name=REF_TO_CHECKOUT::$REF_TO_CHECKOUT"

--- a/.github/workflows/build_publish_nightly.yml
+++ b/.github/workflows/build_publish_nightly.yml
@@ -19,7 +19,7 @@ jobs:
         python -m pip install --user --upgrade setuptools wheel requests
     - name: Check if it's necessary to continiue
       run: |
-        if python ".github/CI/check_latest_commit_for_nightly.py"; then
+        if python ".github/CI/check_latest_commit_for_nightly.py" "$GITHUB_REPOSITORY" "${GITHUB_REF##*/}"; then
             echo "Proceeding with build and publish"
             echo "::set-env name=CONTINIUE::1"
         else

--- a/.github/workflows/build_publish_nightly.yml
+++ b/.github/workflows/build_publish_nightly.yml
@@ -3,9 +3,9 @@
 
 name: Build and publish pycaret-nightly
 
-on: [push]
-  #schedule:
-  #- cron: "0 0 * * *" # every 24 hours on midnight
+on:
+  schedule:
+  - cron: "0 0 * * *" # every 24 hours on midnight
 
 jobs:
   build_and_publish:
@@ -21,6 +21,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install --user --upgrade setuptools wheel requests
+    - name: Get check_latest_commit_for_nightly.py
+      run: |
         curl https://raw.githubusercontent.com/Yard1/pycaret/nightly_publish_workflow/.github/CI/check_latest_commit_for_nightly.py --output check_latest_commit_for_nightly.py --silent
     - name: Check if it's necessary to continiue
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
-name: Python package
+name: pytest on push
 
 on: [push]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
     strategy:

--- a/pycaret/utils.py
+++ b/pycaret/utils.py
@@ -3,9 +3,15 @@
 # License: MIT
 
 version_ = "2.0"
+nightly_version_ = "2.1"
 
 def version():
     print(version_)
+    return version_
+
+def nightly_version():
+    print(nightly_version_)
+    return nightly_version_
 
 def __version__():
     return version_

--- a/setup_nightly.py
+++ b/setup_nightly.py
@@ -31,7 +31,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
-    packages=["pycaret-nightly"],
+    packages=["pycaret"],
     include_package_data=True,
     install_requires=required
 )

--- a/setup_nightly.py
+++ b/setup_nightly.py
@@ -1,8 +1,11 @@
 # Copyright (C) 2019-2020 Moez Ali <moez.ali@queensu.ca>
 # License: MIT, moez.ali@queensu.ca
 
-from pycaret.utils import version
+from pycaret.utils import nightly_version
 from setuptools import setup
+import time
+
+nightly_readme = f'This is a nightly version of the [PyCaret](https://pypi.org/project/pycaret/) library, intended as a preview of the upcoming {nightly_version()} version. It may contain unstable and untested code.\n'
 
 def readme():
     with open('README.md') as f:
@@ -13,12 +16,12 @@ with open('requirements.txt') as f:
     required = f.read().splitlines()
 
 setup(
-    name="pycaret",
-    version=f"{version()}",
-    description="PyCaret - An open source, low-code machine learning library in Python.",
-    long_description=readme(),
+    name="pycaret-nightly",
+    version=f"{nightly_version()}.dev{int(time.time())}",
+    description="Nightly version of PyCaret - An open source, low-code machine learning library in Python.",
+    long_description=nightly_readme+readme(),
     long_description_content_type="text/markdown",
-    url="https://github.com/pycaret/pycaret",
+    url="https://github.com/pycaret/pycaret-nightly",
     author="Moez Ali",
     author_email="moez.ali@queensu.ca",
     license="MIT",
@@ -28,7 +31,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
-    packages=["pycaret"],
+    packages=["pycaret-nightly"],
     include_package_data=True,
     install_requires=required
 )


### PR DESCRIPTION
The following changes will put in place a workflow that:
- Will run every 24h on midnight zulu time
- Will check whether the latest commit on master that passed CI has been made in the last 24 hours
- If yes, will build and publish pycaret-nightly using that commit
- Otherwise, end action

Will require a PyPi token to be set as `pypi_password` secret. Instructions on how to do it are here - https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github

Several files needed to be edited in order to facilitate smooth building and publishing. The main change is that both setup.py files will get the version from pycaret/utils.py, in order to make sure it is in one place.

https://github.com/pycaret/pycaret/issues/432