### PR TITLE
Corrected RMSE container

### DIFF
--- a/pycaret/containers/metrics/regression.py
+++ b/pycaret/containers/metrics/regression.py
@@ -178,11 +178,22 @@ class MSEMetricContainer(RegressionMetricContainer):
 
 class RMSEMetricContainer(RegressionMetricContainer):
     def __init__(self, globals_dict: dict) -> None:
+        def root_mean_squared_error(
+            y_true, y_pred, *, sample_weight=None, multioutput="uniform_average"
+        ):
+            return np.sqrt(
+                metrics.mean_squared_error(
+                    np.abs(y_true),
+                    np.abs(y_pred),
+                    sample_weight=sample_weight,
+                    multioutput=multioutput,
+                )
+            )
 
         super().__init__(
             id="rmse",
             name="RMSE",
-            score_func=metrics.mean_squared_error,
+            score_func=root_mean_squared_error,
             greater_is_better=False,
             args={"squared": False},
             scorer="neg_root_mean_squared_error",

--- a/pycaret/containers/metrics/regression.py
+++ b/pycaret/containers/metrics/regression.py
@@ -181,13 +181,12 @@ class RMSEMetricContainer(RegressionMetricContainer):
         def root_mean_squared_error(
             y_true, y_pred, *, sample_weight=None, multioutput="uniform_average"
         ):
-            return np.sqrt(
-                metrics.mean_squared_error(
-                    np.abs(y_true),
-                    np.abs(y_pred),
-                    sample_weight=sample_weight,
-                    multioutput=multioutput,
-                )
+            return metrics.mean_squared_error(
+                np.abs(y_true),
+                np.abs(y_pred),
+                sample_weight=sample_weight,
+                multioutput=multioutput,
+                squared=False
             )
 
         super().__init__(


### PR DESCRIPTION
Initially, using `pycaret.utils.check_metric()` with RMSE gave same result as using it with MSE. Updated the RMSE container to now calculate the square root of MSE & return as the RMSE.

## Related Issuse or bug
  - Using the `check_metric()` function with `'RMSE'` yielded same result as that with `'MSE`'. In the `pycaret/containers/metrics/regression.py` file, the `score_func` for RMSE Container was incorrect (square root wasn't applied). 

Fixes: #953

#### Describe the changes you've made
Created a function `root_mean_squared_error()` in the RMSE Container class, which calculated the RMSE value. Set this function as the `score_func` for the container.



## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 <a href="https://imgbb.com/"><img src="https://i.ibb.co/BCZjbLB/Screenshot-2021-07-08-155548.png" alt="Screenshot-2021-07-08-155548" border="0" /></a>| <a href="https://ibb.co/2nFmh1x"><img src="https://i.ibb.co/RvgZbkf/image.png" alt="image" border="0"></a> |
 
 
 
 
 
 
 
 
 










