### PR TITLE
initial changes until splitters

### DIFF
--- a/pycaret/containers/metrics/time_series.py
+++ b/pycaret/containers/metrics/time_series.py
@@ -15,9 +15,8 @@ import pycaret.internal.metrics
 from pandas import DataFrame, Series  # type: ignore
 from sklearn import metrics  # type: ignore
 from sktime.performance_metrics.forecasting._functions import (  # type: ignore
-    mase_loss,
-    smape_loss,
-    mape_loss,
+    mean_absolute_scaled_error,
+    mean_absolute_percentage_error,
 )
 
 
@@ -152,21 +151,25 @@ class TimeSeriesMetricContainer(MetricContainer):
 
 def _smape_loss(y_true, y_pred):
     """Wrapper for sktime metrics"""
-    return smape_loss(y_test=_check_series(y_true), y_pred=_check_series(y_pred))
+    return mean_absolute_percentage_error(
+        y_true=_check_series(y_true), y_pred=_check_series(y_pred), symmetric=True
+    )
 
 
 def _mape_loss(y_true, y_pred):
     """Wrapper for sktime metrics"""
-    return mape_loss(y_test=_check_series(y_true), y_pred=_check_series(y_pred))
-
-
-def _mase_loss(y_true, y_pred, y_train):
-    """Wrapper for sktime metrics"""
-    return mase_loss(
-        y_test=_check_series(y_true),
-        y_pred=_check_series(y_pred),
-        y_train=_check_series(y_train),
+    return mean_absolute_percentage_error(
+        y_true=_check_series(y_true), y_pred=_check_series(y_pred), symmetric=False
     )
+
+
+# def _mase_loss(y_true, y_pred, y_train):
+#     """Wrapper for sktime metrics"""
+#     return mase_loss(
+#         y_test=_check_series(y_true),
+#         y_pred=_check_series(y_pred),
+#         y_train=_check_series(y_train),
+#     )
 
 
 def _check_series(y):
@@ -224,21 +227,16 @@ class RMSEMetricContainer(TimeSeriesMetricContainer):
 class MAPEMetricContainer(TimeSeriesMetricContainer):
     def __init__(self, globals_dict: dict) -> None:
         super().__init__(
-            id="mape",
-            name="MAPE",
-            score_func=_mape_loss,
-            greater_is_better=False,
+            id="mape", name="MAPE", score_func=_mape_loss, greater_is_better=False,
         )
 
 
 class SMAPEMetricContainer(TimeSeriesMetricContainer):
     def __init__(self, globals_dict: dict) -> None:
         super().__init__(
-            id="smape",
-            name="SMAPE",
-            score_func=_smape_loss,
-            greater_is_better=False,
+            id="smape", name="SMAPE", score_func=_smape_loss, greater_is_better=False,
         )
+
 
 class R2MetricContainer(TimeSeriesMetricContainer):
     def __init__(self, globals_dict: dict) -> None:

--- a/pycaret/containers/models/time_series.py
+++ b/pycaret/containers/models/time_series.py
@@ -15,7 +15,7 @@ import numpy as np  # type: ignore
 import pandas as pd
 import logging
 
-from sktime.forecasting.base._sktime import _SktimeForecaster  # type: ignore
+from sktime.forecasting.base import BaseForecaster  # type: ignore
 from sktime.forecasting.compose import ReducedForecaster, TransformedTargetForecaster  # type: ignore
 from sktime.forecasting.trend import PolynomialTrendForecaster  # type: ignore
 from sktime.transformations.series.detrend import ConditionalDeseasonalizer, Detrender  # type: ignore
@@ -326,6 +326,7 @@ class SeasonalNaiveContainer(TimeSeriesContainer):
 
 class PolyTrendContainer(TimeSeriesContainer):
     model_type = TSModelTypes.BASELINE
+
     def __init__(self, globals_dict: dict) -> None:
         logger = get_logger()
         np.random.seed(globals_dict["seed"])
@@ -1067,6 +1068,7 @@ class CdsDtContainer(TimeSeriesContainer):
     """Abstract container for sktime  reduced regression forecaster with
     conditional deseasonalizing and detrending.
     """
+
     active = False
     model_type = None
 
@@ -1644,7 +1646,7 @@ class OrthogonalMatchingPursuitCdsDtContainer(CdsDtContainer):
     id = "omp_cds_dt"
     name = "Orthogonal Matching Pursuit w/ Cond. Deseasonalize & Detrending"
     active = True  # set back to True as the parent has False
-    model_type = TSModelTypes.LINEAR 
+    model_type = TSModelTypes.LINEAR
 
     def __init__(self, globals_dict: dict) -> None:
         self.num_features = len(globals_dict["X_train"].columns)
@@ -2268,7 +2270,7 @@ class CatBoostCdsDtContainer(CdsDtContainer):
 # ===================================#
 
 
-class BaseCdsDt(_SktimeForecaster):
+class BaseCdsDt(BaseForecaster):
     model_type = None
 
     def __init__(
@@ -2367,7 +2369,7 @@ except ImportError:
 
 
 class EnsembleTimeSeriesContainer(TimeSeriesContainer):
-    model_type='ensemble'
+    model_type = "ensemble"
 
     def __init__(self, globals_dict: dict) -> None:
         logger = get_logger()

--- a/requirements-ts.txt
+++ b/requirements-ts.txt
@@ -1,3 +1,3 @@
-sktime==0.5.3
-tbats==1.1.0
+sktime>=0.7.0
+tbats>=1.1.0
 pmdarima>=1.8.0


### PR DESCRIPTION
#### Describe the changes you've made
- Initial changes fir upgrade to sktime 0.7.0. 
- Fixed updated for metrics and BaseForecaster
- Now errors out at the Splitters

```python
Traceback (most recent call last):
  File "c:/Users/Nikhil/OneDrive/my_libraries/my_python_libraries/pycaret_dev/time_series_debug.py", line 41, in <module>
    exp.setup(data=y, fh=fh, fold=fold, fold_strategy="expanding", session_id=42, n_jobs=-1)
  File "c:\Users\Nikhil\OneDrive\my_libraries\my_python_libraries\pycaret_dev\pycaret\internal\pycaret_experiment\time_series_experiment.py", line 1062, in setup
    profile_kwargs=profile_kwargs,
  File "c:\Users\Nikhil\OneDrive\my_libraries\my_python_libraries\pycaret_dev\pycaret\internal\pycaret_experiment\tabular_experiment.py", line 1570, in setup
    self.fold_generator = self.get_fold_generator(fold=self.fold_param)
  File "c:\Users\Nikhil\OneDrive\my_libraries\my_python_libraries\pycaret_dev\pycaret\internal\pycaret_experiment\time_series_experiment.py", line 3245, in get_fold_generator
    start_with_window=True,
TypeError: __init__() got an unexpected keyword argument 'window_length'
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?

Not tested yet since more changes are needed to complete the upgrade to sktime 0.7.0

## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

