### PR TITLE
Update clustering.py

### DIFF
--- a/pycaret/clustering.py
+++ b/pycaret/clustering.py
@@ -258,9 +258,7 @@ def setup(
 
     remove_multicollinearity: bool, default = False
         When set to True, features with the inter-correlations higher than the defined 
-        threshold are removed. When two features are highly correlated with each other, 
-        the feature that is less correlated with the target variable is removed. Only
-        considers numeric features.
+        threshold are removed. Only considers numeric features.
 
     multicollinearity_threshold: float, default = 0.9
         Threshold for correlated features. Ignored when ``remove_multicollinearity``


### PR DESCRIPTION
Since clustering is an unsupervised machine learning module, in case of multicollinearity, the feature having less correlation with the target cannot be removed since there is no target variable.

## Related Issuse or bug
  - Info about Issue or bug

Fixes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
Since clustering is an unsupervised machine learning module, in case of multicollinearity, the feature having less correlation with the target cannot be removed since there is no target variable.

## Type of change

Fixing documentation.

 
 
 
 
 
 
 
 
 










