### PR TITLE
Don't consider action results for forks

### DIFF
--- a/.github/CI/check_latest_commit_for_nightly.py
+++ b/.github/CI/check_latest_commit_for_nightly.py
@@ -35,7 +35,7 @@ def get_workflow_runs_for_id_branch(runs, workflow_id, branch):
     return [
         x
         for x in runs
-        if x["head_branch"] == branch and x["workflow_id"] == workflow_id
+        if x["head_branch"] == branch and x["workflow_id"] == workflow_id and x["event"] == "push"
     ]
 
 


### PR DESCRIPTION
Fixes an issue where the nightly publish script would consider a workflow run for a PR of a 'master' branch from a fork.