### PR TITLE
Added low_memory and max_len support to arules.py

### DIFF
--- a/pycaret/arules.py
+++ b/pycaret/arules.py
@@ -115,7 +115,7 @@ def setup(data, transaction_id, item_id, ignore_items=None, session_id=None):
     return X, txid, iid, ignore_list, seed, experiment__
 
 
-def create_model(metric="confidence", threshold=0.5, min_support=0.05, round=4):
+def create_model(metric="confidence", threshold=0.5, min_support=0.05, round=4, low_memory=False, max_len=None):
 
     """
     This function creates an association rules model using data and identifiers
@@ -157,6 +157,17 @@ def create_model(metric="confidence", threshold=0.5, min_support=0.05, round=4):
 
     round: int, default = 4
         Number of decimal places metrics in score grid will be rounded to.
+        
+    low_memory: bool, default = False
+        If `True`, uses an iterator for apriori to search for combinations above
+      `min_support`.
+      Note that while `low_memory=True` should only be used for large dataset
+      if memory resources are limited, because this implementation is approx.
+      3-6x slower than the default.
+
+    max_len: int, default = None
+        Maximum length of the itemsets generated in apriori. If `None` (default) all
+      possible itemsets lengths (under the apriori condition) are evaluated.
 
 
     Returns:
@@ -196,7 +207,7 @@ def create_model(metric="confidence", threshold=0.5, min_support=0.05, round=4):
 
     basket = basket.applymap(encode_units)
 
-    frequent_itemsets = apriori(basket, min_support=min_support, use_colnames=True)
+    frequent_itemsets = apriori(basket, min_support=min_support, use_colnames=True, low_memory=low_memory, max_len=max_len)
     rules = association_rules(frequent_itemsets, metric=metric, min_threshold=threshold)
     rules = rules.sort_values(by=[metric], ascending=False).reset_index(drop=True)
     rules = rules.round(round)


### PR DESCRIPTION
Added low_memory and max_len support to arules.py for large datasets or low resource compute spaces.

apriori.apriori already has support for low_memory and max_len so just adding this option to arules.py
