### PR TITLE
Github Actions, don't fail when update is not necessary

### DIFF
--- a/.github/workflows/build_publish_nightly.yml
+++ b/.github/workflows/build_publish_nightly.yml
@@ -26,6 +26,7 @@ jobs:
         curl "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/${GITHUB_REF##*/}/.github/CI/check_latest_commit_for_nightly.py" --output check_latest_commit_for_nightly.py --silent
     - name: Check if it's necessary to continiue
       run: |
+        set +e
         REF_TO_CHECKOUT=$(python check_latest_commit_for_nightly.py "$GITHUB_REPOSITORY" "${GITHUB_REF##*/}")
         if [[ $? -eq 0 ]] ; then
             echo "Proceeding with build and publish of commit $REF_TO_CHECKOUT"


### PR DESCRIPTION
This will make sure that the Action will not show up as failed when there was no need to update nightly build.
