### PR TITLE
Fix Typo from RVF to RBF

### DIFF
--- a/pycaret/regression.py
+++ b/pycaret/regression.py
@@ -257,7 +257,7 @@ def setup(
     pca_method: str, default = 'linear'
         The 'linear' method performs uses Singular Value  Decomposition. Other options are:
         
-        - kernel: dimensionality reduction through the use of RVF kernel.
+        - kernel: dimensionality reduction through the use of RBF kernel.
         - incremental: replacement for 'linear' pca when the dataset is too large.
 
 


### PR DESCRIPTION
I believe there is a typo at "RVF" Kernel. I changed it to RBF to make it clear :)

## Related Issuse or bug
  - Info about Issue or bug

Fixes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!






## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
 
 
 
 
 
 
 
 
 










