### PR TITLE
fixed shap summary plot bug for binary classification models

### DIFF
--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -7477,12 +7477,10 @@ def interpret_model(
         logger.info("Compiling shap values")
         shap_values = explainer.shap_values(test_X)
 
-        if len(shap_values) == 2:
-            try:
-                shap_plot = shap.summary_plot(shap_values[1], test_X, show=show, **kwargs)
-            except:
-                shap_plot = shap.summary_plot(shap_values, test_X, show=show, **kwargs)
-        else:
+        try:
+            assert len(shap_values) == 2
+            shap_plot = shap.summary_plot(shap_values[1], test_X, show=show, **kwargs)
+        except Exception:
             shap_plot = shap.summary_plot(shap_values, test_X, show=show, **kwargs)
         
         if save:

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -7476,7 +7476,15 @@ def interpret_model(
         explainer = shap.TreeExplainer(model)
         logger.info("Compiling shap values")
         shap_values = explainer.shap_values(test_X)
-        shap_plot = shap.summary_plot(shap_values, test_X, show=show, **kwargs)
+
+        if len(shap_values) == 2:
+            try:
+                shap_plot = shap.summary_plot(shap_values[1], test_X, show=show, **kwargs)
+            except:
+                shap_plot = shap.summary_plot(shap_values, test_X, show=show, **kwargs)
+        else:
+            shap_plot = shap.summary_plot(shap_values, test_X, show=show, **kwargs)
+        
         if save:
             plt.savefig(f"SHAP {plot}.png", bbox_inches="tight")
         return shap_plot


### PR DESCRIPTION
## Related Issuse or bug
  - #1312 

Fixes: #[issue number that will be closed through this PR] #1312

#### Describe the changes you've made
A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!

Currently, when the target variable is binary the 'summary' plot from the interpret_model shows a bar as opposed to beeswarm.

![image](https://user-images.githubusercontent.com/58118658/120096037-401c8c80-c0f7-11eb-8a65-8f1b7e87b164.png)

![image](https://user-images.githubusercontent.com/58118658/120096041-43b01380-c0f7-11eb-85b4-04434c451a80.png)

## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
 
 
 
 
 
 
 
 
 










