### PR TITLE
Time series metrics

### DIFF
--- a/pycaret/containers/metrics/time_series.py
+++ b/pycaret/containers/metrics/time_series.py
@@ -17,7 +17,10 @@ import numpy as np
 from sklearn import metrics
 from sklearn.utils.validation import check_consistent_length
 from sklearn.metrics._regression import _check_reg_targets
-
+from sktime.performance_metrics.forecasting._functions import (mase_loss,
+    smape_loss,
+    mape_loss
+)
 
 class TimeSeriesMetricContainer(MetricContainer):
     """
@@ -145,6 +148,59 @@ class TimeSeriesMetricContainer(MetricContainer):
         }
 
         return d
+
+
+class SMAPEMetricContainer(TimeSeriesMetricContainer):
+     def __init__(self, globals_dict: dict) -> None:
+        super().__init__(
+            id="smape",
+            name="SMAPE",
+            score_func=smape_loss,
+            greater_is_better=False,
+        )
+
+
+class MAPEMetricContainer(TimeSeriesMetricContainer):
+     def __init__(self, globals_dict: dict) -> None:
+        super().__init__(
+            id="mape_ts",
+            name="MAPE_ts",
+            score_func=mape_loss,
+            greater_is_better=False,
+        )
+
+
+class MASEMetricContainer(TimeSeriesMetricContainer):
+     def __init__(self, globals_dict: dict) -> None:
+        super().__init__(
+            id="mase",
+            name="MASE",
+            score_func=mase_loss,
+            greater_is_better=False
+        )
+
+
+class MAEMetricContainer(TimeSeriesMetricContainer):
+     def __init__(self, globals_dict: dict) -> None:
+        super().__init__(
+            id="mae_ts",
+            name="MAE_ts",
+            score_func=metrics.mean_absolute_error,
+            greater_is_better=False,
+            scorer="neg_mean_absolute_error"
+        )
+
+class RMSEMetricContainer(TimeSeriesMetricContainer):
+    def __init__(self, globals_dict: dict) -> None:
+
+        super().__init__(
+            id="rmse_ts",
+            name="RMSE_ts",
+            score_func=metrics.mean_squared_error,
+            greater_is_better=False,
+            args={"squared": False},
+            scorer="neg_root_mean_squared_error",
+        )
 
 
 def get_all_metric_containers(

--- a/pycaret/containers/metrics/time_series.py
+++ b/pycaret/containers/metrics/time_series.py
@@ -1,5 +1,5 @@
 # Module: containers.metrics.time_series
-# Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
+# Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com> and Miguel Trejo <amtrema@hotmail.com>
 # License: MIT
 
 # The purpose of this module is to serve as a central repository of time series metrics. The `time_series` module will

--- a/pycaret/tests/test_utils.py
+++ b/pycaret/tests/test_utils.py
@@ -148,7 +148,7 @@ def test():
     mape = pycaret.utils.check_metric(actual, prediction, "MAPE_ts")
     assert isinstance(mape, float)
     assert mape >= 0
-    mase = pycaret.utils.check_metric(test, prediction, "MASE", train)
+    mase = pycaret.utils.check_metric(test, prediction, "MASE", train=train)
     assert isinstance(mase, float)
     assert mase >= 0
     mae = pycaret.utils.check_metric(actual, prediction, "MAE_ts")

--- a/pycaret/tests/test_utils.py
+++ b/pycaret/tests/test_utils.py
@@ -3,6 +3,7 @@ import os, sys
 sys.path.insert(0, os.path.abspath(".."))
 
 import numpy as np
+import numpy.testing as npt
 import pandas as pd
 import pytest
 import pycaret.utils
@@ -125,11 +126,11 @@ def test():
 
     # Ensure metric is rounded to 2 decimals
     mape = pycaret.utils.check_metric(actual, prediction, "MAPE", 2)
-    assert mape == 0.05
+    npt.assert_almost_equal(mape, 0.05, decimal=2)
 
     # Ensure metric is rounded to default value
     mape = pycaret.utils.check_metric(actual, prediction, "MAPE")
-    assert mape == 0.0469
+    npt.assert_almost_equal(mape, 0.0469, decimal=4)
 
     # preparation (timeseries)
     data = pycaret.datasets.get_data("airline", verbose=False)
@@ -137,7 +138,6 @@ def test():
         data, train_size=0.8, random_state=1, shuffle=False
     )
 
-    # TO DO: call setup, create_model, finalize_model and predict_model
     prediction = pd.Series([100]*len(test), index=test.index)
     actual = test
 
@@ -160,11 +160,11 @@ def test():
 
     # Ensure metric is rounded to 2 decimals
     smape = pycaret.utils.check_metric(actual, prediction, "SMAPE", 2)
-    assert smape == 1.24
+    npt.assert_almost_equal(smape, 1.24, decimal=2)
 
     # Ensure metric is rounded to default value
     smape = pycaret.utils.check_metric(actual, prediction, "SMAPE")
-    assert smape == 1.2448
+    npt.assert_almost_equal(smape, 1.2448, decimal=4)
 
     # Metric does not exist
     with pytest.raises(ValueError, match="Couldn't find metric"):

--- a/pycaret/tests/test_utils.py
+++ b/pycaret/tests/test_utils.py
@@ -3,6 +3,7 @@ import os, sys
 sys.path.insert(0, os.path.abspath(".."))
 
 import numpy as np
+import pandas as pd
 import pytest
 import pycaret.utils
 import pycaret.classification
@@ -129,6 +130,41 @@ def test():
     # Ensure metric is rounded to default value
     mape = pycaret.utils.check_metric(actual, prediction, "MAPE")
     assert mape == 0.0469
+
+    # preparation (timeseries)
+    data = pycaret.datasets.get_data("airline", verbose=False)
+    train, test = sklearn.model_selection.train_test_split(
+        data, train_size=0.8, random_state=1, shuffle=False
+    )
+
+    # TO DO: call setup, create_model, finalize_model and predict_model
+    prediction = pd.Series([100]*len(test), index=test.index)
+    actual = test
+
+    # check metric(timeseries)
+    smape = pycaret.utils.check_metric(actual, prediction, "SMAPE")
+    assert isinstance(smape, float)
+    assert smape >= 0
+    mape = pycaret.utils.check_metric(actual, prediction, "MAPE_ts")
+    assert isinstance(mape, float)
+    assert mape >= 0
+    mase = pycaret.utils.check_metric(test, prediction, "MASE", train)
+    assert isinstance(mase, float)
+    assert mase >= 0
+    mae = pycaret.utils.check_metric(actual, prediction, "MAE_ts")
+    assert isinstance(mae, float)
+    assert mae >= 0
+    rmse = pycaret.utils.check_metric(actual, prediction, "RMSE_ts")
+    assert isinstance(rmse, float)
+    assert rmse >= 0
+
+    # Ensure metric is rounded to 2 decimals
+    smape = pycaret.utils.check_metric(actual, prediction, "SMAPE", 2)
+    assert smape == 1.24
+
+    # Ensure metric is rounded to default value
+    smape = pycaret.utils.check_metric(actual, prediction, "SMAPE")
+    assert smape == 1.2448
 
     # Metric does not exist
     with pytest.raises(ValueError, match="Couldn't find metric"):

--- a/pycaret/utils.py
+++ b/pycaret/utils.py
@@ -75,7 +75,7 @@ def check_metric(actual: pd.Series, prediction: pd.Series, metric: str, round: i
     if metric in metrics:
         try:
             result = metrics[metric](*input_params)
-        except: # TO DO: Which type of exception are you expecting ? 
+        except:
             from sklearn.preprocessing import LabelEncoder
 
             le = LabelEncoder()

--- a/pycaret/utils.py
+++ b/pycaret/utils.py
@@ -3,6 +3,7 @@
 # License: MIT
 
 import pandas as pd
+from typing import Optional
 
 version_ = "2.2.3"
 nightly_version_ = "2.2.3"
@@ -18,10 +19,10 @@ def nightly_version():
     return nightly_version_
 
 
-def check_metric(actual: pd.Series, prediction: pd.Series, metric: str, round: int = 4):
+def check_metric(actual: pd.Series, prediction: pd.Series, metric: str, round: int = 4, train: Optional[pd.Series] = None):
 
     """
