### PR TITLE
Fix load_model() for AWS models in persistence.py

### DIFF
--- a/pycaret/internal/persistence.py
+++ b/pycaret/internal/persistence.py
@@ -393,7 +393,7 @@ def load_model(
                 os.makedirs(path)
             s3.Bucket(bucketname).download_file(key, filename)
 
-        model = load_model(filename, verbose=False)
+        model = load_model(model_name, verbose=False)
 
         if verbose:
             print("Transformation Pipeline and Model Successfully Loaded")


### PR DESCRIPTION
## Related Issuse or bug
  - AWS deployed models can't be loaded

Fixes: #1127 

#### Describe the changes you've made
load_model() for AWS deployed model was calling 'filename' instead of 'model_name'.
Model could not load because it was appending .pkl twice.
Sorry, this is my first PR for pycaret so unsure of the guidelines!

## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Reran the demo code with the change from my fork of pycaret and it works.


#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots
NA
 
 
 
 
 
 










