### PR TITLE
Add support for metrics with custom arguments like MASE, INPI

### DIFF
--- a/pycaret/containers/metrics/time_series.py
+++ b/pycaret/containers/metrics/time_series.py
@@ -12,7 +12,8 @@ from typing import Optional, Union, Dict, Any
 from pycaret.containers.metrics.base_metric import MetricContainer
 from sklearn.metrics._scorer import _BaseScorer  # type: ignore
 import pycaret.internal.metrics
-from pandas import DataFrame, Series  # type: ignore
+import numpy as np
+import pandas as pd
 from sklearn import metrics  # type: ignore
 from sktime.performance_metrics.forecasting._functions import (  # type: ignore
     mean_absolute_scaled_error,
@@ -176,26 +177,55 @@ def _mase_loss(y_true, y_pred, y_train):
     )
 
 
+def _inpi_loss(y_true, y_pred, lower: pd.Series, upper: pd.Series):
+    """Returns the percentage of actual values that are within the
+    prediction interval. Higher score is better.
+    NOTE: If lower and upper have NAN values, it returns np.nan
+    """
+    y_true = _check_series(y_true)
+    y_pred = _check_series(y_pred)
+    lower = _check_series(lower)
+    upper = _check_series(upper)
+
+    # First combine the true, upper and lower values and keep only those values
+    # that match the y_true indices. Then if any of the values have NAN in them,
+    # return NAN, else proceed to calculating metric.
+
+    # NAN's can occur due to following reasons:
+    # (1) Indices match between y_true and (lower or upper) but lower or upper
+    # values have NAN (i.e. forecaster does not support prediction intervals)
+    # (2) y_true is NAN (i.e. model has been finalized)
+    # (3) Indices do not match up between y_true and (lower or upper) - failsafe
+
+    combined = pd.concat([y_true, lower, upper], axis=1)
+    combined.columns = ["y_true", "lower", "upper"]
+    combined.dropna(subset=["y_true"], inplace=True)
+
+    ## Override lower and upper to only those indices that match y_true indices
+    lower = combined["lower"]
+    upper = combined["upper"]
+
+    if y_true.isna().any() or lower.isna().any() or upper.isna().any():
+        return np.nan
+
+    in_limits = np.logical_and(y_true > lower, y_true < upper)
+    return sum(in_limits) / len(in_limits)
+
+
 def _check_series(y):
     """
     Check whether or not y is pandas.Series. Pycaret Experiment
     internally converts data to pandas.DataFrame.
     """
-    if isinstance(y, Series):
+    if isinstance(y, pd.Series):
         return y
-    elif isinstance(y, DataFrame):
+    elif isinstance(y, pd.DataFrame):
         return _set_y_as_series(y)
 
 
 def _set_y_as_series(y):
     """Set first column of a DataFrame as pandas.Series"""
-    return Series(y.iloc[:, 0])
-
-
-# TODO: Disabling for now since need to determine how these special cases will
-# be handles in manually generated function cross_validate_ts
-# MASEMetricContainer: Special Case: Needs y_train
-# MAEMetricContainer: _scorer_func turns out to be a string instead of a func
+    return pd.Series(y.iloc[:, 0])
 
 
 class MASEMetricContainer(TimeSeriesMetricContainer):
@@ -232,20 +262,14 @@ class RMSEMetricContainer(TimeSeriesMetricContainer):
 class MAPEMetricContainer(TimeSeriesMetricContainer):
     def __init__(self, globals_dict: dict) -> None:
         super().__init__(
-            id="mape",
-            name="MAPE",
-            score_func=_mape_loss,
-            greater_is_better=False,
+            id="mape", name="MAPE", score_func=_mape_loss, greater_is_better=False,
         )
 
 
 class SMAPEMetricContainer(TimeSeriesMetricContainer):
     def __init__(self, globals_dict: dict) -> None:
         super().__init__(
-            id="smape",
-            name="SMAPE",
-            score_func=_smape_loss,
-            greater_is_better=False,
+            id="smape", name="SMAPE", score_func=_smape_loss, greater_is_better=False,
         )
 
 
