### PR TITLE
Time Series - Upper and Lower Clamp

### DIFF
--- a/pycaret/internal/pycaret_experiment/time_series_experiment.py
+++ b/pycaret/internal/pycaret_experiment/time_series_experiment.py
@@ -2979,7 +2979,14 @@ class TimeSeriesExperiment(_SupervisedExperiment):
         result = result.astype(float).round(round)
 
         # apply clamp - None is default for upper and lower
-        result = result.clip(upper = self.upper_clamp,lower=self.lower_clamp, axis=0)
+
+        for clamp in ({"upper":self.upper_clamp},{"lower":self.lower_clamp}):
+            try:
+                result = result.clip(axis=0, **clamp)
+            except TypeError:
+                # argument does not get raised until predict
+                self.logger.error(f"Invalid value in experiment setup: {clamp} must be numeric.")
+                pass
 
 
 

--- a/pycaret/internal/pycaret_experiment/time_series_experiment.py
+++ b/pycaret/internal/pycaret_experiment/time_series_experiment.py
@@ -2979,14 +2979,17 @@ class TimeSeriesExperiment(_SupervisedExperiment):
         result = result.astype(float).round(round)
 
         # apply clamp - None is default for upper and lower
-
-        for clamp in ({"upper":self.upper_clamp},{"lower":self.lower_clamp}):
-            try:
-                result = result.clip(axis=0, **clamp)
-            except TypeError:
-                # argument does not get raised until predict
-                self.logger.error(f"Invalid value in experiment setup: {clamp} must be numeric.")
-                pass
+        # these are only applied/initialised in setup.
+        # suggest adding these options in predict_model()
+        # or wholly implementing in predict_model
+        if self._setup_ran:
+            for clamp in ({"upper":self.upper_clamp},{"lower":self.lower_clamp}):
+                try:
+                    result = result.clip(axis=0, **clamp)
+                except TypeError:
+                    # argument does not get raised until predict
+                    self.logger.error(f"Invalid value in experiment setup: {clamp} must be numeric.")
+                    pass
 
 
 

--- a/pycaret/tests/test_time_series_setup.py
+++ b/pycaret/tests/test_time_series_setup.py
@@ -2,6 +2,7 @@
 """
 import math
 import pytest
+from typing import Optional, Union
 import numpy as np  # type: ignore
 
 from pycaret.datasets import get_data
@@ -12,6 +13,7 @@ from .time_series_test_utils import (
     _return_setup_args_raises,
     _get_seasonal_values,
     _get_seasonal_values_alphanumeric,
+    _get_clamp_values
 )
 
 
@@ -237,4 +239,42 @@ def test_setup_seasonal_period_alphanumeric(
     )
 
     assert exp.seasonal_period == expected_seasonal_value
+
+
+@pytest.mark.parametrize("upper_clamp, lower_clamp",_get_clamp_values())
+def test_setup_upper_and_lower_clamps_is_non_breaking(
+    load_pos_and_neg_data,
+    upper_clamp: Optional[Union[float,int]], 
+    lower_clamp: Optional[Union[float,int]]
+    ):
+    """ Tests the get_sp_from_str 
+    function with different values of frequency """
+    
+
+    exp = TimeSeriesExperiment()
+    fh = np.arange(1, 13)
+    fold = 2
+    data = load_pos_and_neg_data
+
+    try:
+        # set up the experiment
+        exp.setup(
+        data=data,
+        fh=fh,
+        fold=fold,
+        fold_strategy="sliding",
+        verbose=False,
+        upper_clamp=upper_clamp,
+        lower_clamp=lower_clamp)
+
+        # check the instance variables are set correctly.
+        assert exp.lower_clamp == lower_clamp   
+        assert exp.upper_clamp == upper_clamp
+
+    except Exception as exc:
+        assert False, f"'sum_x_y' raised an exception {exc}"
+
+
+
+
 

--- a/pycaret/tests/test_time_series_setup.py
+++ b/pycaret/tests/test_time_series_setup.py
@@ -248,7 +248,7 @@ def test_setup_upper_and_lower_clamps_is_non_breaking(
     lower_clamp: Optional[Union[float,int]]
     ):
     """ Tests that the clamp values are set 
