### PR TITLE
Revert "added column for point estimate within pi (outlier or not) in support of #1836"

### DIFF
--- a/pycaret/internal/pycaret_experiment/time_series_experiment.py
+++ b/pycaret/internal/pycaret_experiment/time_series_experiment.py
@@ -2857,16 +2857,12 @@ class TimeSeriesExperiment(_SupervisedExperiment):
             # result = result.join(return_vals[1])
             result = pd.concat(return_vals, axis=1)
             result.columns = ["y_pred", "lower", "upper"]
-            result["within_pi"] = (result["y_pred"] >= result["lower"]) & (
-                result["y_pred"] <= result["upper"]
-            )
         else:
             # Prediction interval is not returned (not implemented)
             if return_pred_int:
                 result = pd.DataFrame(return_vals, columns=["y_pred"])
                 result["lower"] = np.nan
                 result["upper"] = np.nan
-                result["within_pi"] = np.nan
             else:
                 # Leave as series
                 result = return_vals
@@ -2879,14 +2875,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
                         pass
 
         # Converting to float since rounding does not support int
-        if isinstance(result, pd.Series):
-            result = result.astype(float).round(round)
-        else:
-            # Pandas DataFrame
-            cols_to_round = [["y_pred", "lower", "upper"]]
-            for col in cols_to_round:
-                if col in result.columns.to_list():
-                    result[col] = result[col].astype(float).round(round)
+        result = result.astype(float).round(round)
 
         if isinstance(result.index, pd.DatetimeIndex):
             result.index = (

--- a/pycaret/tests/test_time_series.py
+++ b/pycaret/tests/test_time_series.py
@@ -407,16 +407,15 @@ def test_create_predict_finalize_model(name, fh, load_pos_and_neg_data):
     assert np.all(y_pred.index == expected_period_index)
 
     # With Prediction Interval (default alpha = 0.05)
-    expected_cols_with_pi = ["y_pred", "lower", "upper", "within_pi"]
     y_pred = exp.predict_model(model, return_pred_int=True)
     assert isinstance(y_pred, pd.DataFrame)
-    assert np.all(y_pred.columns == expected_cols_with_pi)
+    assert np.all(y_pred.columns == ["y_pred", "lower", "upper"])
     assert np.all(y_pred.index == expected_period_index)
 
     # With Prediction Interval (alpha = 0.2)
     y_pred2 = exp.predict_model(model, return_pred_int=True, alpha=0.2)
     assert isinstance(y_pred2, pd.DataFrame)
-    assert np.all(y_pred2.columns == expected_cols_with_pi)
+    assert np.all(y_pred2.columns == ["y_pred", "lower", "upper"])
     assert np.all(y_pred2.index == expected_period_index)
 
     # Increased forecast horizon to 2 years instead of the original 1 year
@@ -526,7 +525,6 @@ def test_prediction_interval_na(load_pos_and_neg_data):
     y_pred = exp.predict_model(model, return_pred_int=True)
     assert y_pred["lower"].isnull().all()
     assert y_pred["upper"].isnull().all()
-    assert y_pred["within_pi"].isnull().all()
 
 
 @pytest.mark.parametrize("cross_validation, log_experiment", _compare_model_args)


### PR DESCRIPTION
Reverts pycaret/pycaret#1863

This is not correct. The check has to be made with actual data not predictions. Hence reverting back.