### PR TITLE
Adding a warning to all modules predict_model docstring

### DIFF
--- a/pycaret/anomaly.py
+++ b/pycaret/anomaly.py
@@ -3631,9 +3631,10 @@ def predict_model(model,
     
     Warnings
     --------
-    - `predict_model(model = my_model, data = my_data)` will throw an error if the model 
-      passed (e.g. my_model) was built with a different version of Pycaret than the one
-      which `predict_model` was instantiated with. 
+    - The behavior of the predict_model is changed in version 2.1 without backward compatibility.
+    As such, the pipelines trained using the version (<= 2.0), may not work for inference 
+    with version >= 2.1. You can either retrain your models with a newer version or downgrade
+    the version for inference.
 
 
     """

--- a/pycaret/anomaly.py
+++ b/pycaret/anomaly.py
@@ -3629,6 +3629,13 @@ def predict_model(model,
     info_grid
         Information grid is printed when data is None.             
     
+    Warnings
+    --------
+    - `predict_model(model = my_model, data = my_data)` will throw an error if the model 
+      passed (e.g. my_model) was built with a different version of Pycaret than the one
+      which `predict_model` was instantiated with. 
+
+
     """
     
     #ignore warnings

--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -9484,6 +9484,13 @@ def predict_model(estimator,
 
     score_grid
         A table containing the scoring metrics on hold-out / test set.
+
+    Warnings
+    --------
+    - `predict_model(estimator = my_estimator, data = my_data)` will throw an error if the model 
+      passed (e.g. my_model) was built with a different version of Pycaret than the one
+      which `predict_model` was instantiated with. 
+
     
     """
     

--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -9487,10 +9487,11 @@ def predict_model(estimator,
 
     Warnings
     --------
-    - `predict_model(estimator = my_estimator, data = my_data)` will throw an error if the model 
-      passed (e.g. my_model) was built with a different version of Pycaret than the one
-      which `predict_model` was instantiated with. 
-
+    - The behavior of the predict_model is changed in version 2.1 without backward compatibility.
+    As such, the pipelines trained using the version (<= 2.0), may not work for inference 
+    with version >= 2.1. You can either retrain your models with a newer version or downgrade
+    the version for inference.
+    
     
     """
     

--- a/pycaret/clustering.py
+++ b/pycaret/clustering.py
@@ -3676,9 +3676,13 @@ def predict_model(model,
 
     Warnings
     --------
-    - Models that donot support 'predict' function cannot be used in predict_model(). 
-       
-    
+    - Models that do not support 'predict' function cannot be used in predict_model(). 
+
+    - `predict_model(model = my_model, data = my_data)` will throw an error if the model 
+      passed (e.g. my_model) was built with a different version of Pycaret than the one
+      which `predict_model` was instantiated with. 
+
+
     """
     
     #ignore warnings

--- a/pycaret/clustering.py
+++ b/pycaret/clustering.py
@@ -3678,10 +3678,11 @@ def predict_model(model,
     --------
     - Models that do not support 'predict' function cannot be used in predict_model(). 
 
-    - `predict_model(model = my_model, data = my_data)` will throw an error if the model 
-      passed (e.g. my_model) was built with a different version of Pycaret than the one
-      which `predict_model` was instantiated with. 
-
+    - The behavior of the predict_model is changed in version 2.1 without backward compatibility.
+    As such, the pipelines trained using the version (<= 2.0), may not work for inference 
+    with version >= 2.1. You can either retrain your models with a newer version or downgrade
+    the version for inference.
+    
 
     """
     

--- a/pycaret/regression.py
+++ b/pycaret/regression.py
@@ -7893,7 +7893,13 @@ def predict_model(estimator,
 
     score grid:   
         A table containing the scoring metrics on hold-out / test set.
-                  
+
+    Warnings
+    --------
+    - `predict_model(estimator = my_estimator, data = my_data)` will throw an error if the model 
+      passed (e.g. my_model) was built with a different version of Pycaret than the one
+      which `predict_model` was instantiated with. 
+
     
     """
     

--- a/pycaret/regression.py
+++ b/pycaret/regression.py
@@ -7896,10 +7896,11 @@ def predict_model(estimator,
 
     Warnings
     --------
-    - `predict_model(estimator = my_estimator, data = my_data)` will throw an error if the model 
-      passed (e.g. my_model) was built with a different version of Pycaret than the one
-      which `predict_model` was instantiated with. 
-
+    - The behavior of the predict_model is changed in version 2.1 without backward compatibility.
+    As such, the pipelines trained using the version (<= 2.0), may not work for inference 
+    with version >= 2.1. You can either retrain your models with a newer version or downgrade
+    the version for inference.
+    
     
     """
     


### PR DESCRIPTION
This PR adds a warning to alert when `predict_model` is attempting to consume a model built with a different version of Pycaret than the one used to instantiate predict_model. 

Related issue [here](https://github.com/pycaret/pycaret/issues/593).
