### PR TITLE
fix for compare_model folds

### DIFF
--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -596,7 +596,9 @@ class _SupervisedExperiment(_TabularExperiment):
 
         """
 
-        fold = self._get_cv_splitter(fold)
+        if self._ml_usecase != MLUsecase.TIME_SERIES:
+            fold = self._get_cv_splitter(fold)
+        # else keep fold as integer
 
         groups = self._get_groups(groups)
 

--- a/pycaret/internal/pycaret_experiment/time_series_experiment.py
+++ b/pycaret/internal/pycaret_experiment/time_series_experiment.py
@@ -11,11 +11,7 @@ from pycaret.internal.pipeline import (
     estimator_pipeline,
     get_pipeline_fit_kwargs,
 )
-from pycaret.internal.utils import (
-    color_df,
-    SeasonalPeriod,
-    TSModelTypes
-)
+from pycaret.internal.utils import color_df, SeasonalPeriod, TSModelTypes
 import pycaret.internal.patches.sklearn
 import pycaret.internal.patches.yellowbrick
 from pycaret.internal.logging import get_logger
@@ -2648,15 +2644,18 @@ class TimeSeriesExperiment(_SupervisedExperiment):
         return super().get_logs(experiment_name=experiment_name, save=save)
 
     def get_fold_generator(
-        self, fold: Optional[int] = None, fold_strategy: Optional[str] = None
+        self,
+        fold: Optional[Union[int, Any]] = None,
+        fold_strategy: Optional[str] = None,
     ) -> Union[ExpandingWindowSplitter, SlidingWindowSplitter]:
         """Returns the cv object based on number of folds and fold_strategy
 
         Parameters
         ----------
-        fold : Optional[int]
-            The number of folds, by default None which returns the fold generator
-            (cv object) defined during setup
+        fold : Optional[Union[int, Any]]
+            The number of folds (int), by default None which returns the fold generator
+            (cv object) defined during setup. Could also be a sktime cross-validation object.
+            If it is a sktime cross-validation object, it is simply returned back
         fold_strategy : Optional[str], optional
             The fold strategy - 'expanding' or 'sliding', by default None which
             takes the strategy set during `setup`
@@ -2679,6 +2678,8 @@ class TimeSeriesExperiment(_SupervisedExperiment):
                     "Trying to retrieve Fold Generator but this has not been defined yet."
                 )
             fold_generator = self.fold_generator
+        elif not isinstance(fold, int):
+            return fold  # assumes fold is an sktime compatible cross-validation object
         else:
             # Get new cv object based on the fold parameter
             y_size = len(self.y_train)

--- a/pycaret/tests/test_time_series.py
+++ b/pycaret/tests/test_time_series.py
@@ -336,6 +336,27 @@ def test_prediction_interval_na(load_data):
     assert y_pred["upper"].isnull().all()
 
 
+def test_compare_models(load_data):
+    """tests compare_models functionality"""
+    exp = TimeSeriesExperiment()
+
+    fh = 12
+    fold = 2
+    data = load_data
+
+    exp.setup(
+        data=data,
+        fh=fh,
+        fold=fold,
+        fold_strategy="expanding",
+        verbose=False,
+        session_id=42,
+    )
+
+    best_baseline_models = exp.compare_models(n_select=3)
+    assert len(best_baseline_models) == 3
+
+
 @pytest.mark.filterwarnings(
     "ignore::statsmodels.tools.sm_exceptions.ConvergenceWarning:statsmodels"
 )

--- a/pycaret/time_series.py
+++ b/pycaret/time_series.py
@@ -742,7 +742,7 @@ def blend_models(
     fold: Optional[Union[int, Any]] = None,
     round: int = 4,
     choose_better: bool = False,
-    optimize: str = "MAPE_ts",
+    optimize: str = "SMAPE",
     weights: Optional[List[float]] = None,
     fit_kwargs: Optional[dict] = None,
     verbose: bool = True,


### PR DESCRIPTION
1. After adding `get_fold_generator` functionality for time series, `compare_models` is breaking (not returning any models). This was not caught in CI since the test for compare_models was missing.
2. Also fixed functional API for `blend_models` which was failing earlier due to incorrect default metric.

#### Describe the changes you've made
Fixed the issue mentioned above and added unit test for `compare_models`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit test has been added

## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