-    correctly in the constuctor """
+    correctly in the constuctor, and that no errors are raised. """
     
 
     exp = TimeSeriesExperiment()
@@ -273,6 +273,47 @@ def test_setup_upper_and_lower_clamps_is_non_breaking(
 
     except Exception as exc:
         assert False, f"'sum_x_y' raised an exception {exc}"
+
+
+@pytest.mark.parametrize("upper_clamp, lower_clamp",_get_clamp_values())
+def test_clamp_is_enforced(
+    load_pos_and_neg_data,
+    upper_clamp: Optional[Union[float,int]], 
+    lower_clamp: Optional[Union[float,int]]
+    ):
+    """ Tests that the clamp values are set 
+    correctly in the constuctor """
+    
+
+    exp = TimeSeriesExperiment()
+    fh = np.arange(1, 13)
+    fold = 2
+    data = load_pos_and_neg_data
+
+
+    exp.setup(
+    data=data,
+    fh=fh,
+    fold=fold,
+    fold_strategy="sliding",
+    verbose=False,
+    upper_clamp=upper_clamp,
+    lower_clamp=lower_clamp)
+
+    best_model = exp.compare_models()
+
+    df = exp.predict_model(best_model, fh=fh, return_pred_int=True)
+
+    cols = ['y_pred','lower','upper']
+    for col in cols:
+        if upper_clamp is not None:
+            assert df[col].max() <= upper_clamp
+        if lower_clamp is not None:
+            assert df[col].min() >= lower_clamp
+        
+
+
+
 
 
 # @pytest.mark.parametrize("upper_clamp, lower_clamp",[('hello',0.0),(0.0,'hello')])

--- a/pycaret/tests/test_time_series_setup.py
+++ b/pycaret/tests/test_time_series_setup.py
@@ -247,8 +247,8 @@ def test_setup_upper_and_lower_clamps_is_non_breaking(
     upper_clamp: Optional[Union[float,int]], 
     lower_clamp: Optional[Union[float,int]]
     ):
-    """ Tests the get_sp_from_str 
-    function with different values of frequency """
+    """ Tests that the clamp values are set 
+    correctly in the constuctor """
     
 
     exp = TimeSeriesExperiment()
@@ -274,6 +274,34 @@ def test_setup_upper_and_lower_clamps_is_non_breaking(
     except Exception as exc:
         assert False, f"'sum_x_y' raised an exception {exc}"
 
+
+# @pytest.mark.parametrize("upper_clamp, lower_clamp",[('hello',0.0),(0.0,'hello')])
+# def test_setup_clamps_invalid_value_fails(
+#     load_pos_and_neg_data,
+#     upper_clamp: Optional[Union[float,int]], 
+#     lower_clamp: Optional[Union[float,int]]
+#     ):
+#     """ Tests the get_sp_from_str 
+#     function with different values of frequency """
+    
+
+#     exp = TimeSeriesExperiment()
+#     fh = np.arange(1, 13)
+#     fold = 2
+#     data = load_pos_and_neg_data
+
+#     # with pytest.raises(TypeError):
+#     # set up the experiment
+#     exp.setup(
+#     data=data,
+#     fh=fh,
+#     fold=fold,
+#     fold_strategy="sliding",
+#     verbose=False,
+#     upper_clamp=upper_clamp,
+#     lower_clamp=lower_clamp)
+
+#     exp.compare_models(turbo=True)
 
 
 

--- a/pycaret/tests/test_time_series_setup.py
+++ b/pycaret/tests/test_time_series_setup.py
@@ -276,7 +276,7 @@ def test_setup_upper_and_lower_clamps_is_non_breaking(
 
 
 @pytest.mark.parametrize("upper_clamp, lower_clamp",_get_clamp_values())
-def test_clamp_is_enforced(
+def test_clamp_is_enforced_on_predictions(
     load_pos_and_neg_data,
     upper_clamp: Optional[Union[float,int]], 
     lower_clamp: Optional[Union[float,int]]
@@ -307,9 +307,20 @@ def test_clamp_is_enforced(
     cols = ['y_pred','lower','upper']
     for col in cols:
         if upper_clamp is not None:
-            assert df[col].max() <= upper_clamp
+            max_pred_or_upper = df[col].max()
+            if np.isnan(max_pred_or_upper):
+                assert True # pass if NaN 
+            else:
+                assert max_pred_or_upper <= upper_clamp
+        else:
+            assert True
         if lower_clamp is not None:
-            assert df[col].min() >= lower_clamp
+            min_pred_or_lower = df[col].min()
+            if np.isnan(min_pred_or_lower):
+                assert True
+            else:
+                assert min_pred_or_lower >= lower_clamp
+        
         
 
 

--- a/pycaret/tests/test_time_series_setup.py
+++ b/pycaret/tests/test_time_series_setup.py
@@ -307,21 +307,26 @@ def test_clamp_is_enforced_on_predictions(
     cols = ['y_pred','lower','upper']
     for col in cols:
         if upper_clamp is not None:
-            max_pred_or_upper = df[col].max()
-            if np.isnan(max_pred_or_upper):
-                assert True # pass if NaN 
+            if isinstance(upper_clamp, float) or isinstance(upper_clamp, int):
+                max_pred_or_upper = df[col].max()
+                if np.isnan(max_pred_or_upper):
+                    assert True # pass if NaN 
+                else:
+                    assert max_pred_or_upper <= upper_clamp
             else:
-                assert max_pred_or_upper <= upper_clamp
+                assert True # pass if not a float or int, error should be handled in predict()
         else:
             assert True
         if lower_clamp is not None:
-            min_pred_or_lower = df[col].min()
-            if np.isnan(min_pred_or_lower):
-                assert True
+            if isinstance(lower_clamp, float) or isinstance(lower_clamp, int):
+                min_pred_or_lower = df[col].min()
+                if np.isnan(min_pred_or_lower):
+                    assert True 
+                else:
+                    assert min_pred_or_lower >= lower_clamp       
             else:
-                assert min_pred_or_lower >= lower_clamp
-        
-        
+                assert True
+
 
 
 

--- a/pycaret/tests/time_series_test_utils.py
+++ b/pycaret/tests/time_series_test_utils.py
@@ -243,7 +243,9 @@ def _get_clamp_values()->List[Tuple[Optional[Union[int,float]]]]:
         (0.0,0.0), # both 0.0
         (None,2), # same but ints
         (0,0), # same but ints
-        (-1.0,-1.0)
+        (-1.0,-1.0),
+        ('hello',50),
+        (245.5, 'jello')
         ] # negative values 
 
     return test_clamps

--- a/pycaret/tests/time_series_test_utils.py
+++ b/pycaret/tests/time_series_test_utils.py
@@ -1,6 +1,7 @@
 """Helper functions for time series tests
 """
 import random
+from typing import List, Tuple, Optional, Union
 
 import numpy as np  # type: ignore
 import pandas as pd
@@ -230,3 +231,17 @@ def _return_data_big_small():
 #     if mdl_name == "prophet":
 #         data = data.to_timestamp(freq="M")
 #     return data
+
+def _get_clamp_values()->List[Tuple[Optional[Union[int,float]]]]:
+    """
+    creates values for testing clamps
+    """
+    test_clamps = [
+        (None,None), # both none
+        (None,2.0), # upper none
+        (0.0,0.0), # both 0.0
+        (None,2), # same but ints
+        (0,0) # same but ints
+        ] 
+
+    return test_clamps

--- a/pycaret/tests/time_series_test_utils.py
+++ b/pycaret/tests/time_series_test_utils.py
@@ -236,7 +236,7 @@ def _get_clamp_values()->List[Tuple[Optional[Union[int,float]]]]:
     """
     creates values for testing clamps
     """
-    test_clamps = [
+    test_clamps = [ #TODO: Set additional test values
         (None,None), # both none
         (None,2.0), # upper none
         (0.0,0.0), # both 0.0

--- a/pycaret/tests/time_series_test_utils.py
+++ b/pycaret/tests/time_series_test_utils.py
@@ -236,12 +236,14 @@ def _get_clamp_values()->List[Tuple[Optional[Union[int,float]]]]:
     """
     creates values for testing clamps
     """
-    test_clamps = [ #TODO: Set additional test values
+    # (upper_clamp, lower_clamp)
+    test_clamps = [ 
         (None,None), # both none
         (None,2.0), # upper none
         (0.0,0.0), # both 0.0
         (None,2), # same but ints
-        (0,0) # same but ints
-        ] 
+        (0,0), # same but ints
+        (-1.0,-1.0)
+        ] # negative values 
 
     return test_clamps

--- a/pycaret/time_series.py
+++ b/pycaret/time_series.py
@@ -242,8 +242,8 @@ def setup(
         verbose=verbose,
         profile=profile,
         profile_kwargs=profile_kwargs,
-        lower_clamp: Optional[Union[float,int]] = None,
-        upper_clamp: Optional[Union[float,int]] = None,
+        lower_clamp= upper_clamp,
+        upper_clamp= upper_clamp,
     )
 
 

--- a/pycaret/time_series.py
+++ b/pycaret/time_series.py
@@ -242,8 +242,9 @@ def setup(
         verbose=verbose,
         profile=profile,
         profile_kwargs=profile_kwargs,
-        lower_clamp= upper_clamp,
         upper_clamp= upper_clamp,
+        lower_clamp= lower_clamp,
+        
     )
 
 

--- a/pycaret/time_series.py
+++ b/pycaret/time_series.py
@@ -206,7 +206,7 @@ def setup(
 
     upper_clamp: int or float, default = None
         Upper limit (inclusive) of values predicted/forecasted by models.
-        
+
 
     lower_clamp: int or float:, default = None
         Lower limit (inclusive) of values predicted/forecasted by models.
@@ -242,6 +242,8 @@ def setup(
         verbose=verbose,
         profile=profile,
         profile_kwargs=profile_kwargs,
+        lower_clamp: Optional[Union[float,int]] = None,
+        upper_clamp: Optional[Union[float,int]] = None,
     )
 
 

--- a/pycaret/time_series.py
+++ b/pycaret/time_series.py
@@ -55,6 +55,9 @@ def setup(
     verbose: bool = True,
     profile: bool = False,
     profile_kwargs: Dict[str, Any] = None,
+    lower_clamp: Optional[Union[float,int]] = None,
+    upper_clamp: Optional[Union[float,int]] = None,
+
 ):
     """
     This function initializes the training environment and creates the transformation
@@ -199,6 +202,14 @@ def setup(
     profile_kwargs: dict, default = {} (empty dict)
         Dictionary of arguments passed to the ProfileReport method used
         to create the EDA report. Ignored if ``profile`` is False.
+    
+
+    upper_clamp: int or float, default = None
+        Upper limit (inclusive) of values predicted/forecasted by models.
+        
+
+    lower_clamp: int or float:, default = None
+        Lower limit (inclusive) of values predicted/forecasted by models.
 
 
     Returns:


### PR DESCRIPTION
## Related Issue or bug

Info about Issue or bug

Closes #1766

#### Describe the changes you've made

Implemented upper and lower clamp(s) to predictions made in the time series models. This also applies to the prediction `y_pred` and the prediction intervals (`upper` `lower`). These are set to default `None` in `setup()` in the functional api as well as the OOP api.
If invalid values are passed, the `TypeError` is caught, warning is logged and these values are ignored in `TimeSeriesExperiment.predict()`

## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- I have written two tests:
    -  `test_setup_upper_and_lower_clamps_is_non_breaking()` to confirm that this is a non-breaking change to setup.py and that the TimeSeriesExperiment class instances are set as expected.
    - `test_clamp_is_enforced_on_predictions()`Confirms that the clamps are enforced and that errors are not raised when passing in non-numeric values. This also ignores np.nan values where prediction intervals are not supported by models.


#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

NA

## Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
|<b>original screenshot </b> (no clamp)![original](https://user-images.githubusercontent.com/26150780/146673121-563a6a1e-6b24-4619-b59f-5a54d69fbc3e.png)| <b>updated screenshot </b> <br>(lower clamp at 400 and upper clamp at 500) ![clamped](https://user-images.githubusercontent.com/26150780/146673210-06b16839-dfb7-4d5e-a6d7-78ef71dc2b02.png) |