### PR TITLE
scale parameter for plot_model

### DIFF
--- a/pycaret/anomaly.py
+++ b/pycaret/anomaly.py
@@ -1799,6 +1799,7 @@ def assign_model(model,
 def plot_model(model,
                plot = 'tsne',
                feature = None,
+               scale = 1, #added in pycaret 2.1.0
                save = False, #added in pycaret 2.0.0
                system = True): #added in pycaret 2.0.0
                
@@ -1818,19 +1819,22 @@ def plot_model(model,
 
     Parameters
     ----------
-    model : object
+    model: object
         A trained model object can be passed. Model must be created using create_model().
 
-    plot : string, default = 'tsne'
+    plot: string, default = 'tsne'
         Enter abbreviation of type of plot. The current list of plots supported are (Plot - Name):
 
         * 'tsne' - t-SNE (3d) Dimension Plot
         * 'umap' - UMAP Dimensionality Plot
 
-    feature : string, default = None
+    feature: string, default = None
         Feature column is used as a hoverover tooltip. By default, first of column of the
         dataset is chosen as hoverover tooltip, when no feature is passed.
     
+    scale: float, default = 1
+        The resolution scale of the figure.
+
     save: Boolean, default = False
         Plot is saved as png file in local directory when save parameter set to True.
 
@@ -1938,7 +1942,7 @@ def plot_model(model,
         logger.info("Rendering Visual")
 
         fig = px.scatter_3d(df, x=0, y=1, z=2, hover_data=['Feature'], color='Label', title='3d TSNE Plot for Outliers', 
-                                opacity=0.7, width=900, height=800)
+                                opacity=0.7, width=900*scale, height=800*scale)
             
             
         if system:
@@ -1982,7 +1986,7 @@ def plot_model(model,
 
         fig = px.scatter(df, x=0, y=1,
                       color='Label', title='uMAP Plot for Outliers', hover_data=['Feature'], opacity=0.7, 
-                         width=900, height=800)
+                         width=900*scale, height=800*scale)
         if system:
             fig.show() 
 

--- a/pycaret/arules.py
+++ b/pycaret/arules.py
@@ -210,7 +210,9 @@ def create_model(metric='confidence',
     return(rules)
 
 def plot_model(model,
-               plot = '2d'):
+               plot = '2d',
+               scale = 1, #added in pycaret 2.1.0
+               ):
     
     """
     This function takes a model dataframe returned by create_model() function. 
@@ -232,8 +234,10 @@ def plot_model(model,
 
         * Support, Confidence and Lift (2d) - '2d'
         * Support, Confidence and Lift (3d) - '3d'
-  
-    
+
+    scale: float, default = 1
+        The resolution scale of the figure.
+
     Returns
     -------
     Visual_Plot
@@ -290,7 +294,7 @@ def plot_model(model,
         fig.update_layout(plot_bgcolor='rgb(240,240,240)')
 
         fig.update_layout(
-            height=800,
+            height=800*scale,
             title_text='2D Plot of Support, Confidence and Lift'
         )
 
@@ -300,7 +304,7 @@ def plot_model(model,
     if plot == '3d':
         
         fig = px.scatter_3d(data_, x='support', y='confidence', z='lift',
-                      color='antecedent support', title='3d Plot for Rule Mining', opacity=0.7, width=900, height=800,
+                      color='antecedent support', title='3d Plot for Rule Mining', opacity=0.7, width=900*scale, height=800*scale,
                            hover_data = ['antecedents', 'consequents' ])
         fig.show()   
 

--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -7283,6 +7283,7 @@ def stack_models(estimator_list,
 
 def plot_model(estimator, 
                plot = 'auc',
+               scale = 1, #added in pycaret 2.1.0
                save = False, #added in pycaret 2.0.0
                verbose = True, #added in pycaret 2.0.0
                system = True): #added in pycaret 2.0.0
@@ -7328,6 +7329,9 @@ def plot_model(estimator,
         * 'dimension' - Dimension Learning           
         * 'feature' - Feature Importance              
         * 'parameter' - Model Hyperparameter          
+
+    scale: float, default = 1
+        The resolution scale of the figure.
 
     save: Boolean, default = False
         When set to True, Plot is saved as a 'png' file in current working directory.
@@ -7480,6 +7484,7 @@ def plot_model(estimator,
         from yellowbrick.classifier import ROCAUC
         progress.value += 1
         visualizer = ROCAUC(model)
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         logger.info("Fitting Model")
         visualizer.fit(X_train, y_train)
         progress.value += 1
@@ -7503,6 +7508,7 @@ def plot_model(estimator,
         from yellowbrick.classifier import DiscriminationThreshold
         progress.value += 1
         visualizer = DiscriminationThreshold(model, random_state=seed)
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         logger.info("Fitting Model")
         visualizer.fit(X_train, y_train)
         progress.value += 1
@@ -7526,6 +7532,7 @@ def plot_model(estimator,
         from yellowbrick.classifier import PrecisionRecallCurve
         progress.value += 1
         visualizer = PrecisionRecallCurve(model, random_state=seed)
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         logger.info("Fitting Model")
         visualizer.fit(X_train, y_train)
         progress.value += 1
@@ -7549,6 +7556,7 @@ def plot_model(estimator,
         from yellowbrick.classifier import ConfusionMatrix
         progress.value += 1
         visualizer = ConfusionMatrix(model, random_state=seed, fontsize = 15, cmap="Greens")
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         logger.info("Fitting Model")
         visualizer.fit(X_train, y_train)
         progress.value += 1
@@ -7572,6 +7580,7 @@ def plot_model(estimator,
         from yellowbrick.classifier import ClassPredictionError
         progress.value += 1
         visualizer = ClassPredictionError(model, random_state=seed)
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         logger.info("Fitting Model")
         visualizer.fit(X_train, y_train)
         progress.value += 1
@@ -7595,6 +7604,7 @@ def plot_model(estimator,
         from yellowbrick.classifier import ClassificationReport
         progress.value += 1
         visualizer = ClassificationReport(model, random_state=seed, support=True)
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         logger.info("Fitting Model")
         visualizer.fit(X_train, y_train)
         progress.value += 1
@@ -7643,6 +7653,7 @@ def plot_model(estimator,
         y_test_transformed = np.array(y_test_transformed)
         
         viz_ = DecisionViz(model2)
+        viz_.fig.set_dpi(viz_.fig.dpi * scale)
         logger.info("Fitting Model")
         viz_.fit(X_train_transformed, y_train_transformed, features=['Feature One', 'Feature Two'], classes=['A', 'B'])
         viz_.draw(X_test_transformed, y_test_transformed)
@@ -7664,6 +7675,7 @@ def plot_model(estimator,
         from yellowbrick.model_selection import RFECV 
         progress.value += 1
         visualizer = RFECV(model, cv=10)
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         progress.value += 1
         logger.info("Fitting Model")
         visualizer.fit(X_train, y_train)
@@ -7686,6 +7698,7 @@ def plot_model(estimator,
         progress.value += 1
         sizes = np.linspace(0.3, 1.0, 10)  
         visualizer = LearningCurve(model, cv=10, train_sizes=sizes, n_jobs=n_jobs_param, random_state=seed)
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         progress.value += 1
         logger.info("Fitting Model")
         visualizer.fit(X_train, y_train)
@@ -7709,6 +7722,7 @@ def plot_model(estimator,
         progress.value += 1
         X_train_transformed = X_train.select_dtypes(include='float64') 
         visualizer = Manifold(manifold='tsne', random_state = seed)
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         progress.value += 1
         logger.info("Fitting Model")
         visualizer.fit_transform(X_train_transformed, y_train)
@@ -7731,7 +7745,7 @@ def plot_model(estimator,
         
         model_name = str(model).split("(")[0]
         
-        plt.figure(figsize=(7, 6))
+        plt.figure(figsize=(7, 6), dpi=100*scale)
         ax1 = plt.subplot2grid((3, 1), (0, 0), rowspan=2)
 
         ax1.plot([0, 1], [0, 1], "k:", label="Perfectly calibrated")
@@ -7834,6 +7848,7 @@ def plot_model(estimator,
         from yellowbrick.model_selection import ValidationCurve
         viz = ValidationCurve(model, param_name=param_name, param_range=param_range,cv=10, 
                               random_state=seed)
+        viz.fig.set_dpi(viz.fig.dpi * scale)
         logger.info("Fitting Model")
         viz.fit(X_train, y_train)
         progress.value += 1
@@ -7869,6 +7884,7 @@ def plot_model(estimator,
         progress.value += 1
         classes = y_train.unique().tolist()
         visualizer = RadViz(classes=classes, alpha=0.25)
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         logger.info("Fitting Model")
         visualizer.fit(X_train_transformed, y_train_transformed)     
         visualizer.transform(X_train_transformed)
@@ -7900,7 +7916,7 @@ def plot_model(estimator,
         sorted_df = sorted_df.sort_values(by='Value')
         my_range=range(1,len(sorted_df.index)+1)
         progress.value += 1
-        plt.figure(figsize=(8,5))
+        plt.figure(figsize=(8,5), dpi=100*scale)
         plt.hlines(y=my_range, xmin=0, xmax=sorted_df['Value'], color='skyblue')
         plt.plot(sorted_df['Value'], my_range, "o")
         progress.value += 1

--- a/pycaret/clustering.py
+++ b/pycaret/clustering.py
@@ -1870,6 +1870,7 @@ def plot_model(model,
             plot='cluster', 
             feature = None, 
             label = False,
+            scale = 1, #added in pycaret 2.1.0
             save = False, #added in pycaret 2.0.0
             system = True): #added in pycaret 2.0.0
     
@@ -1912,7 +1913,10 @@ def plot_model(model,
     
     label : bool, default = False
         When set to True, data labels are shown in 'cluster' and 'tsne' plot.
-    
+
+    scale: float, default = 1
+        The resolution scale of the figure.
+
     save: Boolean, default = False
         Plot is saved as png file in local directory when save parameter set to True.
 
@@ -2057,7 +2061,7 @@ def plot_model(model,
         fig.update_layout(plot_bgcolor='rgb(240,240,240)')
 
         fig.update_layout(
-            height=600,
+            height=600*scale,
             title_text='2D Cluster PCA Plot'
         )
 
@@ -2118,11 +2122,11 @@ def plot_model(model,
         if label:
             
             fig = px.scatter_3d(df, x=0, y=1, z=2, color='Cluster', title='3d TSNE Plot for Clusters', 
-                    text = 'Label', opacity=0.7, width=900, height=800)
+                    text = 'Label', opacity=0.7, width=900*scale, height=800*scale)
             
         else:
             fig = px.scatter_3d(df, x=0, y=1, z=2, color='Cluster', title='3d TSNE Plot for Clusters', 
-                                hover_data = ['Feature'], opacity=0.7, width=900, height=800)
+                                hover_data = ['Feature'], opacity=0.7, width=900*scale, height=800*scale)
         
         if system:
             fig.show()
@@ -2178,6 +2182,10 @@ def plot_model(model,
                    marginal="box", opacity = 0.7,
                    hover_data=d.columns)
         
+        fig.update_layout(
+            height=600*scale,
+        )
+
         if system:
             fig.show()
 
@@ -2195,6 +2203,7 @@ def plot_model(model,
         try: 
             from yellowbrick.cluster import KElbowVisualizer
             visualizer = KElbowVisualizer(model_,timings=False)
+            visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
             logger.info("Fitting KElbowVisualizer()")
             visualizer.fit(X)
             logger.info("Rendering Visual")
@@ -2218,6 +2227,7 @@ def plot_model(model,
         try:
             from yellowbrick.cluster import SilhouetteVisualizer
             visualizer = SilhouetteVisualizer(model, colors='yellowbrick')
+            visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
             logger.info("Fitting SilhouetteVisualizer()")
             visualizer.fit(X)
             logger.info("Rendering Visual")
@@ -2241,6 +2251,7 @@ def plot_model(model,
         try:    
             from yellowbrick.cluster import InterclusterDistance
             visualizer = InterclusterDistance(model)
+            visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
             logger.info("Fitting InterclusterDistance()")
             visualizer.fit(X)
             logger.info("Rendering Visual")

--- a/pycaret/regression.py
+++ b/pycaret/regression.py
@@ -7082,6 +7082,7 @@ def stack_models(estimator_list,
 
 def plot_model(estimator, 
                plot = 'residuals',
+               scale = 1, #added in pycaret 2.1.0
                save = False, #added in pycaret 1.0.1
                verbose = True, #added in pycaret 1.0.1
                system = True): #added in pycaret 1.0.1): 
@@ -7121,6 +7122,9 @@ def plot_model(estimator,
         * 'manifold' - Manifold Learning                        
         * 'feature' - Feature Importance                        
         * 'parameter' - Model Hyperparameter                    
+
+    scale: float, default = 1
+        The resolution scale of the figure.
 
     save: Boolean, default = False
         When set to True, Plot is saved as a 'png' file in current working directory.
@@ -7261,6 +7265,7 @@ def plot_model(estimator,
         from yellowbrick.regressor import PredictionError
         progress.value += 1
         visualizer = PredictionError(model)
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         logger.info("Fitting Model")
         visualizer.fit(X_train, y_train)
         progress.value += 1
@@ -7283,6 +7288,7 @@ def plot_model(estimator,
         from yellowbrick.regressor import CooksDistance
         progress.value += 1
         visualizer = CooksDistance()
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         progress.value += 1
         logger.info("Fitting Model")
         visualizer.fit(X, y)
@@ -7304,6 +7310,7 @@ def plot_model(estimator,
         from yellowbrick.model_selection import RFECV 
         progress.value += 1
         visualizer = RFECV(model, cv=10)
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         progress.value += 1
         logger.info("Fitting Model")
         visualizer.fit(X_train, y_train)
@@ -7326,6 +7333,7 @@ def plot_model(estimator,
         progress.value += 1
         sizes = np.linspace(0.3, 1.0, 10)  
         visualizer = LearningCurve(model, cv=10, train_sizes=sizes, n_jobs=1, random_state=seed)
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         progress.value += 1
         logger.info("Fitting Model")
         visualizer.fit(X_train, y_train)
@@ -7349,6 +7357,7 @@ def plot_model(estimator,
         progress.value += 1
         X_train_transformed = X_train.select_dtypes(include='float64') 
         visualizer = Manifold(manifold='tsne', random_state = seed)
+        visualizer.fig.set_dpi(visualizer.fig.dpi * scale)
         progress.value += 1
         logger.info("Fitting Model")
         visualizer.fit_transform(X_train_transformed, y_train)
@@ -7442,6 +7451,7 @@ def plot_model(estimator,
         from yellowbrick.model_selection import ValidationCurve
         viz = ValidationCurve(model, param_name=param_name, param_range=param_range,cv=10, 
                               random_state=seed)
+        viz.fig.set_dpi(viz.fig.dpi * scale)
         logger.info("Fitting Model")
         viz.fit(X_train, y_train)
         progress.value += 1
@@ -7473,7 +7483,7 @@ def plot_model(estimator,
         sorted_df = sorted_df.head(10)
         sorted_df = sorted_df.sort_values(by='Value')
         my_range=range(1,len(sorted_df.index)+1)
-        plt.figure(figsize=(8,5))
+        plt.figure(figsize=(8,5), dpi=100*scale)
         plt.hlines(y=my_range, xmin=0, xmax=sorted_df['Value'], color='skyblue')
         plt.plot(sorted_df['Value'], my_range, "o")
         plt.yticks(my_range, sorted_df['Variable'])


### PR DESCRIPTION
Add `scale` parameter to plot_model to allow for rendering of plots in higher resolution (aside from NLP, which only has interactive plots).

I chose `scale` instead of `dpi` because plotly.express doesn't allow setting of dpi and only allows for pixel values. Other plots have their dpi scaled.

Fixes https://github.com/pycaret/pycaret/issues/394