### PR TITLE
Fix remove_multicollinearity considering cat feats

### DIFF
--- a/pycaret/anomaly.py
+++ b/pycaret/anomaly.py
@@ -258,8 +258,8 @@ def setup(
     remove_multicollinearity: bool, default = False
         When set to True, features with the inter-correlations higher than the defined 
         threshold are removed. When two features are highly correlated with each other, 
-        the feature that is less correlated with the target variable is removed. 
-
+        the feature that is less correlated with the target variable is removed. Only
+        considers numeric features.
 
     multicollinearity_threshold: float, default = 0.9
         Threshold for correlated features. Ignored when ``remove_multicollinearity``

--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -308,8 +308,8 @@ def setup(
     remove_multicollinearity: bool, default = False
         When set to True, features with the inter-correlations higher than the defined 
         threshold are removed. When two features are highly correlated with each other, 
-        the feature that is less correlated with the target variable is removed. 
-
+        the feature that is less correlated with the target variable is removed. Only
+        considers numeric features.
 
     multicollinearity_threshold: float, default = 0.9
         Threshold for correlated features. Ignored when ``remove_multicollinearity``

--- a/pycaret/clustering.py
+++ b/pycaret/clustering.py
@@ -259,8 +259,8 @@ def setup(
     remove_multicollinearity: bool, default = False
         When set to True, features with the inter-correlations higher than the defined 
         threshold are removed. When two features are highly correlated with each other, 
-        the feature that is less correlated with the target variable is removed. 
-
+        the feature that is less correlated with the target variable is removed. Only
+        considers numeric features.
 
     multicollinearity_threshold: float, default = 0.9
         Threshold for correlated features. Ignored when ``remove_multicollinearity``

--- a/pycaret/internal/preprocess.py
+++ b/pycaret/internal/preprocess.py
@@ -2500,7 +2500,7 @@ class Fix_multicollinearity(BaseEstimator, TransformerMixin):
     """
 
         # global data1
-        data1 = data
+        data1 = data.select_dtypes(include=["int64", "float64", "float32"])
         # try:
         #   self.data1 = self.data1.astype('float16')
         # except:

--- a/pycaret/regression.py
+++ b/pycaret/regression.py
@@ -306,7 +306,8 @@ def setup(
     remove_multicollinearity: bool, default = False
         When set to True, features with the inter-correlations higher than the defined 
         threshold are removed. When two features are highly correlated with each other, 
-        the feature that is less correlated with the target variable is removed. 
+        the feature that is less correlated with the target variable is removed. Only
+        considers numeric features.
 
 
     multicollinearity_threshold: float, default = 0.9


### PR DESCRIPTION
## Related Issuse or bug
`remove_multicollinearity` was considering all columns instead of just numerical ones, leading to exceptions in certain cases.

#### Describe the changes you've made
`remove_multicollinearity` now only considers numerical columns. Docstrings have been updated.

## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
 
 
 
 
 
 
 
 
 










