### PR TITLE
fix for non default optimize metric

### DIFF
--- a/pycaret/tests/test_time_series.py
+++ b/pycaret/tests/test_time_series.py
@@ -470,6 +470,23 @@ def test_tune_model_custom_folds(load_data):
     assert len(metrics2) == custom_fold + 2  # + 2 for Mean and SD
 
 
+def test_tune_model_alternate_metric(load_data):
+    """tests model selection using non default metric"""
+    exp = TimeSeriesExperiment()
+    fh = 12
+    fold = 2
+
+    exp.setup(data=load_data, fold=fold, fh=fh, fold_strategy="sliding")
+
+    model_obj = exp.create_model("naive")
+    tuned_model_obj = exp.tune_model(model_obj, optimize="MAE")
+    y_pred = exp.predict_model(tuned_model_obj)
+    assert isinstance(y_pred, pd.Series)
+
+    expected_period_index = load_data.iloc[-fh:].index
+    assert np.all(y_pred.index == expected_period_index)
+
+
 def test_tune_model_raises(load_data):
     """Tests conditions that raise an error due to lack of data"""
 


### PR DESCRIPTION
## Related Issuse or bug
Time Series tune_model does not work with non-default `optimize` argument

```python
tune_model(model, optimize = 'MAE')
```  

```bash
~\pycaret-timeseries\pycaret\pycaret\time_series.py in fit(self, y, X, **fit_params)
   2199             raise ValueError(
   2200                 f"Refit Metric: '{refit_metric}' is not available. ",
-> 2201                 f"Available Values are: {list(scorers.keys())}",
   2202             )
   2203 
ValueError: ("Refit Metric: 'smape' is not available. ", "Available Values are: ['MAE']")
```

#### Describe the changes you've made
Fixed the above mentioned issue. Refit metric was not being passed to the Grid Search instantiation earlier.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit test has been added

## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

