### PR TITLE
typo fix: "NNote" to "Note"

### DIFF
--- a/tutorials/Regression Tutorial Level Intermediate - REG102.ipynb
+++ b/tutorials/Regression Tutorial Level Intermediate - REG102.ipynb
@@ -15456,7 +15456,7 @@
     "id": "OgDwm-V41RTR"
    },
    "source": [
-    "NNote that this is the same setup grid that was shown in __[Regression Tutorial (REG101) - Level Beginner](https://github.com/pycaret/pycaret/blob/master/tutorials/Regression%20Tutorial%20Level%20Beginner%20-%20REG101.ipynb)__. The only difference here is the customization parameters that were passed to `setup()` are now set to `True`. Also notice that the `session_id` is the same as the one used in the beginner tutorial, which means that the effect of randomization is completely isolated. Any improvements we see in this experiment are solely due to the pre-processing steps taken in `setup()` or any other modeling techniques used in later sections of this tutorial."
+    "Note that this is the same setup grid that was shown in __[Regression Tutorial (REG101) - Level Beginner](https://github.com/pycaret/pycaret/blob/master/tutorials/Regression%20Tutorial%20Level%20Beginner%20-%20REG101.ipynb)__. The only difference here is the customization parameters that were passed to `setup()` are now set to `True`. Also notice that the `session_id` is the same as the one used in the beginner tutorial, which means that the effect of randomization is completely isolated. Any improvements we see in this experiment are solely due to the pre-processing steps taken in `setup()` or any other modeling techniques used in later sections of this tutorial."
    ]
   },
   {


### PR DESCRIPTION
## Related Issuse or bug
  - Fixes a typo noticed in the the second regression tutorial notebook ("NNote" --> "Note")

Fixes: Typo.

#### Describe the changes you've made
I edited the raw ipynb file and changed the typo, the cells were not rerun, only the single instance was changed. 


## Type of change

- [X] Code style update (formatting, local variables)
- [X] Other: Typo Fix in Tutorial

## How Has This Been Tested?

I didn't run tests as this is a cosmetic/pedantic/superficial change.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)


## Checklist:
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

 
 
 
 
 
 
 










