### PR TITLE
Fix `compare_models` errors="ignore" not handling 0.0

### DIFF
--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -2195,8 +2195,11 @@ def compare_models(
                         refit=False,
                     )
                     model_results = pull(pop=True)
+                    assert np.sum(model_results.iloc[0]) != 0.0
                 except:
-                    logger.error(f"create_model() for {model} raised an exception:")
+                    logger.error(
+                        f"create_model() for {model} raised an exception or returned all 0.0:"
+                    )
                     logger.error(traceback.format_exc())
                     continue
         logger.info("SubProcess create_model() end ==================================")
@@ -2332,8 +2335,11 @@ def compare_models(
                             groups=groups,
                         )
                         sorted_models.append(model)
+                        assert np.sum(model_results.iloc[0]) != 0.0
                     except Exception:
-                        logger.error(f"create_model() for {model} raised an exception:")
+                        logger.error(
+                            f"create_model() for {model} raised an exception or returned all 0.0:"
+                        )
                         logger.error(traceback.format_exc())
                         model = None
                         continue


### PR DESCRIPTION
## Related Issuse or bug
  - Info about Issue or bug


Fixes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
Fixed `compare_models` not being able to handle a situation where all 0.0s are returned in train-test split. This is a follow up to https://github.com/pycaret/pycaret/pull/1510.


## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
 
 
 
 
 
 
 
 
 