-    Function to evaluate classification and regression metrics.
+    Function to evaluate classification, regression and timeseries metrics.
 
 
     actual : pandas.Series
@@ -30,6 +31,10 @@ def check_metric(actual: pd.Series, prediction: pd.Series, metric: str, round: i
 
     prediction : pandas.Series
         Predicted values of the target variable.
+
+
+    train: pandas.Series
+        Train values of the target variable.
 
 
     metric : str
@@ -48,6 +53,7 @@ def check_metric(actual: pd.Series, prediction: pd.Series, metric: str, round: i
     # general dependencies
     import pycaret.containers.metrics.classification
     import pycaret.containers.metrics.regression
+    import pycaret.containers.metrics.time_series
 
     globals_dict = {"y": prediction}
     metric_containers = {
@@ -55,15 +61,21 @@ def check_metric(actual: pd.Series, prediction: pd.Series, metric: str, round: i
             globals_dict
         ),
         **pycaret.containers.metrics.regression.get_all_metric_containers(globals_dict),
+        **pycaret.containers.metrics.time_series.get_all_metric_containers(globals_dict)
     }
     metrics = {v.name: v.score_func for k, v in metric_containers.items()}
+
+    if isinstance(train, pd.Series):
+        input_params = [actual, prediction, train]
+    else:
+        input_params = [actual, prediction]
 
     # metric calculation starts here
 
     if metric in metrics:
         try:
-            result = metrics[metric](actual, prediction)
-        except:
+            result = metrics[metric](*input_params)
+        except: # TO DO: Which type of exception are you expecting ? 
             from sklearn.preprocessing import LabelEncoder
 
             le = LabelEncoder()

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -8,5 +8,6 @@ psutil
 awscli
 azure-storage-blob
 google-cloud-storage
+sktime==0.5.2
 #hpbandster
 #ConfigSpace


### PR DESCRIPTION
## Related Issue or bug

* [#1039]

#### Describe the changes you've made

Major changes of this branch include:

* Add SMAPE, MAPE, MASE, MAE and RMSE containers for time series. [link](https://github.com/pycaret/pycaret/blob/time_series_metrics/pycaret/containers/metrics/time_series.py#L153)

Minor changes include:

* Add `sktime` as a requirement to `requirements-optional` to ensure installation during CI stage. [link](https://github.com/pycaret/pycaret/blob/time_series_metrics/requirements-optional.txt#L11)

## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Testing changes include:

* Added time series metrics testing to `check_metric` function. [link](https://github.com/pycaret/pycaret/blob/time_series_metrics/pycaret/utils.py#L64)
*  Test float values through `numpy.testing.assert_almost_equal`. [example](https://github.com/pycaret/pycaret/blob/time_series_metrics/pycaret/tests/test_utils.py#L163)

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

