### PR TITLE
Fix MAPE check_metric returning NaN, enable test

### DIFF
--- a/pycaret/tests/test_utils.py
+++ b/pycaret/tests/test_utils.py
@@ -107,9 +107,9 @@ def test():
     assert isinstance(rmsle, float)
     assert rmsle >= 0
     mape = pycaret.utils.check_metric(actual, prediction, "MAPE")
-    # provisional support
-    # assert isinstance(mape, float)
-    # assert mape >= 0
+    #provisional support
+    assert isinstance(mape, float)
+    assert mape >= 0
 
     assert 1 == 1
 

--- a/pycaret/tests/test_utils.py
+++ b/pycaret/tests/test_utils.py
@@ -107,7 +107,6 @@ def test():
     assert isinstance(rmsle, float)
     assert rmsle >= 0
     mape = pycaret.utils.check_metric(actual, prediction, "MAPE")
-    #provisional support
     assert isinstance(mape, float)
     assert mape >= 0
 

--- a/pycaret/utils.py
+++ b/pycaret/utils.py
@@ -91,11 +91,11 @@ def check_metric(actual, prediction, metric, round=4):
 
     elif metric == 'MAPE':
 
-        mask = actual != 0
-        result = (np.fabs(actual - prediction)/actual)[mask].mean()
+        mask = actual.iloc[:,0] != 0
+        result = (np.fabs(actual.iloc[:,0] - prediction.iloc[:,0])/actual.iloc[:,0])[mask].mean()
         result = result.round(round)
        
-    return result
+    return float(result)
 
 
 def enable_colab():


### PR DESCRIPTION
Fix `check_metric` for MAPE returning NaN.

Fixes https://github.com/pycaret/pycaret/issues/458