### PR TITLE
fix target missing for multicollinearity

### DIFF
--- a/pycaret/internal/preprocess.py
+++ b/pycaret/internal/preprocess.py
@@ -2510,10 +2510,13 @@ class Fix_multicollinearity(BaseEstimator, TransformerMixin):
             data = takes preprocessed data frame
         Returns:
             None
-    """
+        """
+
+        if data[self.target_variable].dtype not in ["int32", "int64"]:
+            raise ValueError('dtype for the target variable should be int32 or int64 only')
 
         # global data1
-        data1 = data.select_dtypes(include=["int64", "float64", "float32"])
+        data1 = data.select_dtypes(include=["int32", "int64", "float32", "float64"])
         # try:
         #   self.data1 = self.data1.astype('float16')
         # except:

--- a/pycaret/tests/test_classification.py
+++ b/pycaret/tests/test_classification.py
@@ -17,6 +17,8 @@ def test():
     clf1 = pycaret.classification.setup(
         data,
         target="Purchase",
+        remove_multicollinearity=True,
+        multicollinearity_threshold=0.95,
         log_experiment=True,
         silent=True,
         html=False,


### PR DESCRIPTION
## Related Issuse or bug
  - Info about Issue or bug

Fixes: #1478, #1482, #1483

#### Describe the changes you've made
Fixed the target missing issue for multicollinearity. Before, int32 was used as the dtype for the target variable after encoding, but int32 was not detected.






## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Reproduced the issue by adding the multicollinearity setting in test_classification.py. The test is passed with the new code. 

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
 
 
 
 
 
 
 
 
 










