### PR TITLE
Closing plt module after saving figure on interpret_model function.

### DIFF
--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -7673,6 +7673,7 @@ def interpret_model(
                 plot_filename = plot
             logger.info(f"Saving '{plot_filename}.png'")
             plt.savefig(plot_filename)
+            plt.close()
 
         return shap_plot
 
@@ -7712,6 +7713,7 @@ def interpret_model(
                 plot_filename = plot
             logger.info(f"Saving '{plot_filename}.png'")
             plt.savefig(f"{plot_filename}.png", bbox_inches="tight")
+            plt.close()
 
         return None
 


### PR DESCRIPTION
## Related Issuse or bug
  - Bug 1581
  - https://github.com/pycaret/pycaret/issues/1581

Fixes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
Added plt.close() after any use of the function interpret_model() when the parameter save is set up as True.

## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

```
import os
from pycaret.datasets import get_data
import pycaret.classification as clf

data = get_data('blood')
s = clf.setup(data, train_size=0.80, target='Class', session_id=42, silent=True)

rf = clf.create_model('rf', verbose=False)
clf.tune_model(rf, optimize='auc', n_iter=10, fold=5)

clf.plot_model(rf, plot='auc', verbose=False, save=True)
os.rename('AUC.png', 'AUC_before_interpret.png')
clf.plot_model(rf, plot='confusion_matrix', verbose=False, save=True)
os.rename('Confusion Matrix.png', 'Confusion Matrix_before_interpret.png')
clf.plot_model(rf, plot='error', verbose=False, save=True)
os.rename('Prediction Error.png', 'Prediction Error_before_interpret.png')
clf.interpret_model(rf, plot='summary', save=True)

var_list = clf.get_config('X').columns.tolist()
for var in var_list:
    clf.interpret_model(rf, plot='correlation', feature=var, save=True)
    os.rename('SHAP correlation.png', 'SHAP correlation ('+var.replace("/","_")+').png')

clf.plot_model(rf, plot='auc', verbose=False, save=True)
os.rename('AUC.png', 'AUC_after_interpret.png')
clf.plot_model(rf, plot='confusion_matrix', verbose=False, save=True)
os.rename('Confusion Matrix.png', 'Confusion Matrix_after_interpret.png')
clf.plot_model(rf, plot='error', verbose=False, save=True)
os.rename('Prediction Error.png', 'Prediction Error_after_interpret.png')
```

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
 
 
 
 
 
 
 
 
 