@@ -258,6 +282,13 @@ class R2MetricContainer(TimeSeriesMetricContainer):
             score_func=metrics.r2_score,
             greater_is_better=True,
             scorer="r2",
+        )
+
+
+class INPIMetricContainer(TimeSeriesMetricContainer):
+    def __init__(self, globals_dict: dict) -> None:
+        super().__init__(
+            id="inpi", name="INPI", score_func=_inpi_loss, greater_is_better=True,
         )
 
 

--- a/pycaret/containers/metrics/time_series.py
+++ b/pycaret/containers/metrics/time_series.py
@@ -168,11 +168,12 @@ def _mape_loss(y_true, y_pred, **kwargs):
     )
 
 
-def _mase_loss(y_true, y_pred, y_train):
+def _mase_loss(y_true, y_pred, y_train, sp):
     """Wrapper for sktime metrics"""
     return mean_absolute_scaled_error(
         y_true=_check_series(y_true),
         y_pred=_check_series(y_pred),
+        sp=sp,
         y_train=_check_series(y_train),
     )
 

--- a/pycaret/containers/metrics/time_series.py
+++ b/pycaret/containers/metrics/time_series.py
@@ -103,7 +103,7 @@ class TimeSeriesMetricContainer(MetricContainer):
             else pycaret.internal.metrics.make_scorer_with_error_score(
                 score_func,
                 greater_is_better=greater_is_better,
-                errors_score=0.0,
+                error_score=0.0,
                 **args,
             )
         )
@@ -167,13 +167,13 @@ def _mape_loss(y_true, y_pred, **kwargs):
     )
 
 
-# def _mase_loss(y_true, y_pred, y_train):
-#     """Wrapper for sktime metrics"""
-#     return mase_loss(
-#         y_test=_check_series(y_true),
-#         y_pred=_check_series(y_pred),
-#         y_train=_check_series(y_train),
-#     )
+def _mase_loss(y_true, y_pred, y_train):
+    """Wrapper for sktime metrics"""
+    return mean_absolute_scaled_error(
+        y_true=_check_series(y_true),
+        y_pred=_check_series(y_pred),
+        y_train=_check_series(y_train),
+    )
 
 
 def _check_series(y):
@@ -197,11 +197,12 @@ def _set_y_as_series(y):
 # MASEMetricContainer: Special Case: Needs y_train
 # MAEMetricContainer: _scorer_func turns out to be a string instead of a func
 
-# class MASEMetricContainer(TimeSeriesMetricContainer):
-#     def __init__(self, globals_dict: dict) -> None:
-#         super().__init__(
-#             id="mase", name="MASE", score_func=_mase_loss, greater_is_better=False
-#         )
+
+class MASEMetricContainer(TimeSeriesMetricContainer):
+    def __init__(self, globals_dict: dict) -> None:
+        super().__init__(
+            id="mase", name="MASE", score_func=_mase_loss, greater_is_better=False
+        )
 
 
 class MAEMetricContainer(TimeSeriesMetricContainer):
