### PR TITLE
get_leaderboard

### DIFF
--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -2637,7 +2637,7 @@ def get_leaderboard():
 
 
     Returns:
-        Pandas.DataFrame
+        pandas.DataFrame
 
     """
     return pycaret.internal.tabular.get_leaderboard()

--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -2622,3 +2622,22 @@ def load_config(file_name: str):
     """
 
     return pycaret.internal.tabular.load_config(file_name=file_name)
+
+def get_leaderboard():
+    
+    """
+    This function returns the leaderboard of all models trained in the 
+    current setup.
+
+
+    Example
+    -------
+    >>> from pycaret.classification import get_leaderboard
+    >>> leaderboard = get_leaderboard()
+
+
+    Returns:
+        Pandas.DataFrame
+
+    """
+    return pycaret.internal.tabular.get_leaderboard()

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -9871,6 +9871,34 @@ def load_config(file_name: str):
     return r
 
 
+def get_leaderboard():
+    """
+    generates leaderboard for all models run in current run.
+    """
+    model_container = get_config('master_model_container')
+    result_container = get_config('create_model_container')
+    
+    result_container_mean = []
+    
+    mc = 0
+
+    for i in np.arange(0,len(result_container)):
+        c = result_container[i]
+        r = c[-2:-1]
+        model_name = _get_model_name(model_container[mc]) 
+        r['Model Name'] = model_name
+        r['Model'] = model_container[mc]
+        r.set_index('Model Name', drop=True, inplace=True)
+        r = r[['Model', 'Accuracy', 'AUC', 'Recall', 'Prec.', 'F1', 'Kappa', 'MCC']]
+        result_container_mean.append(r)
+        mc += 1
+    
+    results = pd.concat(result_container_mean)
+    
+    results.reset_index(inplace=True)
+    
+    return results
+    
 def _choose_better(
     models_and_results: list,
     compare_dimension: str,

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -9883,14 +9883,14 @@ def get_leaderboard():
     mc = 0
 
     for i in range(len(result_container)):
-        c = result_container[i]
-        r = c[-2:-1]
+        model_results = result_container[i]
+        mean_scores = model_results[-2:-1]
         model_name = _get_model_name(model_container[mc]) 
-        r['Model Name'] = model_name
-        r['Model'] = model_container[mc]
-        r.set_index('Model Name', drop=True, inplace=True)
-        r = r[['Model', 'Accuracy', 'AUC', 'Recall', 'Prec.', 'F1', 'Kappa', 'MCC']]
-        result_container_mean.append(r)
+        mean_scores['Model Name'] = model_name
+        mean_scores['Model'] = model_container[mc]
+        mean_scores.set_index('Model Name', drop=True, inplace=True)
+        mean_scores = mean_scores[['Model', 'Accuracy', 'AUC', 'Recall', 'Prec.', 'F1', 'Kappa', 'MCC']]
+        result_container_mean.append(mean_scores)
         mc += 1
     
     results = pd.concat(result_container_mean)

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -9882,7 +9882,7 @@ def get_leaderboard():
     
     mc = 0
 
-    for i in np.arange(0,len(result_container)):
+    for i in range(len(result_container)):
         c = result_container[i]
         r = c[-2:-1]
         model_name = _get_model_name(model_container[mc]) 

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -9875,30 +9875,32 @@ def get_leaderboard():
     """
     generates leaderboard for all models run in current run.
     """
-    model_container = get_config('master_model_container')
-    result_container = get_config('create_model_container')
-    
+    model_container = get_config("master_model_container")
+    result_container = get_config("create_model_container")
+
     result_container_mean = []
-    
-    mc = 0
 
     for i in range(len(result_container)):
         model_results = result_container[i]
         mean_scores = model_results[-2:-1]
-        model_name = _get_model_name(model_container[mc]) 
-        mean_scores['Model Name'] = model_name
-        mean_scores['Model'] = model_container[mc]
-        mean_scores.set_index('Model Name', drop=True, inplace=True)
-        mean_scores = mean_scores[['Model', 'Accuracy', 'AUC', 'Recall', 'Prec.', 'F1', 'Kappa', 'MCC']]
+        model_name = _get_model_name(model_container[i])
+        mean_scores["Index"] = i
+        mean_scores["Model Name"] = model_name
+        mean_scores["Model"] = str(model_container[i])
+        rearranged_columns = list(mean_scores.columns)
+        rearranged_columns.remove("Model")
+        rearranged_columns.remove("Model Name")
+        rearranged_columns = ["Model Name", "Model"] + rearranged_columns
+        mean_scores = mean_scores[rearranged_columns]
         result_container_mean.append(mean_scores)
-        mc += 1
-    
+
     results = pd.concat(result_container_mean)
-    
-    results.reset_index(inplace=True)
-    
+
+    results.set_index("Index", inplace=True, drop=True)
+
     return results
-    
+
+
 def _choose_better(
     models_and_results: list,
     compare_dimension: str,

--- a/pycaret/regression.py
+++ b/pycaret/regression.py
@@ -2411,7 +2411,7 @@ def get_leaderboard():
 
 
     Returns:
-        Pandas.DataFrame
+        pandas.DataFrame
 
     """
     return pycaret.internal.tabular.get_leaderboard()

--- a/pycaret/regression.py
+++ b/pycaret/regression.py
@@ -2395,3 +2395,23 @@ def load_config(file_name: str):
     """
 
     return pycaret.internal.tabular.load_config(file_name=file_name)
+
+
+def get_leaderboard():
+    
+    """
+    This function returns the leaderboard of all models trained in the 
+    current setup.
+
+
+    Example
+    -------
+    >>> from pycaret.classification import get_leaderboard
+    >>> leaderboard = get_leaderboard()
+
+
+    Returns:
+        Pandas.DataFrame
+
+    """
+    return pycaret.internal.tabular.get_leaderboard()


### PR DESCRIPTION
I have recently implemented a new function called `get_leaderboard`. This function retrieves all the trained model object and their metrics from global variables and returns as `pandas.DataFrame`. This is how the desired output looks like:

![image](https://user-images.githubusercontent.com/54699234/130454740-e05a2164-bcb5-46e2-8c74-53d72b94eef9.png)

I created this function in my Notebook and used the `get_config` function to retrieve everything I needed. Here is my code:

```
import pandas as pd
from pycaret.internal.tabular import _get_model_name

def get_leaderboard():
    
    model_container = get_config('master_model_container')
    result_container = get_config('create_model_container')
    
    result_container_mean = []
    
    mc = 0

    for i in np.arange(0,len(result_container)):
        c = result_container[i]
        r = c[-2:-1]
        model_name = _get_model_name(model_container[mc]) 
        r['Model Name'] = model_name
        r['Model'] = model_container[mc]
        r.set_index('Model Name', drop=True, inplace=True)
        r = r[['Model', 'Accuracy', 'AUC', 'Recall', 'Prec.', 'F1', 'Kappa', 'MCC']]
        result_container_mean.append(r)
        mc += 1
    
    results = pd.concat(result_container_mean)
    
    results.reset_index(inplace=True)
    
    return results
```

The main problem is when I execute this code directly the function that I pushed in `tabular.py` I get this error:

![image](https://user-images.githubusercontent.com/54699234/130455137-1fe39710-330b-433a-97d5-4376519e1771.png)

You can reproduce this error from the `get_leaderboard` branch or this draft PR:

```
from pycaret.datasets import get_data
data = get_data('juice')

from pycaret.classification import *
s = setup(data, target = 'Purchase', session_id = 123)

best = compare_models()

get_leaderboard()
```

Also please feel free to improve the code if you would like. Let me know if you have any questions. 

Thanks

