### PR TITLE
[timeseries] Fix`_fit_and_score` metrics not getting their kwargs

### DIFF
--- a/pycaret/containers/metrics/time_series.py
+++ b/pycaret/containers/metrics/time_series.py
@@ -151,15 +151,19 @@ class TimeSeriesMetricContainer(MetricContainer):
 
 def _smape_loss(y_true, y_pred, **kwargs):
     """Wrapper for sktime metrics"""
+    y_true = _check_series(y_true)
+    y_pred = _check_series(y_pred)
     return mean_absolute_percentage_error(
-        y_true=_check_series(y_true), y_pred=_check_series(y_pred), symmetric=True
+        y_true=y_true, y_pred=y_pred, symmetric=True, **kwargs
     )
 
 
 def _mape_loss(y_true, y_pred, **kwargs):
     """Wrapper for sktime metrics"""
+    y_true = _check_series(y_true)
+    y_pred = _check_series(y_pred)
     return mean_absolute_percentage_error(
-        y_true=_check_series(y_true), y_pred=_check_series(y_pred), symmetric=False
+        y_true=y_true, y_pred=y_pred, symmetric=False, **kwargs
     )
 
 

--- a/pycaret/containers/metrics/time_series.py
+++ b/pycaret/containers/metrics/time_series.py
@@ -149,14 +149,14 @@ class TimeSeriesMetricContainer(MetricContainer):
         return d
 
 
-def _smape_loss(y_true, y_pred):
+def _smape_loss(y_true, y_pred, **kwargs):
     """Wrapper for sktime metrics"""
     return mean_absolute_percentage_error(
         y_true=_check_series(y_true), y_pred=_check_series(y_pred), symmetric=True
     )
 
 
-def _mape_loss(y_true, y_pred):
+def _mape_loss(y_true, y_pred, **kwargs):
     """Wrapper for sktime metrics"""
     return mean_absolute_percentage_error(
         y_true=_check_series(y_true), y_pred=_check_series(y_pred), symmetric=False

--- a/pycaret/internal/pycaret_experiment/time_series_experiment.py
+++ b/pycaret/internal/pycaret_experiment/time_series_experiment.py
@@ -295,7 +295,7 @@ def _fit_and_score(
 
     scoring = _get_metrics_dict_ts(scoring)
     for scorer_name, scorer in scoring.items():
-        metric = scorer._score_func(y_true=y_test, y_pred=y_pred)
+        metric = scorer._score_func(y_true=y_test, y_pred=y_pred, **scorer._kwargs)
         fold_scores[scorer_name] = metric
     score_time = time.time() - start
 
@@ -1351,7 +1351,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
         """
         MONITOR UPDATE ENDS
         """
-        metrics_dict = dict([(k, v.scorer) for k, v in metrics.items()])
+        metrics_dict = {k: v.scorer for k, v in metrics.items()}
 
         self.logger.info("Starting cross validation")
 


### PR DESCRIPTION
## Related Issuse or bug
  - Info about Issue or bug

Fixes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
Fixes the `_fit_and_score` method in time series not passing metric kwargs to function calls, leading to inaccurate metric values.






## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
 
 
 
 
 
 
 
 
 










