### PR TITLE
Add support for CUDA version of LightGBM

### DIFF
--- a/pycaret/containers/models/classification.py
+++ b/pycaret/containers/models/classification.py
@@ -1318,13 +1318,13 @@ class LGBMClassifierContainer(ClassifierContainer):
             try:
                 lgb = LGBMClassifier(device="gpu")
                 lgb.fit(np.zeros((2, 2)), [0, 1])
-                is_gpu_enabled = True
+                is_gpu_enabled = "gpu"
                 del lgb
             except:
                 try:
                     lgb = LGBMClassifier(device="cuda")
                     lgb.fit(np.zeros((2, 2)), [0, 1])
-                    is_gpu_enabled = True
+                    is_gpu_enabled = "cuda"
                     del lgb
                 except LightGBMError:
                     is_gpu_enabled = False
@@ -1333,9 +1333,11 @@ class LGBMClassifierContainer(ClassifierContainer):
                             f"LightGBM GPU mode not available. Consult https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html."
                         )
 
-        if is_gpu_enabled:
+        if is_gpu_enabled=="gpu":
             args["device"] = "gpu"
-
+        elif is_gpu_enabled=="cuda":
+            args["device"] = "cuda"
+        
         super().__init__(
             id="lightgbm",
             name="Light Gradient Boosting Machine",

--- a/pycaret/containers/models/classification.py
+++ b/pycaret/containers/models/classification.py
@@ -1320,12 +1320,18 @@ class LGBMClassifierContainer(ClassifierContainer):
                 lgb.fit(np.zeros((2, 2)), [0, 1])
                 is_gpu_enabled = True
                 del lgb
-            except LightGBMError:
-                is_gpu_enabled = False
-                if globals_dict["gpu_param"] == "force":
-                    raise RuntimeError(
-                        f"LightGBM GPU mode not available. Consult https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html."
-                    )
+            except:
+                try:
+                    lgb = LGBMClassifier(device="cuda")
+                    lgb.fit(np.zeros((2, 2)), [0, 1])
+                    is_gpu_enabled = True
+                    del lgb
+                except LightGBMError:
+                    is_gpu_enabled = False
+                    if globals_dict["gpu_param"] == "force":
+                        raise RuntimeError(
+                            f"LightGBM GPU mode not available. Consult https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html."
+                        )
 
         if is_gpu_enabled:
             args["device"] = "gpu"

--- a/pycaret/containers/models/classification.py
+++ b/pycaret/containers/models/classification.py
@@ -1090,10 +1090,9 @@ class XGBClassifierContainer(ClassifierContainer):
             self.active = False
             return
 
-        xgboost_version = tuple([int(x) for x in xgboost.__version__.split(".")])
-        if xgboost_version < (1, 1, 0):
+        if version.parse(xgboost.__version__) < version.parse("1.1.0"):
             logger.warning(
-                f"Wrong xgboost version. Expected xgboost>=1.1.0, got xgboost=={xgboost_version}"
+                f"Wrong xgboost version. Expected xgboost>=1.1.0, got xgboost=={xgboost.__version__}"
             )
             self.active = False
             return
@@ -1370,10 +1369,9 @@ class CatBoostClassifierContainer(ClassifierContainer):
             self.active = False
             return
 
-        catboost_version = tuple([int(x) for x in catboost.__version__.split(".")])
-        if catboost_version < (0, 23, 2):
+        if version.parse(catboost.__version__) < version.parse("0.23.2"):
             logger.warning(
-                f"Wrong catboost version. Expected catboost>=0.23.2, got catboost=={catboost_version}"
+                f"Wrong catboost version. Expected catboost>=0.23.2, got catboost=={catboost.__version__}"
             )
             self.active = False
             return

--- a/pycaret/containers/models/classification.py
+++ b/pycaret/containers/models/classification.py
@@ -25,18 +25,7 @@ from pycaret.internal.utils import (
 from pycaret.internal.distributions import *
 import pycaret.containers.base_container
 import numpy as np
-
-def CompareVersion(version1: str, version2: str) -> int:\
-    """
-    Compare between two versions. 
-    If version1 > version2, return 1;
-    if version1 == version2, return 0;
-    if version1 < version2, return -1.
-    """
-    v1, v2 = ([*map(int, v.split('.'))] for v in (version1, version2))
-    d = len(v2) - len(v1)
-    v1, v2 = v1 + [0] * d, v2 + [0] * -d
-    return (v1 > v2) - (v1 < v2)
+from packaging import version
 
 class ClassifierContainer(ModelContainer):
     """
@@ -767,7 +756,7 @@ class RandomForestClassifierContainer(ClassifierContainer):
             }
         else:
             import cuml
-            if CompareVersion("0.19",cuml.__version__) >= 0:
+            if version.parse(cuml.__version__) >= version.parse("0.19"):
                 args = {
                 "random_state": globals_dict["seed"],
                 }

--- a/pycaret/containers/models/regression.py
+++ b/pycaret/containers/models/regression.py
@@ -23,18 +23,7 @@ from pycaret.internal.utils import (
 from pycaret.internal.distributions import *
 import pycaret.containers.base_container
 import numpy as np
-
-def CompareVersion(version1: str, version2: str) -> int:\
-    """
-    Compare between two versions. 
-    If version1 > version2, return 1;
-    if version1 == version2, return 0;
-    if version1 < version2, return -1.
-    """
-    v1, v2 = ([*map(int, v.split('.'))] for v in (version1, version2))
-    d = len(v2) - len(v1)
-    v1, v2 = v1 + [0] * d, v2 + [0] * -d
-    return (v1 > v2) - (v1 < v2)
+from packaging import version
 
 class RegressorContainer(ModelContainer):
     """
@@ -1139,7 +1128,7 @@ class RandomForestRegressorContainer(RegressorContainer):
             }
         else:
             import cuml
-            if CompareVersion("0.19",cuml.__version__) >= 0:
+            if version.parse(cuml.__version__) >= version.parse("0.19"):
                 args = {
                 "random_state": globals_dict["seed"],
                 }

--- a/pycaret/containers/models/regression.py
+++ b/pycaret/containers/models/regression.py
@@ -1445,10 +1445,9 @@ class XGBRegressorContainer(RegressorContainer):
             self.active = False
             return
 
-        xgboost_version = tuple([int(x) for x in xgboost.__version__.split(".")])
-        if xgboost_version < (1, 1, 0):
+        if version.parse(xgboost.__version__) < version.parse("1.1.0"):
             logger.warning(
-                f"Wrong xgboost version. Expected xgboost>=1.1.0, got xgboost=={xgboost_version}"
+                f"Wrong xgboost version. Expected xgboost>=1.1.0, got xgboost=={xgboost.__version__}"
             )
             self.active = False
             return
@@ -1725,10 +1724,9 @@ class CatBoostRegressorContainer(RegressorContainer):
             self.active = False
             return
 
-        catboost_version = tuple([int(x) for x in catboost.__version__.split(".")])
-        if catboost_version < (0, 23, 2):
+        if version.parse(catboost.__version__) < version.parse("0.23.2"):
             logger.warning(
-                f"Wrong catboost version. Expected catboost>=0.23.2, got catboost=={catboost_version}"
+                f"Wrong catboost version. Expected catboost>=0.23.2, got catboost=={catboost.__version__}"
             )
             self.active = False
             return

--- a/pycaret/containers/models/regression.py
+++ b/pycaret/containers/models/regression.py
@@ -1673,13 +1673,13 @@ class LGBMRegressorContainer(RegressorContainer):
             try:
                 lgb = LGBMRegressor(device="gpu")
                 lgb.fit(np.zeros((2, 2)), [0, 1])
-                is_gpu_enabled = True
+                is_gpu_enabled = "gpu"
                 del lgb
             except:
                 try:
                     lgb = LGBMRegressor(device="cuda")
                     lgb.fit(np.zeros((2, 2)), [0, 1])
-                    is_gpu_enabled = True
+                    is_gpu_enabled = "cuda"
                     del lgb
                 except LightGBMError:
                     is_gpu_enabled = False
@@ -1688,8 +1688,10 @@ class LGBMRegressorContainer(RegressorContainer):
                             f"LightGBM GPU mode not available. Consult https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html."
                         )
 
