### PR TITLE
display association rules plots in streamlit

### DIFF
--- a/pycaret/anomaly.py
+++ b/pycaret/anomaly.py
@@ -562,6 +562,7 @@ def plot_model(
     label: bool = False,
     scale: float = 1,
     save: bool = False,
+    display_format = None
 ):
 
     """
@@ -606,13 +607,16 @@ def plot_model(
     save: bool, default = False
         When set to True, plot is saved in the current working directory.
         
+    display_format: str, default = None
+        To display plots in [Streamlit](https://www.streamlit.io/), set this to 'streamlit'.
+        
 
     Returns:
         None
 
     """
     return pycaret.internal.tabular.plot_model(
-        model, plot=plot, feature_name=feature, label=label, scale=scale, save=save
+        model, plot=plot, feature_name=feature, label=label, scale=scale, save=save, display_format=display_format
     )
 
 

--- a/pycaret/arules.py
+++ b/pycaret/arules.py
@@ -255,6 +255,30 @@ def plot_model(
         None
         
     """
+    
+    
+    # error handling
+    
+    # check if model is a pandas dataframe
+    if isinstance(model, pd.DataFrame) == False:
+        raise TypeError("Model needs to be a pandas.DataFrame object.")
+        
+    # check plot parameter
+    plot_types = ["2d", "3d"]
+    
+    if plot not in plot_types:
+        raise ValueError("Plots can only be \"2d\" or \"3d\".")
+        
+    # checking display_format parameter
+    plot_formats = [None, "streamlit"]
+    
+    if display_format not in plot_formats:
+        raise ValueError("display_format can only be None or \"streamlit\".")
+        
+    """
+    error handling ends here
+    """
+   
 
     # loading libraries
     import numpy as np

--- a/pycaret/arules.py
+++ b/pycaret/arules.py
@@ -273,7 +273,7 @@ def plot_model(
     plot_formats = [None, "streamlit"]
     
     if display_format not in plot_formats:
-        raise ValueError("display_format can only be None or \"streamlit\".")
+        raise ValueError("display_format can only be None or 'streamlit'.")
         
     """
     error handling ends here

--- a/pycaret/arules.py
+++ b/pycaret/arules.py
@@ -10,22 +10,22 @@ def setup(data, transaction_id, item_id, ignore_items=None, session_id=None):
     """
     This function initializes the environment in pycaret. setup() must called before
     executing any other function in pycaret. It takes three mandatory parameters:
-    (i) data, (ii) transaction_id param identifying basket and (iii) item_id param 
-    used to create rules. These three params are normally found in any transactional 
-    dataset. pycaret will internally convert the pandas.DataFrame into a sparse matrix 
+    (i) data, (ii) transaction_id param identifying basket and (iii) item_id param
+    used to create rules. These three params are normally found in any transactional
+    dataset. pycaret will internally convert the pandas.DataFrame into a sparse matrix
     which is required for association rules mining.
 
-    
+
     Example
     -------
     >>> from pycaret.datasets import get_data
     >>> data = get_data('france')
     >>> from pycaret.arules import *
     >>> exp = setup(data = data, transaction_id = 'InvoiceNo', item_id = 'Description')
-        
+
 
     data: pandas.DataFrame
-        Shape (n_samples, n_features) where n_samples is the number of samples and 
+        Shape (n_samples, n_features) where n_samples is the number of samples and
         n_features is the number of features.
 
 
@@ -36,20 +36,20 @@ def setup(data, transaction_id, item_id, ignore_items=None, session_id=None):
     item_id: str
         Name of column used for creation of rules. Normally, this will be the variable of
         interest.
-    
+
 
     ignore_items: list, default = None
         List of strings to be ignored when considering rule mining.
 
 
     session_id: int, default = None
-        If None, a random seed is generated and returned in the Information grid. The 
-        unique number is then distributed as a seed in all functions used during the 
+        If None, a random seed is generated and returned in the Information grid. The
+        unique number is then distributed as a seed in all functions used during the
         experiment. This can be used for later reproducibility of the entire experiment.
 
 
     Returns:
-        Global variables. 
+        Global variables.
 
     """
 
@@ -118,8 +118,8 @@ def setup(data, transaction_id, item_id, ignore_items=None, session_id=None):
 def create_model(metric="confidence", threshold=0.5, min_support=0.05, round=4):
 
     """
-    This function creates an association rules model using data and identifiers 
-    passed at setup stage. This function internally transforms the data for 
+    This function creates an association rules model using data and identifiers
+    passed at setup stage. This function internally transforms the data for
     association rule mining.
 
 
@@ -133,8 +133,8 @@ def create_model(metric="confidence", threshold=0.5, min_support=0.05, round=4):
 
 
     metric: str, default = 'confidence'
-        Metric to evaluate if a rule is of interest. Default is set to confidence. 
-        Other available metrics include 'support', 'lift', 'leverage', 'conviction'. 
+        Metric to evaluate if a rule is of interest. Default is set to confidence.
+        Other available metrics include 'support', 'lift', 'leverage', 'conviction'.
         These metrics are computed as follows:
 
         * support(A->C) = support(A+C) [aka 'support'], range: [0, 1]
@@ -142,31 +142,31 @@ def create_model(metric="confidence", threshold=0.5, min_support=0.05, round=4):
         * lift(A->C) = confidence(A->C) / support(C), range: [0, inf]
         * leverage(A->C) = support(A->C) - support(A)*support(C), range: [-1, 1]
         * conviction = [1 - support(C)] / [1 - confidence(A->C)], range: [0, inf]
-    
+
 
     threshold: float, default = 0.5
         Minimal threshold for the evaluation metric, via the `metric` parameter,
         to decide whether a candidate rule is of interest.
-    
+
 
     min_support: float, default = 0.05
         A float between 0 and 1 for minumum support of the itemsets returned.
         The support is computed as the fraction `transactions_where_item(s)_occur /
         total_transactions`.
-    
+
 
     round: int, default = 4
-        Number of decimal places metrics in score grid will be rounded to. 
+        Number of decimal places metrics in score grid will be rounded to.
 
 
     Returns:
         pandas.DataFrame
-        
+
 
     Warnings
     --------
     - Setting low values for min_support may increase training time.
-  
+
     """
 
     # loading dependencies
@@ -214,12 +214,10 @@ def create_model(metric="confidence", threshold=0.5, min_support=0.05, round=4):
     return rules
 
 
-def plot_model(
-    model, plot="2d", scale=1, display_format=None
-):
+def plot_model(model, plot="2d", scale=1, display_format=None):
 
     """
-    This function takes a model dataframe returned by create_model() function. 
+    This function takes a model dataframe returned by create_model() function.
     '2d' and '3d' plots are available.
 
 
@@ -238,7 +236,7 @@ def plot_model(
 
 
     plot: str, default = '2d'
-        Enter abbreviation of type of plot. The current list of plots supported are 
+        Enter abbreviation of type of plot. The current list of plots supported are
         (Name - Abbreviated String):
 
         * Support, Confidence and Lift (2d) - '2d'
@@ -247,38 +245,36 @@ def plot_model(
 
     scale: float, default = 1
         The resolution scale of the figure.
-        
+
     display_format: str, default = None
         To display plots in [Streamlit](https://www.streamlit.io/), set this to 'streamlit'.
 
     Returns:
         None
-        
+
     """
-    
-    
+
     # error handling
-    
+
     # check if model is a pandas dataframe
     if isinstance(model, pd.DataFrame) == False:
         raise TypeError("Model needs to be a pandas.DataFrame object.")
-        
+
     # check plot parameter
     plot_types = ["2d", "3d"]
-    
+
     if plot not in plot_types:
         raise ValueError("Plots can only be '2d' or '3d'.")
-        
+
     # checking display_format parameter
     plot_formats = [None, "streamlit"]
-    
+
     if display_format not in plot_formats:
         raise ValueError("display_format can only be None or 'streamlit'.")
-        
+
     """
     error handling ends here
     """
-   
 
     # loading libraries
     import numpy as np
@@ -342,7 +338,6 @@ def plot_model(
             height=800 * scale, title_text="2D Plot of Support, Confidence and Lift"
         )
 
-
     if plot == "3d":
 
         fig = px.scatter_3d(
@@ -357,8 +352,8 @@ def plot_model(
             height=800 * scale,
             hover_data=["antecedents", "consequents"],
         )
-        
-    if display_format=="streamlit":
+
+    if display_format == "streamlit":
         st.write(fig)
     else:
         fig.show()

--- a/pycaret/arules.py
+++ b/pycaret/arules.py
@@ -215,7 +215,7 @@ def create_model(metric="confidence", threshold=0.5, min_support=0.05, round=4):
 
 
 def plot_model(
-    model, plot="2d", scale=1,
+    model, plot="2d", scale=1, display_format=None
 ):
 
     """
@@ -247,6 +247,9 @@ def plot_model(
 
     scale: float, default = 1
         The resolution scale of the figure.
+        
+    display_format: str, default = None
+        To display plots in [Streamlit](https://www.streamlit.io/), set this to 'streamlit'.
 
     Returns:
         None
@@ -315,7 +318,6 @@ def plot_model(
             height=800 * scale, title_text="2D Plot of Support, Confidence and Lift"
         )
 
-        fig.show()
 
     if plot == "3d":
 
@@ -331,6 +333,10 @@ def plot_model(
             height=800 * scale,
             hover_data=["antecedents", "consequents"],
         )
+        
+    if display_format=="streamlit"
+        st.write(fig)
+    else:
         fig.show()
 
 

--- a/pycaret/arules.py
+++ b/pycaret/arules.py
@@ -267,7 +267,7 @@ def plot_model(
     plot_types = ["2d", "3d"]
     
     if plot not in plot_types:
-        raise ValueError("Plots can only be \"2d\" or \"3d\".")
+        raise ValueError("Plots can only be '2d' or '3d'.")
         
     # checking display_format parameter
     plot_formats = [None, "streamlit"]

--- a/pycaret/arules.py
+++ b/pycaret/arules.py
@@ -334,7 +334,7 @@ def plot_model(
             hover_data=["antecedents", "consequents"],
         )
         
-    if display_format=="streamlit"
+    if display_format=="streamlit":
         st.write(fig)
     else:
         fig.show()

--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -1432,6 +1432,7 @@ def plot_model(
     groups: Optional[Union[str, Any]] = None,
     use_train_data: bool = False,
     verbose: bool = True,
+    display_format = None
 ) -> str:
 
     """
@@ -1509,6 +1510,9 @@ def plot_model(
 
     verbose: bool, default = True
         When set to False, progress bar is not displayed.
+        
+    display_format: str, default = None
+        To display plots in [Streamlit](https://www.streamlit.io/), set this to 'streamlit'.
 
 
     Returns:
@@ -1539,6 +1543,7 @@ def plot_model(
         verbose=verbose,
         use_train_data=use_train_data,
         system=True,
+        display_format=display_format
     )
 
 

--- a/pycaret/clustering.py
+++ b/pycaret/clustering.py
@@ -595,6 +595,7 @@ def plot_model(
     label: bool = False,
     scale: float = 1,
     save: bool = False,
+    display_format = None
 ):
 
     """
@@ -645,6 +646,9 @@ def plot_model(
 
     save: bool, default = False
         When set to True, plot is saved in the current working directory.
+        
+    display_format: str, default = None
+        To display plots in [Streamlit](https://www.streamlit.io/), set this to 'streamlit'.
 
 
     Returns:
@@ -652,7 +656,7 @@ def plot_model(
 
     """
     return pycaret.internal.tabular.plot_model(
-        model, plot=plot, feature_name=feature, label=label, scale=scale, save=save
+        model, plot=plot, feature_name=feature, label=label, scale=scale, save=save, display_format=display_format
     )
 
 

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -5790,6 +5790,12 @@ def plot_model(
         raise TypeError(
             "feature parameter must be string containing column name of dataset."
         )
+        
+    # checking display_format parameter
+    plot_formats = [None, "streamlit"]
+    
+    if display_format not in plot_formats:
+        raise ValueError("display_format can only be None or \"streamlit\".")
 
     """
     

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -5598,6 +5598,7 @@ def plot_model(
     verbose: bool = True,
     system: bool = True,
     display: Optional[Display] = None,  # added in pycaret==2.2.0
+    display_format=None
 ) -> str:
 
     """
@@ -5669,6 +5670,9 @@ def plot_model(
 
     system: bool, default = True
         Must remain True all times. Only to be changed by internal functions.
+        
+    display_format: str, default = None
+        To display plots in [Streamlit](https://www.streamlit.io/), set this to 'streamlit'.
 
     Returns
     -------
@@ -5955,7 +5959,10 @@ def plot_model(
                         )
 
                     elif system:
-                        fig.show()
+                        if display_format=="streamlit":
+                            st.write(fig)
+                        else:
+                            fig.show()
 
                     logger.info("Visual Rendered Successfully")
                     return plot_filename
@@ -6017,7 +6024,10 @@ def plot_model(
                             f"Saving '{plot_filename}' in current active directory"
                         )
                     elif system:
-                        fig.show()
+                        if display_format=="streamlit":
+                            st.write(fig)
+                        else:
+                            fig.show()
 
                     logger.info("Visual Rendered Successfully")
                     return plot_filename
@@ -6099,7 +6109,10 @@ def plot_model(
                             f"Saving '{plot_filename}' in current active directory"
                         )
                     elif system:
-                        fig.show()
+                        if display_format=="streamlit":
+                            st.write(fig)
+                        else:
+                            fig.show()
 
                     logger.info("Visual Rendered Successfully")
                     return plot_filename
@@ -6197,7 +6210,10 @@ def plot_model(
                             f"Saving '{plot_filename}' in current active directory"
                         )
                     elif system:
-                        fig.show()
+                        if display_format=="streamlit":
+                            st.write(fig)
+                        else:
+                            fig.show()
 
                     logger.info("Visual Rendered Successfully")
                     return plot_filename

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -5795,7 +5795,7 @@ def plot_model(
     plot_formats = [None, "streamlit"]
     
     if display_format not in plot_formats:
-        raise ValueError("display_format can only be None or \"streamlit\".")
+        raise ValueError("display_format can only be None or 'streamlit'.")
 
     """
     

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -7291,6 +7291,7 @@ def evaluate_model(
         use_train_data=fixed(use_train_data),
         system=fixed(True),
         display=fixed(None),
+        display_format=fixed(None),
     )
 
 

--- a/pycaret/nlp.py
+++ b/pycaret/nlp.py
@@ -2043,6 +2043,12 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
                 "(Type Error): Model not supported for plot = topic_model. Please see docstring for list of available models supported for topic_model."
             )
 
+    # checking display_format parameter
+    plot_formats = [None, "streamlit"]
+    
+    if display_format not in plot_formats:
+        raise ValueError("display_format can only be None or \"streamlit\".")
+            
     """
     error handling ends here
     """

--- a/pycaret/nlp.py
+++ b/pycaret/nlp.py
@@ -4253,6 +4253,7 @@ def evaluate_model(model):
         topic_num=b,
         save=fixed(False),
         system=fixed(True),
+        display_format=fixed(None),
     )
 
 

--- a/pycaret/nlp.py
+++ b/pycaret/nlp.py
@@ -2047,7 +2047,7 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
     plot_formats = [None, "streamlit"]
     
     if display_format not in plot_formats:
-        raise ValueError("display_format can only be None or \"streamlit\".")
+        raise ValueError("display_format can only be None or 'streamlit'.")
             
     """
     error handling ends here

--- a/pycaret/nlp.py
+++ b/pycaret/nlp.py
@@ -1861,7 +1861,7 @@ def assign_model(model, verbose=True):
     return bb_
 
 
-def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=True):
+def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=True, display_format = None):
 
     """
     This function takes a trained model object (optional) and returns a plot based 
@@ -1914,6 +1914,9 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
 
     system: bool, default = True
         Must remain True all times. Only to be changed by internal functions.
+        
+    display_format: str, default = None
+        To display plots in [Streamlit](https://www.streamlit.io/), set this to 'streamlit'.
 
 
     Returns:
@@ -2089,18 +2092,36 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
                 logger.warning("topic_num set to None. Plot generated at corpus level.")
                 common_words = get_top_n_words(data_[target_], n=100)
                 df2 = pd.DataFrame(common_words, columns=["Text", "count"])
-                df3 = (
-                    df2.groupby("Text")
-                    .sum()["count"]
-                    .sort_values(ascending=False)
-                    .iplot(
-                        kind="bar",
-                        yTitle="Count",
-                        linecolor="black",
-                        title="Top 100 words after removing stop words",
-                        asFigure=save_param,
+                
+                if display_format=="streamlit":
+                    df3 = (
+                        df2.groupby("Text")
+                        .sum()["count"]
+                        .sort_values(ascending=False)
+                        .iplot(
+                            kind="bar",
+                            yTitle="Count",
+                            linecolor="black",
+                            title="Top 100 words after removing stop words",
+                            asFigure=True # plotly obj needs to be returned for streamlit to interpret
+                        )
                     )
-                )
+                    
+                    st.write(df3)
+                    
+                else:
+                    df3 = (
+                        df2.groupby("Text")
+                        .sum()["count"]
+                        .sort_values(ascending=False)
+                        .iplot(
+                            kind="bar",
+                            yTitle="Count",
+                            linecolor="black",
+                            title="Top 100 words after removing stop words",
+                            asFigure=save_param,
+                        )
+                    )
 
             else:
                 title = (
@@ -2118,18 +2139,36 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
                 ]
                 common_words = get_top_n_words(filtered_df[target_], n=100)
                 df2 = pd.DataFrame(common_words, columns=["Text", "count"])
-                df3 = (
-                    df2.groupby("Text")
-                    .sum()["count"]
-                    .sort_values(ascending=False)
-                    .iplot(
-                        kind="bar",
-                        yTitle="Count",
-                        linecolor="black",
-                        title=title,
-                        asFigure=save_param,
+                
+                if display_format=="streamlit":
+                    df3 = (
+                        df2.groupby("Text")
+                        .sum()["count"]
+                        .sort_values(ascending=False)
+                        .iplot(
+                            kind="bar",
+                            yTitle="Count",
+                            linecolor="black",
+                            title=title,
+                            asFigure=True # plotly obj needs to be returned for streamlit to interpret
+                        )
                     )
-                )
+                    
+                    st.write(df3)
+                    
+                else:
+                    df3 = (
+                        df2.groupby("Text")
+                        .sum()["count"]
+                        .sort_values(ascending=False)
+                        .iplot(
+                            kind="bar",
+                            yTitle="Count",
+                            linecolor="black",
+                            title=title,
+                            asFigure=save_param,
+                        )
+                    )
 
             logger.info("Visual Rendered Successfully")
 
@@ -2154,15 +2193,30 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
                 b = data_[target_].apply(lambda x: len(str(x).split()))
                 b = pd.DataFrame(b)
                 logger.info("Rendering Visual")
-                b = b[target_].iplot(
-                    kind="hist",
-                    bins=100,
-                    xTitle="word count",
-                    linecolor="black",
-                    yTitle="count",
-                    title="Word Count Distribution",
-                    asFigure=save_param,
-                )
+                
+                if display_format=="streamlit":
+                    b = b[target_].iplot(
+                        kind="hist",
+                        bins=100,
+                        xTitle="word count",
+                        linecolor="black",
+                        yTitle="count",
+                        title="Word Count Distribution",
+                        asFigure=True # plotly obj needs to be returned for streamlit to interpret
+                    )
+                    
+                    st.write(b)
+                    
+                else:
+                    b = b[target_].iplot(
+                        kind="hist",
+                        bins=100,
+                        xTitle="word count",
+                        linecolor="black",
+                        yTitle="count",
+                        title="Word Count Distribution",
+                        asFigure=save_param
+                    )
 
             else:
                 title = str(topic_num) + ": " + "Word Count Distribution"
@@ -2180,15 +2234,30 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
                 b = filtered_df[target_].apply(lambda x: len(str(x).split()))
                 b = pd.DataFrame(b)
                 logger.info("Rendering Visual")
-                b = b[target_].iplot(
-                    kind="hist",
-                    bins=100,
-                    xTitle="word count",
-                    linecolor="black",
-                    yTitle="count",
-                    title=title,
-                    asFigure=save_param,
-                )
+                
+                if display_format=="streamlit":
+                    b = b[target_].iplot(
+                        kind="hist",
+                        bins=100,
+                        xTitle="word count",
+                        linecolor="black",
+                        yTitle="count",
+                        title=title,
+                        asFigure=True # plotly obj needs to be returned for streamlit to interpret
+                    )
+                    
+                    st.write(b)
+                    
+                else:
+                    b = b[target_].iplot(
+                        kind="hist",
+                        bins=100,
+                        xTitle="word count",
+                        linecolor="black",
+                        yTitle="count",
+                        title=title,
+                        asFigure=save_param
+                    )
 
             logger.info("Visual Rendered Successfully")
 
@@ -2226,18 +2295,36 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
                 common_words = get_top_n_bigram(data_[target_], 100)
                 df3 = pd.DataFrame(common_words, columns=["Text", "count"])
                 logger.info("Rendering Visual")
-                df3 = (
-                    df3.groupby("Text")
-                    .sum()["count"]
-                    .sort_values(ascending=False)
-                    .iplot(
-                        kind="bar",
-                        yTitle="Count",
-                        linecolor="black",
-                        title="Top 100 bigrams after removing stop words",
-                        asFigure=save_param,
+                
+                if display_format=="streamlit":
+                    df3 = (
+                        df3.groupby("Text")
+                        .sum()["count"]
+                        .sort_values(ascending=False)
+                        .iplot(
+                            kind="bar",
+                            yTitle="Count",
+                            linecolor="black",
+                            title="Top 100 bigrams after removing stop words",
+                            asFigure=True # plotly obj needs to be returned for streamlit to interpret
+                        )
                     )
-                )
+                    
+                    st.write(df3)
+                    
+                else:
+                    df3 = (
+                        df3.groupby("Text")
+                        .sum()["count"]
+                        .sort_values(ascending=False)
+                        .iplot(
+                            kind="bar",
+                            yTitle="Count",
+                            linecolor="black",
+                            title="Top 100 bigrams after removing stop words",
+                            asFigure=save_param
+                        )
+                    )
 
             else:
                 title = (
@@ -2256,18 +2343,36 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
                 common_words = get_top_n_bigram(filtered_df[target_], 100)
                 df3 = pd.DataFrame(common_words, columns=["Text", "count"])
                 logger.info("Rendering Visual")
-                df3 = (
-                    df3.groupby("Text")
-                    .sum()["count"]
-                    .sort_values(ascending=False)
-                    .iplot(
-                        kind="bar",
-                        yTitle="Count",
-                        linecolor="black",
-                        title=title,
-                        asFigure=save_param,
+                
+                if display_format=="streamlit":
+                    df3 = (
+                        df3.groupby("Text")
+                        .sum()["count"]
+                        .sort_values(ascending=False)
+                        .iplot(
+                            kind="bar",
+                            yTitle="Count",
+                            linecolor="black",
+                            title=title,
+                            asFigure=True # plotly obj needs to be returned for streamlit to interpret
+                        )
                     )
-                )
+                    
+                    st.write(df3)
+                    
+                else:
+                    df3 = (
+                        df3.groupby("Text")
+                        .sum()["count"]
+                        .sort_values(ascending=False)
+                        .iplot(
+                            kind="bar",
+                            yTitle="Count",
+                            linecolor="black",
+                            title=title,
+                            asFigure=save_param
+                        )
+                    )
 
             logger.info("Visual Rendered Successfully")
 
@@ -2305,19 +2410,37 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
                 common_words = get_top_n_trigram(data_[target_], 100)
                 df3 = pd.DataFrame(common_words, columns=["Text", "count"])
                 logger.info("Rendering Visual")
-                df3 = (
-                    df3.groupby("Text")
-                    .sum()["count"]
-                    .sort_values(ascending=False)
-                    .iplot(
-                        kind="bar",
-                        yTitle="Count",
-                        linecolor="black",
-                        title="Top 100 trigrams after removing stop words",
-                        asFigure=save_param,
+                
+                if display_format=="streamlit":
+                    df3 = (
+                        df3.groupby("Text")
+                        .sum()["count"]
+                        .sort_values(ascending=False)
+                        .iplot(
+                            kind="bar",
+                            yTitle="Count",
+                            linecolor="black",
+                            title="Top 100 trigrams after removing stop words",
+                            asFigure=True # plotly obj needs to be returned for streamlit to interpret
+                        )
                     )
-                )
-
+                    
+                    st.write(df3)
+                    
+                else:
+                    df3 = (
+                        df3.groupby("Text")
+                        .sum()["count"]
+                        .sort_values(ascending=False)
+                        .iplot(
+                            kind="bar",
+                            yTitle="Count",
+                            linecolor="black",
+                            title="Top 100 trigrams after removing stop words",
+                            asFigure=save_param
+                        )
+                    )
+                    
             else:
                 title = (
                     str(topic_num) + ": " + "Top 100 trigrams after removing stop words"
@@ -2335,19 +2458,37 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
                 common_words = get_top_n_trigram(filtered_df[target_], 100)
                 df3 = pd.DataFrame(common_words, columns=["Text", "count"])
                 logger.info("Rendering Visual")
-                df3 = (
-                    df3.groupby("Text")
-                    .sum()["count"]
-                    .sort_values(ascending=False)
-                    .iplot(
-                        kind="bar",
-                        yTitle="Count",
-                        linecolor="black",
-                        title=title,
-                        asFigure=save_param,
+                
+                if display_format=="streamlit":
+                    df3 = (
+                        df3.groupby("Text")
+                        .sum()["count"]
+                        .sort_values(ascending=False)
+                        .iplot(
+                            kind="bar",
+                            yTitle="Count",
+                            linecolor="black",
+                            title=title,
+                            asFigure=True # plotly obj needs to be returned for streamlit to interpret
+                        )
                     )
-                )
-
+                    
+                    st.write(df3)
+                    
+                else:
+                    df3 = (
+                        df3.groupby("Text")
+                        .sum()["count"]
+                        .sort_values(ascending=False)
+                        .iplot(
+                            kind="bar",
+                            yTitle="Count",
+                            linecolor="black",
+                            title=title,
+                            asFigure=save_param
+                        )
+                    )
+                    
             logger.info("Visual Rendered Successfully")
 
             if save:
@@ -2377,16 +2518,31 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
                 )
                 sentiments = pd.DataFrame(sentiments)
                 logger.info("Rendering Visual")
-                sentiments = sentiments[target_].iplot(
-                    kind="hist",
-                    bins=50,
-                    xTitle="polarity",
-                    linecolor="black",
-                    yTitle="count",
-                    title="Sentiment Polarity Distribution",
-                    asFigure=save_param,
-                )
-
+                
+                if display_format=="streamlit":
+                    sentiments = sentiments[target_].iplot(
+                        kind="hist",
+                        bins=50,
+                        xTitle="polarity",
+                        linecolor="black",
+                        yTitle="count",
+                        title="Sentiment Polarity Distribution",
+                        asFigure=True # plotly obj needs to be returned for streamlit to interpret
+                    )
+                    
+                    st.write(sentiments)
+                    
+                else:
+                    sentiments = sentiments[target_].iplot(
+                        kind="hist",
+                        bins=50,
+                        xTitle="polarity",
+                        linecolor="black",
+                        yTitle="count",
+                        title="Sentiment Polarity Distribution",
+                        asFigure=save_param
+                    )
+                    
             else:
                 title = str(topic_num) + ": " + "Sentiment Polarity Distribution"
                 logger.info(
@@ -2404,16 +2560,31 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
                 )
                 sentiments = pd.DataFrame(sentiments)
                 logger.info("Rendering Visual")
-                sentiments = sentiments[target_].iplot(
-                    kind="hist",
-                    bins=50,
-                    xTitle="polarity",
-                    linecolor="black",
-                    yTitle="count",
-                    title=title,
-                    asFigure=save_param,
-                )
-
+                
+                if display_format=="streamlit":
+                    sentiments = sentiments[target_].iplot(
+                        kind="hist",
+                        bins=50,
+                        xTitle="polarity",
+                        linecolor="black",
+                        yTitle="count",
+                        title=title,
+                        asFigure=True # plotly obj needs to be returned for streamlit to interpret
+                    )
+                    
+                    st.write(sentiments)
+                    
+                else:
+                    sentiments = sentiments[target_].iplot(
+                        kind="hist",
+                        bins=50,
+                        xTitle="polarity",
+                        linecolor="black",
+                        yTitle="count",
+                        title=title,
+                        asFigure=save_param
+                    )
+                    
             logger.info("Visual Rendered Successfully")
 
             if save:
@@ -2439,14 +2610,27 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
         pos_df = pos_df.loc[pos_df["pos"] != "POS"]
         pos_df = pos_df.pos.value_counts()[:20]
         logger.info("Rendering Visual")
-        pos_df = pos_df.iplot(
-            kind="bar",
-            xTitle="POS",
-            yTitle="count",
-            title="Top 20 Part-of-speech tagging for review corpus",
-            asFigure=save_param,
-        )
-
+        
+        if display_format=="streamlit":
+            pos_df = pos_df.iplot(
+                kind="bar",
+                xTitle="POS",
+                yTitle="count",
+                title="Top 20 Part-of-speech tagging for review corpus",
+                asFigure=True # plotly obj needs to be returned for streamlit to interpret
+            )
+            
+            st.write(pos_df)
+            
+        else:
+            pos_df = pos_df.iplot(
+                kind="bar",
+                xTitle="POS",
+                yTitle="count",
+                title="Top 20 Part-of-speech tagging for review corpus",
+                asFigure=save_param
+            )
+            
         logger.info("Visual Rendered Sucessfully")
 
         if save:
@@ -2498,7 +2682,10 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
         )
 
         if system:
-            fig.show()
+            if display_format=="streamlit":
+                st.write(fig)
+            else:
+                fig.show()
 
         logger.info("Visual Rendered Successfully")
 
@@ -2621,7 +2808,10 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
         )
 
         if system:
-            fig.show()
+            if display_format=="streamlit":
+                st.write(fig)
+            else:
+                fig.show()
 
         logger.info("Visual Rendered Successfully")
 
@@ -2683,7 +2873,10 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
                 logger.info("Saving 'Wordcloud.png' in current active directory")
 
             else:
-                plt.show()
+                if display_format=="streamlit":
+                    st.write(plt)
+                else:
+                    plt.show()
 
             logger.info("Visual Rendered Successfully")
 
@@ -2734,7 +2927,10 @@ def plot_model(model=None, plot="frequency", topic_num=None, save=False, system=
             logger.info("Saving 'UMAP.png' in current active directory")
 
         else:
-            umap.show()
+            if display_format=="streamlit":
+                st.write(umap)
+            else:
+                umap.show()
 
         logger.info("Visual Rendered Successfully")
 

--- a/pycaret/regression.py
+++ b/pycaret/regression.py
@@ -1403,6 +1403,7 @@ def plot_model(
     groups: Optional[Union[str, Any]] = None,
     use_train_data: bool = False,
     verbose: bool = True,
+    display_format = None
 ) -> str:
 
     """
@@ -1473,6 +1474,9 @@ def plot_model(
 
     verbose: bool, default = True
         When set to False, progress bar is not displayed.
+        
+    display_format: str, default = None
+        To display plots in [Streamlit](https://www.streamlit.io/), set this to 'streamlit'.
 
 
     Returns:
@@ -1491,6 +1495,7 @@ def plot_model(
         verbose=verbose,
         use_train_data=use_train_data,
         system=True,
+        display_format=display_format
     )
 
 


### PR DESCRIPTION
# issue #884

### Changes

Added `display_format`

```
def plot_model(model, plot="2d", scale=1, display_format=None):
.
.
.
    if display_format=='streamlit'
        st.write(fig)
    else:
        fig.show()

```

### Notes

* Didn't include `import streamlit as st` since this will only work inside streamlit anyway
* Didn't use [`st.plotly_chart`](https://docs.streamlit.io/en/stable/api.html#streamlit.plotly_chart) since [`st.write`](https://docs.streamlit.io/en/stable/api.html#streamlit.write) can plot many types of charts and won't have to be changed if plotly is dropped later

# Update

* Added `display_format` to anywhere `plot_model` can be called 😃
* Error handling

### Additional:
In [nlp.py](https://github.com/pycaret/pycaret/blob/plot-in-streamlit/pycaret/nlp.py) where `fig.iplot()` is used, I had to change [`asFigure = save_param`](https://github.com/pycaret/pycaret/blob/2d528733269dcb353fe8d88f0c90f02c6bc8c593/pycaret/nlp.py#L2101) to `asFigure = True` because streamlit needs a plotly object to interpret (https://discuss.streamlit.io/t/cufflinks-in-streamlit/2232/2)

```
.
.
.
if display_format=='streamlit':
    fig = df.iplot(asFigure=True) # plotly obj needs to be returned for streamlit to interpret
    st.write(fig)
else:
    df.iplot()
```