### PR TITLE
Use `__getattr__` in pipeline for fit vars

### DIFF
--- a/pycaret/internal/validation.py
+++ b/pycaret/internal/validation.py
@@ -43,10 +43,6 @@ class fit_if_not_fitted(object):
         logger = get_logger()
         self.estimator = deepcopy(estimator)
         if not is_fitted(self.estimator):
-            try:
-                self.estimator._carry_over_final_estimator_fit_vars()
-            except:
-                pass
             if not is_fitted(self.estimator):
                 logger.info(f"fit_if_not_fitted: {estimator} is not fitted, fitting")
                 try:


### PR DESCRIPTION
## Related Issuse or bug
  - Info about Issue or bug

Fixes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
Instead of carrying over fit attributes of the final estimator in a pipeline, we simply use `__getattr__` to redirect the calls there, greatly simplifying and futureproofing the code.

## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
 
 
 
 
 
 
 
 
 