-        if is_gpu_enabled:
+        if is_gpu_enabled=="gpu":
             args["device"] = "gpu"
+        elif is_gpu_enabled=="cuda":
+            args["device"] = "cuda"
 
         super().__init__(
             id="lightgbm",

--- a/pycaret/containers/models/regression.py
+++ b/pycaret/containers/models/regression.py
@@ -24,6 +24,17 @@ from pycaret.internal.distributions import *
 import pycaret.containers.base_container
 import numpy as np
 
+def CompareVersion(version1: str, version2: str) -> int:\
+    """
+    Compare between two versions. 
+    If version1 > version2, return 1;
+    if version1 == version2, return 0;
+    if version1 < version2, return -1.
+    """
+    v1, v2 = ([*map(int, v.split('.'))] for v in (version1, version2))
+    d = len(v2) - len(v1)
+    v1, v2 = v1 + [0] * d, v2 + [0] * -d
+    return (v1 > v2) - (v1 < v2)
 
 class RegressorContainer(ModelContainer):
     """
@@ -1121,14 +1132,22 @@ class RandomForestRegressorContainer(RegressorContainer):
                 pycaret.internal.cuml_wrappers.get_random_forest_regressor()
             )
 
-        args = (
-            {
+        if not gpu_imported:
+            args = {
                 "random_state": globals_dict["seed"],
                 "n_jobs": globals_dict["n_jobs_param"],
             }
-            if not gpu_imported
-            else {"seed": globals_dict["seed"]}
-        )
+        else:
+            import cuml
+            if CompareVersion("0.19",cuml.__version__) >= 0:
+                args = {
+                "random_state": globals_dict["seed"],
+                }
+            else:
+                args = {
+                    "seed": globals_dict["seed"]
+                }
+                
         tune_args = {}
         tune_grid = {
             "n_estimators": np_list_arange(10, 300, 10, inclusive=True),

--- a/pycaret/containers/models/regression.py
+++ b/pycaret/containers/models/regression.py
@@ -1675,12 +1675,18 @@ class LGBMRegressorContainer(RegressorContainer):
                 lgb.fit(np.zeros((2, 2)), [0, 1])
                 is_gpu_enabled = True
                 del lgb
-            except LightGBMError:
-                is_gpu_enabled = False
-                if globals_dict["gpu_param"] == "force":
-                    raise RuntimeError(
-                        f"LightGBM GPU mode not available. Consult https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html."
-                    )
+            except:
+                try:
+                    lgb = LGBMRegressor(device="cuda")
+                    lgb.fit(np.zeros((2, 2)), [0, 1])
+                    is_gpu_enabled = True
+                    del lgb
+                except LightGBMError:
+                    is_gpu_enabled = False
+                    if globals_dict["gpu_param"] == "force":
+                        raise RuntimeError(
+                            f"LightGBM GPU mode not available. Consult https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html."
+                        )
 
         if is_gpu_enabled:
             args["device"] = "gpu"

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -68,6 +68,7 @@ from unittest.mock import patch
 import plotly.express as px
 import plotly.graph_objects as go
 import scikitplot as skplt
+from packaging import version
 
 warnings.filterwarnings("ignore")
 
@@ -1011,16 +1012,13 @@ def setup(
     if use_gpu:
         try:
             from cuml import __version__
-
+ 
             cuml_version = __version__
             logger.info(f"cuml=={cuml_version}")
-
-            cuml_version = cuml_version.split(".")
-            cuml_version = (int(cuml_version[0]), int(cuml_version[1]))
         except:
             logger.warning(f"cuML not found")
 
-        if cuml_version is None or not cuml_version >= (0, 15):
+        if cuml_version is None or not version.parse(cuml_version) >= version.parse("0.15"):
             message = f"cuML is outdated or not found. Required version is >=0.15, got {__version__}"
             if use_gpu == "force":
                 raise ImportError(message)


### PR DESCRIPTION
## Related Issuse or bug
This PR adds support for CUDA version of LightGBM.


#### Describe the changes you've made
At present, PyCaret only supports OpenCL version of LightGBM( as introduced in `PyCaret on GPU` of `README.md`.
Actually, LightGBM also supports a (experimental) CUDA version(https://github.com/microsoft/LightGBM/tree/master/python-package). To use CUDA version, we only need to set `device="cuda"` in `LGBMRegressor` / `LGBMClassifier`.
I made some changes in `containers/models/classification.py`/`containers/models/regression.py` to make LightGBM works properly with `gpu_param=True` or  `gpu_param="force"` , when CUDA version( instead of OpenCL version) of LightGBM is installed.
PS: 
- To build CUDA version: `pip install lightgbm --install-option=--cuda`
- I don't know if information related to LightGBM on GPU should be changed in README/User guide etc. So I only changed the code.






## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
 
 
 
 
 
 
 
 
 










