### PR TITLE
os.env variable for custom logging level

### DIFF
--- a/pycaret/internal/logging.py
+++ b/pycaret/internal/logging.py
@@ -4,6 +4,7 @@
 
 import logging
 import traceback
+import os
 
 
 def get_logger() -> logging.Logger:
@@ -16,7 +17,8 @@ def get_logger() -> logging.Logger:
 
 def create_logger() -> logging.Logger:
     logger = logging.getLogger("logs")
-    logger.setLevel(logging.DEBUG)
+    level = os.getenv("CUSTOM_LOGGING_LEVEL", "DEBUG")
+    logger.setLevel(level)
 
     # create console handler and set level to debug
     if logger.hasHandlers():


### PR DESCRIPTION
## Related Issues or bug

This fix would allow the user to set a system environment variable to handle logging levels. The variable name is "CUSTOM_LOGGING_LEVEL". If not found in the os.env, the default will be "DEBUG" (which is the current settings) 


#### Describe the changes you've made
Alowed os.environ to get a variable named "CUSTOM_LOGGING_LEVEL" in the pycaret.internal.logging module.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

a local editable installed copy was used to test and set with different logging levels. Test was a success

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

NA

## Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