@@ -231,14 +232,20 @@ class RMSEMetricContainer(TimeSeriesMetricContainer):
 class MAPEMetricContainer(TimeSeriesMetricContainer):
     def __init__(self, globals_dict: dict) -> None:
         super().__init__(
-            id="mape", name="MAPE", score_func=_mape_loss, greater_is_better=False,
+            id="mape",
+            name="MAPE",
+            score_func=_mape_loss,
+            greater_is_better=False,
         )
 
 
 class SMAPEMetricContainer(TimeSeriesMetricContainer):
     def __init__(self, globals_dict: dict) -> None:
         super().__init__(
-            id="smape", name="SMAPE", score_func=_smape_loss, greater_is_better=False,
+            id="smape",
+            name="SMAPE",
+            score_func=_smape_loss,
+            greater_is_better=False,
         )
 
 

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -78,7 +78,12 @@ class _SupervisedExperiment(_TabularExperiment):
         return
 
     def _calculate_metrics(
-        self, y_test, pred, pred_prob, weights: Optional[list] = None,
+        self,
+        y_test,
+        pred,
+        pred_prob,
+        weights: Optional[list] = None,
+        **additional_kwargs,
     ) -> dict:
         """
         Calculate all metrics in _all_metrics.
@@ -92,16 +97,21 @@ class _SupervisedExperiment(_TabularExperiment):
                 pred=pred,
                 pred_proba=pred_prob,
                 weights=weights,
+                **additional_kwargs,
             )
         except Exception:
             ml_usecase = get_ml_task(y_test)
             if ml_usecase == MLUsecase.CLASSIFICATION:
-                metrics = pycaret.containers.metrics.classification.get_all_metric_containers(
-                    self.variables, True
+                metrics = (
+                    pycaret.containers.metrics.classification.get_all_metric_containers(
+                        self.variables, True
+                    )
                 )
             elif ml_usecase == MLUsecase.REGRESSION:
-                metrics = pycaret.containers.metrics.regression.get_all_metric_containers(
-                    self.variables, True
+                metrics = (
+                    pycaret.containers.metrics.regression.get_all_metric_containers(
+                        self.variables, True
+                    )
                 )
             return calculate_metrics(
                 metrics=metrics,  # type: ignore
@@ -109,6 +119,7 @@ class _SupervisedExperiment(_TabularExperiment):
                 pred=pred,
                 pred_proba=pred_prob,
                 weights=weights,
+                **additional_kwargs,
             )
 
     def _is_unsupervised(self) -> bool:

--- a/pycaret/internal/pycaret_experiment/time_series_experiment.py
+++ b/pycaret/internal/pycaret_experiment/time_series_experiment.py
@@ -929,7 +929,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
 
         seasonal_period: int or str, default = None
             Seasonal period in timeseries data. If not provided the frequency of the data
-            index is map to a seasonal period as follows:
+            index is mapped to a seasonal period as follows:
 
             * 'S': 60
             * 'T': 60
@@ -942,7 +942,8 @@ class TimeSeriesExperiment(_SupervisedExperiment):
             * 'Y': 1
 
             Alternatively you can provide a custom `seasonal_period` by passing
-            it as an integer.
+            it as an integer or a string corresponding to the keys above (e.g.
+            'W' for weekly data, 'M' for monthly data, etc.).
 
 
         enforce_pi: bool, default = False

--- a/pycaret/internal/pycaret_experiment/time_series_experiment.py
+++ b/pycaret/internal/pycaret_experiment/time_series_experiment.py
@@ -275,6 +275,8 @@ def _fit_and_score(
     cutoff = forecaster.cutoff
 
     #### Score the model ----
+    lower = pd.Series([])
+    upper = pd.Series([])
     if forecaster.is_fitted:
         y_pred, lower, upper = get_predictions_with_intervals(
             forecaster=forecaster, X_test=X_test
@@ -3750,5 +3752,10 @@ def get_predictions_with_intervals(
         upper = pd.Series([np.nan] * len(y_pred))
         lower.index = y_pred.index
         upper.index = y_pred.index
+
+    # Prophet with return_pred_int = True returns datetime index.
+    for series in [y_pred, lower, upper]:
+        if isinstance(series.index, pd.DatetimeIndex):
+            series.index = series.index.to_period()
 
     return y_pred, lower, upper

--- a/pycaret/internal/utils.py
+++ b/pycaret/internal/utils.py
@@ -1,7 +1,7 @@
 # Module: internal.utils
 # Author: Moez Ali <moez.ali@queensu.ca> and Antoni Baum (Yard1) <antoni.baum@protonmail.com>
 # License: MIT
-
+import inspect
 import os
 import numpy as np
 
@@ -13,7 +13,7 @@ import ipywidgets as ipw
 from IPython.display import display, HTML, clear_output, update_display
 from pycaret.internal.logging import get_logger
 from pycaret.internal.validation import *
-from typing import Any, List, Optional, Dict, Tuple, Union
+from typing import Any, Callable, List, Optional, Dict, Set, Tuple, Union
 from sklearn import clone
 from sklearn.model_selection import KFold, StratifiedKFold, BaseCrossValidator
 from sklearn.model_selection._split import _BaseKFold
@@ -389,6 +389,10 @@ def _calculate_unsupervised_metric(
     return (display_name, calculated_metric)
 
 
+def get_function_params(function: Callable) -> Set[str]:
+    return inspect.signature(function).parameters
+
+
 def calculate_metrics(
     metrics: Dict[str, "pycaret.containers.metrics.base_metric.MetricContainer"],
     y_test,
@@ -396,6 +400,7 @@ def calculate_metrics(
     pred_proba: Optional[float] = None,
     score_dict: Optional[Dict[str, np.array]] = None,
     weights: Optional[list] = None,
+    **additional_kwargs,
 ) -> Dict[str, np.array]:
 
     score_dict = []
@@ -410,6 +415,7 @@ def calculate_metrics(
                 pred,
                 pred_proba,
                 weights,
+                **additional_kwargs,
             )
         )
 
@@ -418,18 +424,22 @@ def calculate_metrics(
 
 
 def _calculate_metric(
-    container, score_func, display_name, y_test, pred_, pred_proba, weights
+    container, score_func, display_name, y_test, pred_, pred_proba, weights, **kwargs
 ):
     if not score_func:
         return None
+    # get all kwargs in additional_kwargs
+    # that correspond to parameters in function signature
+    kwargs = {
+        **{k: v for k, v in kwargs.items() if k in get_function_params(score_func)},
+        **container.args,
+    }
     target = pred_proba if container.target == "pred_proba" else pred_
     try:
-        calculated_metric = score_func(
-            y_test, target, sample_weight=weights, **container.args
-        )
+        calculated_metric = score_func(y_test, target, sample_weight=weights, **kwargs)
     except:
         try:
-            calculated_metric = score_func(y_test, target, **container.args)
+            calculated_metric = score_func(y_test, target, **kwargs)
         except:
             calculated_metric = 0
 

--- a/pycaret/tests/test_time_series.py
+++ b/pycaret/tests/test_time_series.py
@@ -6,7 +6,7 @@ import pytest
 import numpy as np  # type: ignore
 import pandas as pd  # type: ignore
 
-
+from pycaret.datasets import get_data
 from pycaret.internal.pycaret_experiment import TimeSeriesExperiment
 from pycaret.internal.ensemble import _ENSEMBLE_METHODS
 
@@ -321,6 +321,27 @@ def test_setup_seasonal_period_int(load_pos_and_neg_data, seasonal_key, seasonal
     )
 
     assert exp.seasonal_period == seasonal_value
+
+
+def test_seasonal_period_to_use():
+
+    exp = TimeSeriesExperiment()
+    fh = 12
+
+    # Airline Data with seasonality of 12
+    data = get_data("airline", verbose=False)
+    exp.setup(
+        data=data, fh=fh, verbose=False, session_id=42,
+    )
+    assert exp.sp_to_use == 12
+
+    # WhiteAirline Data with seasonality of 12
+    data = get_data("1", folder="time_series/white_noise", verbose=False)
+    exp.setup(
+        data=data, fh=fh, seasonal_period=12, verbose=False, session_id=42,
+    )
+    # Should get 1 even though we passed 12
+    assert exp.sp_to_use == 1
 
 
 def test_enforce_pi(load_pos_and_neg_data):

--- a/pycaret/tests/test_time_series_metrics.py
+++ b/pycaret/tests/test_time_series_metrics.py
@@ -1,0 +1,75 @@
+"""Module to test time_series functionality
+"""
+import pytest
+
+import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
+
+from pycaret.containers.metrics.time_series import _inpi_loss
+
+
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
+
+
+##########################
+#### Tests Start Here ####
+##########################
+
+
+def test_inpi_loss():
+    """Tests inpi_loss
+    """
+
+    ##############################
+    #### Regular Calculations ####
+    ##############################
+    y_pred = None
+    lower = pd.Series([0.5, 1.5, 2.5, 3.5])
+    upper = pd.Series([1.5, 2.5, 3.5, 4.5])
+
+    # All pass
+    y_true = pd.Series([1, 2, 3, 4])
+    loss = _inpi_loss(y_true=y_true, y_pred=y_pred, lower=lower, upper=upper)
+    assert loss == 1.00
+
+    # Upper Limit breached
+    y_true = pd.Series([1, 2, 4, 4])
+    loss = _inpi_loss(y_true=y_true, y_pred=y_pred, lower=lower, upper=upper)
+    assert loss == 0.75
+
+    # Lower Limit breached
+    y_true = pd.Series([1, 1, 3, 4])
+    loss = _inpi_loss(y_true=y_true, y_pred=y_pred, lower=lower, upper=upper)
+    assert loss == 0.75
+
+    # Both Limits breached
+    y_true = pd.Series([1, 1, 4, 4])
+    loss = _inpi_loss(y_true=y_true, y_pred=y_pred, lower=lower, upper=upper)
+    assert loss == 0.50
+
+    ##################################
+    #### Check for NANs in limits ####
+    ##################################
+    lower = pd.Series([np.nan] * 4)
+    upper = pd.Series([np.nan] * 4)
+    y_true = pd.Series([1, 2, 3, 4])
+    loss = _inpi_loss(y_true=y_true, y_pred=y_pred, lower=lower, upper=upper)
+    assert loss is np.nan
+
+    ##################################
+    #### Check for NANs in y_true ####
+    ##################################
+    lower = pd.Series([0.5, 1.5, 2.5, 3.5])
+    upper = pd.Series([1.5, 2.5, 3.5, 4.5])
+    y_true = pd.Series([1, 2, np.nan, 4])
+    loss = _inpi_loss(y_true=y_true, y_pred=y_pred, lower=lower, upper=upper)
+    assert loss is np.nan
+
+    ######################################
+    #### Check for mismatched indices ####
+    ######################################
+    lower = pd.Series([0.5, 1.5, 2.5, 3.5], index=[0, 1, 2, 3])
+    upper = pd.Series([1.5, 2.5, 3.5, 4.5], index=[0, 1, 2, 3])
+    y_true = pd.Series([1, 2, 3, 4], index=[0, 1, 2, 4])
+    loss = _inpi_loss(y_true=y_true, y_pred=y_pred, lower=lower, upper=upper)
+    assert loss is np.nan

--- a/pycaret/time_series.py
+++ b/pycaret/time_series.py
@@ -111,7 +111,7 @@ def setup(
 
     seasonal_period: int or str, default = None
         Seasonal period in timeseries data. If not provided the frequency of the data
-        index is map to a seasonal period as follows:
+        index is mapped to a seasonal period as follows:
 
         * 'S': 60
         * 'T': 60
@@ -123,8 +123,9 @@ def setup(
         * 'A': 1
         * 'Y': 1
 
-        Alternatively you can provide a custom `seasonal_parameter` by passing
-        it as an integer.
+        Alternatively you can provide a custom `seasonal_period` by passing
+        it as an integer or a string corresponding to the keys above (e.g.
+        'W' for weekly data, 'M' for monthly data, etc.).
 
 
     enforce_pi: bool, default = False


### PR DESCRIPTION
## Related Issuse or bug

Closes https://github.com/pycaret/pycaret/issues/1331
Closes #1406 

#### Describe the changes you've made

- Added option to pass additional kwargs to scorers (some of them like `sp` come from experiment, others like `y_train`, `lower` and `upper`  prediction limit from from respective folds in `fit_and_score`. These are needed for metrics like MASE, INPI, etc.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit test have been added and existing ones pass


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

