### PR TITLE
fix for no fig.show and added return_fig arg per #1699

### DIFF
--- a/pycaret/internal/plots/time_series.py
+++ b/pycaret/internal/plots/time_series.py
@@ -585,13 +585,13 @@ def plot_predictions(
         showlegend=True,
     )
 
-    data = [mean, original]
+    data_for_fig = [mean, original]
 
     layout = go.Layout(
         yaxis=dict(title="Values"), xaxis=dict(title="Time"), title=title,
     )
 
-    fig = go.Figure(data=data, layout=layout)
+    fig = go.Figure(data=data_for_fig, layout=layout)
 
     fig_template = fig_kwargs.get("fig_template", "ggplot2")
     fig.update_layout(template=fig_template)

--- a/pycaret/internal/pycaret_experiment/time_series_experiment.py
+++ b/pycaret/internal/pycaret_experiment/time_series_experiment.py
@@ -853,8 +853,8 @@ class TimeSeriesExperiment(_SupervisedExperiment):
 
         fh: int or list or np.array, default = 1
             The forecast horizon to be used for forecasting. Default is set to ``1`` i.e.
-            forecast one point ahead. When integer is passed it means N continious points 
-            in the future without any gap. If you want to forecast values with gaps, you 
+            forecast one point ahead. When integer is passed it means N continious points
+            in the future without any gap. If you want to forecast values with gaps, you
             must pass an array e.g. np.array([2, 5]) will forecast 2 and 5 points ahead.
 
 
@@ -878,7 +878,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
 
         enforce_pi: bool, default = False
             When set to True, only models that support prediction intervals are
-            loaded in the environment. 
+            loaded in the environment.
 
 
         n_jobs: int, default = -1
@@ -908,7 +908,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
 
 
         system_log: bool or logging.Logger, default = True
-            Whether to save the system logging file (as logs.log). If the input already is a 
+            Whether to save the system logging file (as logs.log). If the input already is a
             logger object, that one is used instead.
 
 
@@ -1611,7 +1611,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
 
 
         search_algorithm: str, default = 'random'
-            use 'random' for random grid search and 'grid' for complete grid search. 
+            use 'random' for random grid search and 'grid' for complete grid search.
 
 
         choose_better: bool, default = True
@@ -2351,6 +2351,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
         self,
         estimator: Optional[Any] = None,
         plot: Optional[str] = None,
+        return_fig: bool = False,
         return_data: bool = False,
         verbose: bool = False,
         display_format: Optional[str] = None,
@@ -2362,8 +2363,8 @@ class TimeSeriesExperiment(_SupervisedExperiment):
 
         """
         This function analyzes the performance of a trained model on holdout set.
-        When used without any estimator, this function generates plots on the 
-        original data set. When used with an estimator, it will generate plots on 
+        When used without any estimator, this function generates plots on the
+        original data set. When used with an estimator, it will generate plots on
         the model residuals.
 
 
@@ -2400,8 +2401,14 @@ class TimeSeriesExperiment(_SupervisedExperiment):
             * 'residuals' - Residuals Plot
 
 
+        return_fig: : bool, default = False
+            When set to True, it returns the figure used for plotting.
+
+
         return_data: bool, default = False
             When set to True, it returns the data for plotting.
+            If both return_fig and return_data is set to True, order of return
+            is figure then data.
 
 
         verbose: bool, default = True
@@ -2466,6 +2473,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
         ]
 
         return_pred_int = False
+        return_obj = []
 
         # Type checks
         if estimator is not None and isinstance(estimator, str):
@@ -2595,28 +2603,29 @@ class TimeSeriesExperiment(_SupervisedExperiment):
             self.logger.info(f"Saving '{plot_filename}'")
             fig.write_html(plot_filename)
 
-            if return_data:
-                return plot_filename, plot_data
-            else:
-                return plot_filename
+            ### Add file name to return object ----
+            return_obj.append(plot_filename)
 
         elif system:
             if display_format == "streamlit":
                 st.write(fig)
-                return fig
-            # else:
-            #     fig.show()
+            else:
+                fig.show()
             self.logger.info("Visual Rendered Successfully")
 
-            if return_data:
-                return fig, plot_data
-            else:
-                return fig
+        ### Add figure and data to return object if required ----
+        if return_fig:
+            return_obj.append(fig)
+        if return_data:
+            return_obj.append(plot_data)
 
-        # if return_data:
-        #     return plot_filename, plot_data
-        # else:
-        #     return plot_filename
+        #### Return None if empty, return as list if more than one object,
+        # else return object directly ----
+        if len(return_obj) == 0:
+            return_obj = None
+        elif len(return_obj) == 1:
+            return_obj = return_obj[0]
+        return return_obj
 
     # def evaluate_model(
     #     self,
@@ -2746,8 +2755,8 @@ class TimeSeriesExperiment(_SupervisedExperiment):
     ) -> pd.DataFrame:
 
         """
-        This function forecast using a trained model. When ``fh`` is None, 
-        it forecasts using the same forecast horizon used during the 
+        This function forecast using a trained model. When ``fh`` is None,
+        it forecasts using the same forecast horizon used during the
         training.
 
 
@@ -2768,7 +2777,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
 
         fh: int, default = None
             Number of points from the last date of training to forecast.
-            When fh is None, it forecasts using the same forecast horizon 
+            When fh is None, it forecasts using the same forecast horizon
             used during the training.
 
 
@@ -3423,7 +3432,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
         >>> from pycaret.time_series import *
         >>> exp_name = setup(data = data, fh = 12)
         >>> best = compare_models()
-        >>> exp_logs = get_logs()   
+        >>> exp_logs = get_logs()
 
 
         experiment_name: str, default = None

--- a/pycaret/time_series.py
+++ b/pycaret/time_series.py
@@ -877,6 +877,7 @@ def blend_models(
 def plot_model(
     estimator: Optional[Any] = None,
     plot: Optional[str] = None,
+    return_fig: bool = False,
     return_data: bool = False,
     verbose: bool = False,
     display_format: Optional[str] = None,
@@ -925,8 +926,14 @@ def plot_model(
         * 'residuals' - Residuals Plot
 
 
+    return_fig: : bool, default = False
+            When set to True, it returns the figure used for plotting.
+
+
     return_data: bool, default = False
         When set to True, it returns the data for plotting.
+        If both return_fig and return_data is set to True, order of return
+        is figure then data.
 
 
     verbose: bool, default = True
@@ -963,6 +970,7 @@ def plot_model(
     return _CURRENT_EXPERIMENT.plot_model(
         estimator=estimator,
         plot=plot,
+        return_fig=return_fig,
         return_data=return_data,
         display_format=display_format,
         data_kwargs=data_kwargs,


### PR DESCRIPTION
## Related Issue or bug
  - #1699

#### Describe the changes you've made
- Added return_fig argument to plot_model()
- plot_model reverted to previous functionality of showing fig internally by default. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit tests run locally

## Checklist:
- x ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
