### PR TITLE
added column for point estimate within pi (outlier or not) in support of #1836

### DIFF
--- a/pycaret/internal/pycaret_experiment/time_series_experiment.py
+++ b/pycaret/internal/pycaret_experiment/time_series_experiment.py
@@ -2857,10 +2857,8 @@ class TimeSeriesExperiment(_SupervisedExperiment):
             # result = result.join(return_vals[1])
             result = pd.concat(return_vals, axis=1)
             result.columns = ["y_pred", "lower", "upper"]
-            result["within_pi"] = result.apply(
-                lambda row: (row["y_pred"] >= row["lower"])
-                and (row["y_pred"] <= row["upper"]),
-                axis=1,
+            result["within_pi"] = (result["y_pred"] >= result["lower"]) & (
+                result["y_pred"] <= result["upper"]
             )
         else:
             # Prediction interval is not returned (not implemented)

--- a/pycaret/tests/test_time_series.py
+++ b/pycaret/tests/test_time_series.py
@@ -407,15 +407,16 @@ def test_create_predict_finalize_model(name, fh, load_pos_and_neg_data):
     assert np.all(y_pred.index == expected_period_index)
 
     # With Prediction Interval (default alpha = 0.05)
+    expected_cols_with_pi = ["y_pred", "lower", "upper", "within_pi"]
     y_pred = exp.predict_model(model, return_pred_int=True)
     assert isinstance(y_pred, pd.DataFrame)
-    assert np.all(y_pred.columns == ["y_pred", "lower", "upper"])
+    assert np.all(y_pred.columns == expected_cols_with_pi)
     assert np.all(y_pred.index == expected_period_index)
 
     # With Prediction Interval (alpha = 0.2)
     y_pred2 = exp.predict_model(model, return_pred_int=True, alpha=0.2)
     assert isinstance(y_pred2, pd.DataFrame)
-    assert np.all(y_pred2.columns == ["y_pred", "lower", "upper"])
+    assert np.all(y_pred2.columns == expected_cols_with_pi)
     assert np.all(y_pred2.index == expected_period_index)
 
     # Increased forecast horizon to 2 years instead of the original 1 year
@@ -525,6 +526,7 @@ def test_prediction_interval_na(load_pos_and_neg_data):
     y_pred = exp.predict_model(model, return_pred_int=True)
     assert y_pred["lower"].isnull().all()
     assert y_pred["upper"].isnull().all()
+    assert y_pred["within_pi"].isnull().all()
 
 
 @pytest.mark.parametrize("cross_validation, log_experiment", _compare_model_args)


### PR DESCRIPTION
## Related Issuse or bug

Related to #1836


#### Describe the changes you've made

`predict_model` with prediction interval now returns an extra column that indicates whether the point estimate is within prediction interval or not.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit test has been added

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

