### PR TITLE
Time series seasonal parameter and fh splitting data.

### DIFF
--- a/pycaret/internal/PycaretExperiment.py
+++ b/pycaret/internal/PycaretExperiment.py
@@ -4706,11 +4706,11 @@ class _SupervisedExperiment(_TabularExperiment):
 
                 from sktime.forecasting.model_selection import temporal_train_test_split # sktime is an optional dependency
 
-                train_data, test_data = temporal_train_test_split(
+
+                train_data, test_data, self.X_train, self.X_test = temporal_train_test_split(
                     y=y_before_preprocess,
-                    X=None,
-                    fh=fh, # if fh is provided it splits by it
-                    #train_size=train_size, # original split by train size
+                    X=X_before_preprocess,
+                    fh=fh # if fh is provided it splits by it
                 )
 
                 train_data, test_data = pd.DataFrame(train_data), pd.DataFrame(test_data)

--- a/pycaret/internal/PycaretExperiment.py
+++ b/pycaret/internal/PycaretExperiment.py
@@ -890,7 +890,7 @@ class _TabularExperiment(_PyCaretExperiment):
         log_profile: bool = False,
         log_data: bool = False,
         silent: bool = False,
-        sp: Optional[int] = None,
+        seasonal_parameter: Optional[int] = None,
         verbose: bool = True,
         profile: bool = False,
         profile_kwargs: Dict[str, Any] = None,
@@ -15834,7 +15834,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
     def setup(
         self,
         data: Union[pd.Series, pd.DataFrame],
-        train_size: float = 0.7,
+        #train_size: float = 0.7,
         test_data: Optional[pd.DataFrame] = None,
         preprocess: bool = True,
         imputation_type: str = "simple",
@@ -15843,7 +15843,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
         fold_strategy: Union[str, Any] = "timeseries",  # added in pycaret==2.2
         fold: int = 10,
         fh: Union[List[int], int, np.array] = 1,
-        sp: Optional[Union[int, str]] = None,
+        seasonal_parameter: Optional[Union[int, str]] = None,
         n_jobs: Optional[int] = -1,
         use_gpu: bool = False,
         custom_pipeline: Union[
@@ -15878,15 +15878,11 @@ class TimeSeriesExperiment(_SupervisedExperiment):
             Shape (n_samples, 1), where n_samples is the number of samples.
 
 
-        train_size: float, default = 0.7
-            Proportion of the dataset to be used for training and validation. Should be
-            between 0.0 and 1.0.
-
-
         test_data: pandas.DataFrame, default = None
             If not None, test_data is used as a hold-out set and ``train_size`` parameter is
             ignored. test_data must be labelled and the shape of data and test_data must
             match.
+
 
         fh: np.array, default = None
             The forecast horizon to be used for forecasting. User must specify a value.
@@ -15924,7 +15920,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
             Number of steps ahead to take to evaluate forecast.
 
 
-        sp: int or str, default = None
+        seasonal_parameter: int or str, default = None
             Seasonal periods in timeseries data. If not provided the frequency of the data
             index is map to a seasonal period as follows:
 
@@ -15937,6 +15933,8 @@ class TimeSeriesExperiment(_SupervisedExperiment):
             * 'Q': 4
             * 'A': 1
             * 'Y': 1
+
+            Alternatively you can provide a custom seasonal parameter by passing it as an integer.
 
 
         n_jobs: int, default = -1
@@ -16050,31 +16048,31 @@ class TimeSeriesExperiment(_SupervisedExperiment):
             )
         self.fh = fh
 
-        if sp is None:
+        if seasonal_parameter is None:
 
             index_freq = data.index.freqstr
             index_freq = index_freq.split('-')[0] or index_freq
 
             if index_freq in SeasonalParameter.__members__:
-                sp = SeasonalParameter[index_freq].value
+                seasonal_parameter = SeasonalParameter[index_freq].value
             else:
                 raise ValueError(
-                    f"Unsupported Period frequency: {index_freq}, valid Period frequencies: {', '.join(valid_freq)}"
+                    f"Unsupported Period frequency: {index_freq}, valid Period frequencies: {', '.join(SeasonalParameter.__members__.keys())}"
                 )
 
         else:
 
-            if not isinstance(sp, (int, str)):
+            if not isinstance(seasonal_parameter, (int, str)):
                 raise ValueError(
-                    f"sp parameter must be an int or str, got {type(sp)}"
+                    f"seasonal_parameter parameter must be an int or str, got {type(seasonal_parameter)}"
                 )
 
-            if isinstance(sp, str):
+            if isinstance(seasonal_parameter, str):
                 try:
-                    sp = SeasonalParameter[sp]
+                    seasonal_parameter = SeasonalParameter[seasonal_parameter]
                 except KeyError:
                     raise ValueError(
-                        f"Unsupported Period frequency: {sp}, valid Period frequencies: {', '.join(valid_freq)}"
+                        f"Unsupported Period frequency: {seasonal_parameter}, valid Period frequencies: {', '.join(SeasonalParameter.__members__.keys())}"
                     )
 
 
@@ -16123,7 +16121,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
         return super().setup(
             data=data,
             target=data.columns[0],
-            train_size=train_size,
+            #train_size=train_size,
             test_data=test_data,
             preprocess=preprocess,
             imputation_type=imputation_type,
@@ -16155,7 +16153,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
             fold_strategy=fold_strategy,
             fold=fold,
             fh=fh,
-            sp=sp,
+            seasonal_parameter=seasonal_parameter,
             fold_shuffle=False,
             n_jobs=n_jobs,
             use_gpu=use_gpu,

--- a/pycaret/internal/PycaretExperiment.py
+++ b/pycaret/internal/PycaretExperiment.py
@@ -9170,6 +9170,7 @@ class _UnsupervisedExperiment(_TabularExperiment):
         data_split_shuffle,
         dtypes,
         display: Display,
+        fh=None
     ) -> None:
         display.move_progress()
         self.X = self.prep_pipe.fit_transform(train_data).drop(target, axis=1)

--- a/pycaret/internal/PycaretExperiment.py
+++ b/pycaret/internal/PycaretExperiment.py
@@ -16042,9 +16042,16 @@ class TimeSeriesExperiment(_SupervisedExperiment):
                 'Y': 1 #year
             }
 
+            valid_freq = list(freq_to_sp.keys())
             index_freq = data.index.freqstr
             index_freq = index_freq.split('-')[0] or index_freq
-            sp = freq_to_sp.get(index_freq, None)
+
+            if index_freq in valid_freq:
+                sp = freq_to_sp.get(index_freq, None)
+            else:
+                raise ValueError(
+                f"Unsupported Period frequency: {index_freq}, valid Period frequencies: {', '.join(valid_freq)}"
+            )
 
         if isinstance(data, (pd.Series, pd.DataFrame)):
             if isinstance(data, pd.DataFrame):

--- a/pycaret/internal/PycaretExperiment.py
+++ b/pycaret/internal/PycaretExperiment.py
@@ -4709,8 +4709,8 @@ class _SupervisedExperiment(_TabularExperiment):
                 train_data, test_data = temporal_train_test_split(
                     y=y_before_preprocess,
                     X=None,
-                    #train_size=train_size, # change to forecast horizon instead of 30%
                     fh=fh, # if fh is provided it splits by it
+                    #train_size=train_size, # original split by train size
                 )
 
                 train_data, test_data = pd.DataFrame(train_data), pd.DataFrame(test_data)

--- a/pycaret/internal/PycaretExperiment.py
+++ b/pycaret/internal/PycaretExperiment.py
@@ -4695,7 +4695,7 @@ class _SupervisedExperiment(_TabularExperiment):
         data_split_shuffle,
         dtypes,
         display: Display,
-        fh
+        fh=None
     ) -> None:
         _stratify_columns = get_columns_to_stratify_by(
             X_before_preprocess, y_before_preprocess, self.stratify_param, target

--- a/pycaret/internal/utils.py
+++ b/pycaret/internal/utils.py
@@ -16,8 +16,21 @@ from typing import Any, List, Optional, Dict, Tuple, Union
 from sklearn import clone
 from sklearn.model_selection import KFold, StratifiedKFold, BaseCrossValidator
 from sklearn.model_selection._split import _BaseKFold
+from enum import IntEnum
 
 
+class SeasonalParameter(IntEnum):
+    S = 60 # second
+    T = 60 # minute
+    H = 24 # hour
+    D = 7 # day
+    W = 52 # week
+    M = 12 # month
+    Q = 4 # quarter
+    A = 1 #year
+    Y = 1 #year
+
+    
 def get_config(variable: str, globals_d: dict):
 
     """

--- a/pycaret/tests/test_time_series_splitters.py
+++ b/pycaret/tests/test_time_series_splitters.py
@@ -43,10 +43,12 @@ def test_setup_initialization(fold, fh, fold_strategy, load_data):
         elif fold_strategy == "slidingwindow":
             assert isinstance(exp_name.fold_generator, SlidingWindowSplitter)
 
-        expected = int(len(load_data)*train_size) - fold * fh  # Since fh is an int
+        #expected = int(len(load_data)*train_size) - fold * fh  # Since fh is an int, if train_size splits original data
+        expected = int(len(load_data) - fh) - fold * fh # if fh splits original data
         assert exp_name.fold_generator.initial_window == expected
         assert np.all(exp_name.fold_generator.fh == np.arange(1, fh+1))
         assert exp_name.fold_generator.step_length == fh  # Since fh is an int
+    
     # elif fold_strategy == "timeseries":
     #     assert isinstance(exp_name.fold_generator, TimeSeriesSplit)
 

--- a/pycaret/tests/test_time_series_splitters.py
+++ b/pycaret/tests/test_time_series_splitters.py
@@ -28,13 +28,13 @@ def test_setup_initialization(fold, fh, fold_strategy, load_data):
     )
     from sklearn.model_selection import TimeSeriesSplit
 
-    train_size = 0.7
+    #train_size = 0.7
     exp_name = setup(
         data=load_data,
         fold=fold,
         fh=fh,
         fold_strategy=fold_strategy,
-        train_size=train_size
+        #train_size=train_size
     )
 
     if (fold_strategy == "expandingwindow") or (fold_strategy == "slidingwindow"):

--- a/pycaret/time_series.py
+++ b/pycaret/time_series.py
@@ -39,7 +39,7 @@ _CURRENT_EXPERIMENT_DECORATOR_DICT = {"_CURRENT_EXPERIMENT": _CURRENT_EXPERIMENT
 
 def setup(
     data: Union[pd.Series, pd.DataFrame],
-    train_size: float = 0.7,
+    #train_size: float = 0.7,
     test_data: Optional[pd.DataFrame] = None,
     preprocess: bool = True,
     imputation_type: str = "simple",
@@ -48,7 +48,7 @@ def setup(
     fold_strategy: Union[str, Any] = "timeseries",  # added in pycaret==2.2
     fold: int = 10,
     fh: Union[List[int], int, np.ndarray] = 1,
-    sp: Optional[Union[int, str]] = None,
+    seasonal_parameter: Optional[Union[int, str]] = None,
     n_jobs: Optional[int] = -1,
     use_gpu: bool = False,
     custom_pipeline: Union[Any, Tuple[str, Any], List[Any], List[Tuple[str, Any]]] = None,
@@ -79,11 +79,6 @@ def setup(
 
     data : pandas.Series or pandas.DataFrame
         Shape (n_samples, 1), where n_samples is the number of samples.
-
-
-    train_size: float, default = 0.7
-        Proportion of the dataset to be used for training and validation. Should be
-        between 0.0 and 1.0.
 
 
     test_data: pandas.DataFrame, default = None
@@ -122,7 +117,7 @@ def setup(
         Number of steps ahead to take to evaluate forecast.
 
 
-    sp: int or str, default = None
+    seasonal_parameter: int or str, default = None
         Seasonal periods in timeseries data. If not provided the frequency of the data
         index is map to a seasonal period as follows:
 
@@ -135,6 +130,8 @@ def setup(
         * 'Q': 4
         * 'A': 1
         * 'Y': 1
+
+        Alternatively you can provide a custom seasonal parameter by passing it as an integer.
 
 
     n_jobs: int, default = -1
@@ -229,14 +226,14 @@ def setup(
     set_current_experiment(exp)
     return exp.setup(
         data=data,
-        train_size=train_size,
+        #train_size=train_size,
         test_data=test_data,
         preprocess=preprocess,
         imputation_type=imputation_type,
         fold_strategy=fold_strategy,
         fold=fold,
         fh=fh,
-        sp=sp,
+        seasonal_parameter=seasonal_parameter,
         n_jobs=n_jobs,
         use_gpu=use_gpu,
         custom_pipeline=custom_pipeline,

--- a/pycaret/time_series.py
+++ b/pycaret/time_series.py
@@ -48,6 +48,7 @@ def setup(
     fold_strategy: Union[str, Any] = "timeseries",  # added in pycaret==2.2
     fold: int = 10,
     fh: Union[List[int], int, np.ndarray] = 1,
+    sp: Optional[int] = None,
     n_jobs: Optional[int] = -1,
     use_gpu: bool = False,
     custom_pipeline: Union[Any, Tuple[str, Any], List[Any], List[Tuple[str, Any]]] = None,
@@ -119,6 +120,21 @@ def setup(
 
     fh: int, list or np.array, default = 1
         Number of steps ahead to take to evaluate forecast.
+
+
+    sp: int, default = None
+        Seasonal periods in timeseries data. If not provided the frequency of the data
+        index is map to a seasonal period as follows:
+
+        * "S": 60
+        * "T": 60
+        * 'H': 24
+        * 'D': 7
+        * 'W': 52
+        * 'M': 12
+        * 'Q': 4
+        * 'A': 1
+        * 'Y': 1
 
 
     n_jobs: int, default = -1
@@ -220,6 +236,7 @@ def setup(
         fold_strategy=fold_strategy,
         fold=fold,
         fh=fh,
+        sp=sp,
         n_jobs=n_jobs,
         use_gpu=use_gpu,
         custom_pipeline=custom_pipeline,

--- a/pycaret/time_series.py
+++ b/pycaret/time_series.py
@@ -48,7 +48,7 @@ def setup(
     fold_strategy: Union[str, Any] = "timeseries",  # added in pycaret==2.2
     fold: int = 10,
     fh: Union[List[int], int, np.ndarray] = 1,
-    sp: Optional[int] = None,
+    sp: Optional[Union[int, str]] = None,
     n_jobs: Optional[int] = -1,
     use_gpu: bool = False,
     custom_pipeline: Union[Any, Tuple[str, Any], List[Any], List[Tuple[str, Any]]] = None,
@@ -122,7 +122,7 @@ def setup(
         Number of steps ahead to take to evaluate forecast.
 
 
-    sp: int, default = None
+    sp: int or str, default = None
         Seasonal periods in timeseries data. If not provided the frequency of the data
         index is map to a seasonal period as follows:
 


### PR DESCRIPTION

#### Describe the changes you've made


Major changes are:

* User can set a seasonal parameter `sp` in the setup function, if not provided the frequency of the PeriodIndex will be taken as the seasonal parameter. [link](https://github.com/pycaret/pycaret/blob/time_series_seasonal_parameter/pycaret/time_series.py#L125)
* The forecast horizon `fh` splits the original data in train/test, before this change the `train_size` parameter splitted the original data. [link](https://github.com/pycaret/pycaret/blob/time_series_seasonal_parameter/pycaret/internal/PycaretExperiment.py#L4712)


## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

No new tests added, however two test are modified:
*  `test_create_model` and `test_tune_model`  to assert that the prediction index match the last `fh` elements of the original data. [link](https://github.com/pycaret/pycaret/blob/time_series_seasonal_parameter/pycaret/tests/test_time_series.py#L77)
* In `test_time_series_splitters`  the `initial_window` of the fold_generator is equal to `int(len(load_data) - fh) - fold * fh` as the forecast horizon splits the data in train/test. [link](https://github.com/pycaret/pycaret/blob/time_series_seasonal_parameter/pycaret/tests/test_time_series_splitters.py#L47)

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
 
 
 
 
 
 










