### PR TITLE
add X_new_sample option to interpret_model

### DIFF
--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -1625,6 +1625,7 @@ def interpret_model(
     feature: Optional[str] = None,
     observation: Optional[int] = None,
     use_train_data: bool = False,
+    X_new_sample: Optional[pd.DataFrame] = None,
     save: bool = False,
     **kwargs,
 ):
@@ -1668,6 +1669,12 @@ def interpret_model(
         of test data.
 
 
+    X_new_sample: pd.DataFrame, default = None
+        Row from an out-of-sample dataframe (neither train nor test data) to be plotted.
+        The sample must have the same columns as the raw input data, and it is transformed
+        by the preprocessing pipeline automatically before plotting.
+
+
     save: bool, default = False
         When set to True, Plot is saved as a 'png' file in current working directory.
 
@@ -1687,6 +1694,7 @@ def interpret_model(
         feature=feature,
         observation=observation,
         use_train_data=use_train_data,
+        X_new_sample=X_new_sample,
         save=save,
         **kwargs,
     )

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -7328,7 +7328,8 @@ def interpret_model(
     plot: str = "summary",
     feature: Optional[str] = None,
     observation: Optional[int] = None,
-    use_train_data: bool = False,
+    use_train_data: Optional[bool] = False,
+    X_new_sample: Optional[pd.DataFrame] = None,
     save: bool = False,
     **kwargs,  # added in pycaret==2.1
 ):
@@ -7372,6 +7373,11 @@ def interpret_model(
         with the option to select the feature on x and y axes through drop down
         interactivity. For analysis at the sample level, an observation parameter must
         be passed with the index value of the observation in test / hold-out set.
+
+    X_new_sample: pd.DataFrame, default = None
+        Row from an out-of-sample dataframe (neither train nor test data) to be plotted.
+        The sample must have the same columns as the raw input data, and it is transformed
+        by the preprocessing pipeline automatically before plotting.
 
     save: bool, default = False
         When set to True, Plot is saved as a 'png' file in current working directory.
@@ -7434,13 +7440,19 @@ def interpret_model(
             "type parameter only accepts 'summary', 'correlation' or 'reason'."
         )
 
+    if X_new_sample is not None and (observation is not None or use_train_data):
+        raise ValueError(
+            "Specifying 'X_new_sample' and ('observation' or 'use_train_data') is ambiguous."
+        )
     """
     Error Checking Ends here
 
     """
-
-    # Storing X_train and y_train in data_X and data_y parameter
-    test_X = X_train if use_train_data else X_test
+    if X_new_sample is not None:
+        test_X = prep_pipe.transform(X_new_sample)
+    else:
+        # Storing X_train and y_train in data_X and data_y parameter
+        test_X = X_train if use_train_data else X_test
 
     np.random.seed(seed)
 

--- a/pycaret/regression.py
+++ b/pycaret/regression.py
@@ -1578,6 +1578,7 @@ def interpret_model(
     feature: Optional[str] = None,
     observation: Optional[int] = None,
     use_train_data: bool = False,
+    X_new_sample: Optional[pd.DataFrame] = None,
     save: bool = False,
     **kwargs,
 ):
@@ -1622,6 +1623,12 @@ def interpret_model(
         of test data.
 
 
+    X_new_sample: pd.DataFrame, default = None
+        Row from an out-of-sample dataframe (neither train nor test data) to be plotted.
+        The sample must have the same columns as the raw input data, and it is transformed
+        by the preprocessing pipeline automatically before plotting.
+
+
     save: bool, default = False
         When set to True, Plot is saved as a 'png' file in current working directory.
 
@@ -1641,6 +1648,7 @@ def interpret_model(
         feature=feature,
         observation=observation,
         use_train_data=use_train_data,
+        X_new_sample=X_new_sample,
         save=save,
         **kwargs,
     )

--- a/pycaret/tests/test_classification_plots.py
+++ b/pycaret/tests/test_classification_plots.py
@@ -61,6 +61,7 @@ def test():
     for model in models:
         for plot in available_shap:
             pycaret.classification.interpret_model(model, plot=plot)
+            pycaret.classification.interpret_model(model, plot=plot, X_new_sample=data.iloc[:10])
 
     assert 1 == 1
 

--- a/pycaret/tests/test_regression_plots.py
+++ b/pycaret/tests/test_regression_plots.py
@@ -54,6 +54,7 @@ def test():
     for model in models:
         for plot in available_shap:
             pycaret.regression.interpret_model(model, plot=plot)
+            pycaret.regression.interpret_model(model, plot=plot, X_new_sample=data.iloc[:10])
 
     assert 1 == 1
 


### PR DESCRIPTION
## Allows new data to be passed to `interpret_model`
  - Previously, `pycaret.internal.tabular.interpret_model` only worked for observations within the training/test data.
  - This PR adds an option `X_new_sample: Optional[pd.DataFrame] = None` which allows the user to use other data that is in the exact same format as the original dataset. 


Fixes: #254 

#### Describe the changes you've made
In order to use outside data, the new data is simply transformed by the `prep_pipe` from global scope via `test_X = prep_pipe.transform(X_new_sample)`.


## Type of change

- [x ] New feature (non-breaking change which adds functionality)
- [x ] This change requires a documentation update

## How Has This Been Tested?

Tests plots are generated in `pycaret/tests/test_classification_plots.py` and `pycaret/tests/test_regression_plots.py` which use the first ten rows of the dataset. The plots are generated without error. 

