### PR TITLE
fix the issue in Fix_multicollinearity when target is float32 or float64

### DIFF
--- a/pycaret/internal/preprocess.py
+++ b/pycaret/internal/preprocess.py
@@ -2512,8 +2512,8 @@ class Fix_multicollinearity(BaseEstimator, TransformerMixin):
             None
         """
 
-        if data[self.target_variable].dtype not in ["int32", "int64"]:
-            raise ValueError('dtype for the target variable should be int32 or int64 only')
+        if data[self.target_variable].dtype not in ["int32", "int64", "float32", "float64"]:
+            raise ValueError('dtype for the target variable should be int32, int64, float32, or float64 only')
 
         # global data1
         data1 = data.select_dtypes(include=["int32", "int64", "float32", "float64"])

--- a/pycaret/tests/test_regression.py
+++ b/pycaret/tests/test_regression.py
@@ -17,6 +17,8 @@ def test():
     reg1 = pycaret.regression.setup(
         data,
         target="medv",
+        remove_multicollinearity=True,
+        multicollinearity_threshold=0.95,
         silent=True,
         log_experiment=True,
         html=False,


### PR DESCRIPTION
## Related Issuse or bug
  - Info about Issue or bug

Fixes: #1609 

#### Describe the changes you've made
Fixed the issue where Fix_multicollinearity does not work when target is float32 or float64.






## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [] My code follows the code style of this project.
-->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Reproduced the issue by adding the multicollinearity setting in test_regression.py. The test is passed with the new code.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
 
 
 
 
 
 
 
 
 










