### PR TITLE
[BUG] Fix class_names for plot_tree

### DIFF
--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -7044,8 +7044,12 @@ def plot_model(
             ) as fitted_pipeline_with_model:
                 trees = []
                 feature_names = list(data_X.columns)
-                if _ml_usecase == MLUsecase.CLASSIFICATION and hasattr(prep_pipe.named_steps["dtypes"], "replacement"):
-                    class_names = list(prep_pipe.named_steps["dtypes"].replacement.keys())
+                if _ml_usecase == MLUsecase.CLASSIFICATION and hasattr(
+                    prep_pipe.named_steps["dtypes"], "replacement"
+                ):
+                    class_names = list(
+                        prep_pipe.named_steps["dtypes"].replacement.keys()
+                    )
                 else:
                     class_names = None
                 fitted_tree_estimator = fitted_pipeline_with_model.steps[-1][1]

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -7044,11 +7044,8 @@ def plot_model(
             ) as fitted_pipeline_with_model:
                 trees = []
                 feature_names = list(data_X.columns)
-                if _ml_usecase == MLUsecase.CLASSIFICATION:
-                    class_names = {
-                        v: k
-                        for k, v in prep_pipe.named_steps["dtypes"].replacement.items()
-                    }
+                if _ml_usecase == MLUsecase.CLASSIFICATION and hasattr(prep_pipe.named_steps["dtypes"], "replacement"):
+                    class_names = list(prep_pipe.named_steps["dtypes"].replacement.keys())
                 else:
                     class_names = None
                 fitted_tree_estimator = fitted_pipeline_with_model.steps[-1][1]
@@ -7082,8 +7079,6 @@ def plot_model(
                         trees = fitted_tree_estimator.estimators_
                     except:
                         trees = [fitted_tree_estimator]
-                if _ml_usecase == MLUsecase.CLASSIFICATION:
-                    class_names = list(class_names.values())
                 for i, tree in enumerate(trees):
                     logger.info(f"Plotting tree {i}")
                     plot_tree(


### PR DESCRIPTION
## Related Issuse or bug

Info about Issue or bug 
Closes #1981

#### Describe the changes you've made
The `fit_transform` method of the `DataTypes_Auto_infer` class is a method that encodes and transforms the target into numeric data (0, 1, ..., N) when the target is the label of an object, and if such data has already been passed, the `replacement` attribute is not be made.

https://github.com/pycaret/pycaret/blob/8b3e4f26225667a801cdd2de94d1010730fe10e6/pycaret/internal/preprocess.py#L432

Therefore, an `AttributeError` occurs at L7050 in `table.py`.

https://github.com/pycaret/pycaret/blob/8b3e4f26225667a801cdd2de94d1010730fe10e6/pycaret/internal/tabular.py#L7050

Incidentally, this error also occurs when the objective variable is "object", because "object" is converted to "int64" in L421. 

https://github.com/pycaret/pycaret/blob/8b3e4f26225667a801cdd2de94d1010730fe10e6/pycaret/internal/preprocess.py#L421

To avoid this error, we added one conditional expression.
In addition, we have refactored the creation of `class_names`.
As a result, the class_names of the plot_tree is given as None and is drawn, but I think the user would be happier if the value of class_names was included as in L7058. What do you think?

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## How Has This Been Tested?
Since there was no unit test for `plot_model(plot="tree")`, I built the model with Decision Tree and Random Forest, and then checked if they could be plotted with `plot_model`.
Example code can be found in the issue #1981.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
