### PR TITLE
Separate y from the preprocessing pipeline

### DIFF
--- a/pycaret/internal/preprocess/preprocess.py
+++ b/pycaret/internal/preprocess/preprocess.py
@@ -89,6 +89,23 @@ def find_id_columns(data, target, numerical_features):
     return id_columns
 
 
+class Target_Remover(BaseEstimator, TransformerMixin):
+    """
+    Removes the target from the dataset if the target column exists in the dataset
+    """
+    def __init__(self, target):
+        self.target = target
+
+    def fit(self, X=None, y=None):  # Nothing to fit
+        return self
+
+    def transform(self, X, y=None):  # Just remove target from X
+        return X.drop(self.target, axis=1, errors='ignore')
+
+    def fit_transform(self, X, y=None):  # Same as transform
+        return self.transform(X)
+
+
 class DataTypes_Auto_infer(BaseEstimator, TransformerMixin):
     """
     - This will try to infer data types automatically, option to override learent data types is also available.
@@ -3666,6 +3683,9 @@ def Preprocess_Path_One(
     else:
         pca = SKLEARN_EMPTY_STEP
 
+    # Initiate a target remover
+    target_remover = Target_Remover(target=target_variable)
+
     pipe = Pipeline(
         [
             ("dtypes", dtypes),
@@ -3693,6 +3713,7 @@ def Preprocess_Path_One(
             ("feature_select", feature_select),
             ("fix_multi", fix_multi),
             ("dfs", dfs),
+            ("target_remover", target_remover),
             ("pca", pca),
         ]
     )

--- a/pycaret/tests/test_preprocess.py
+++ b/pycaret/tests/test_preprocess.py
@@ -15,6 +15,27 @@ import pycaret.internal.preprocess
 from pycaret.internal.preprocess import TransformedTargetClassifier
 
 
+def test_target_remover():
+    """
+    Test if the target remover removes the target correctly
+    """
+    # Load an example dataset and set the features and target
+    data = pycaret.datasets.get_data("juice")
+    target = "Purchase"
+    features = data.columns.tolist()
+    features.remove(target)
+    data_features = data[features]
+
+    # Initiate a target generator
+    target_generator = pycaret.internal.preprocess.Target_Remover(target=target)
+
+    # Use the target remover to remove the target column from X
+    result = target_generator.fit_transform(X=data)
+
+    # Check if the result contains only X and is the same as the original data
+    pd.testing.assert_frame_equal(data_features.sort_index(axis=1), result.sort_index(axis=1))
+
+
 def test_sklearn_pipeline_simple_imputer():
     """
     Test if the simple imputer in pycaret works with sklearn's pipeline
@@ -145,6 +166,9 @@ def test_complete_sklearn_pipeline():
 
 
 def test_target_transformer():
+    """
+    Test if the target transformer for classifiers works correctly
+    """
     # Load an example dataset and set the features and target
     data = pycaret.datasets.get_data("juice")
     target = "Purchase"


### PR DESCRIPTION
#### Describe the changes you've made
1. Separated y from the preprocessing pipeline in PycaretExperiment.py and tested with a target remover added in the preprocessing pipeline. 
2. Also made sure the tests related to the refactored transformers (i.e., all transformers after the target remover in the pipeline, currently only the test_pca.py) passed.

This is a draft and it hasn't dealt with the encoding of y for classification problems. The proposal for the next step is to use the TransformedTargetClassifier class to wrap classifiers. @Yard1 could you take a look and see if this approach is reasonable? Thanks!






## Type of change


 
 
 
 
 
 
 
 
 










