### PR TITLE
made unit tests more modular per #2029

### DIFF
--- a/pycaret/internal/pycaret_experiment/time_series_experiment.py
+++ b/pycaret/internal/pycaret_experiment/time_series_experiment.py
@@ -1083,7 +1083,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
         if seasonal_period is None:
 
             index_freq = data_.index.freqstr
-            self.seasonal_period = get_sp_from_str(str_freq = index_freq)
+            self.seasonal_period = get_sp_from_str(str_freq=index_freq)
 
         else:
 
@@ -1093,7 +1093,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
                 )
 
             if isinstance(seasonal_period, str):
-                self.seasonal_period = get_sp_from_str(str_freq = seasonal_period)
+                self.seasonal_period = get_sp_from_str(str_freq=seasonal_period)
             else:
                 self.seasonal_period = seasonal_period
 
@@ -2681,26 +2681,29 @@ class TimeSeriesExperiment(_SupervisedExperiment):
             fig_kwargs=fig_kwargs,
         )
 
-        plot_name = self._available_plots[plot]
-        plot_filename = f"{plot_name}.html"
+        # Sometimes the plot is not successful, such as decomp with RangeIndex.
+        # In such cases, plotting should be bypassed.
+        if fig is not None:
+            plot_name = self._available_plots[plot]
+            plot_filename = f"{plot_name}.html"
 
-        # Per https://github.com/pycaret/pycaret/issues/1699#issuecomment-962460539
-        if save:
-            if not isinstance(save, bool):
-                plot_filename = os.path.join(save, plot_filename)
+            # Per https://github.com/pycaret/pycaret/issues/1699#issuecomment-962460539
+            if save:
+                if not isinstance(save, bool):
+                    plot_filename = os.path.join(save, plot_filename)
 
-            self.logger.info(f"Saving '{plot_filename}'")
-            fig.write_html(plot_filename)
+                self.logger.info(f"Saving '{plot_filename}'")
+                fig.write_html(plot_filename)
 
-            ### Add file name to return object ----
-            return_obj.append(plot_filename)
+                ### Add file name to return object ----
+                return_obj.append(plot_filename)
 
-        elif system:
-            if display_format == "streamlit":
-                st.write(fig)
-            else:
-                fig.show()
-            self.logger.info("Visual Rendered Successfully")
+            elif system:
+                if display_format == "streamlit":
+                    st.write(fig)
+                else:
+                    fig.show()
+                self.logger.info("Visual Rendered Successfully")
 
         ### Add figure and data to return object if required ----
         if return_fig:
@@ -3865,7 +3868,8 @@ def update_additional_scorer_kwargs(
     )
     return additional_scorer_kwargs
 
-def get_sp_from_str(str_freq:str)->int:
+
+def get_sp_from_str(str_freq: str) -> int:
     """Takes the seasonal period as string detects if it is alphaneumeric and returns its integer equivalent. 
         For example - 
         input - '30W'
@@ -3890,20 +3894,20 @@ def get_sp_from_str(str_freq:str)->int:
     """
     str_freq = str_freq.split("-")[0] or str_freq
     # Checking whether the index_freq contains both digit and alphabet
-    if bool(re.search(r'\d', str_freq)):
+    if bool(re.search(r"\d", str_freq)):
         temp = re.compile("([0-9]+)([a-zA-Z]+)")
         res = temp.match(str_freq).groups()
         # separating the digits and alphabets
         if res[1] in SeasonalPeriod.__members__:
             prefix = int(res[0])
             value = SeasonalPeriod[res[1]].value
-            lcm = abs(value*prefix)//math.gcd(value,prefix)
-            seasonal_period = int(lcm/prefix)
+            lcm = abs(value * prefix) // math.gcd(value, prefix)
+            seasonal_period = int(lcm / prefix)
             return seasonal_period
         else:
             raise ValueError(
-            f"Unsupported Period frequency: {str_freq}, valid Period frequency suffixes are: {', '.join(SeasonalPeriod.__members__.keys())}"
-        )
+                f"Unsupported Period frequency: {str_freq}, valid Period frequency suffixes are: {', '.join(SeasonalPeriod.__members__.keys())}"
+            )
     else:
 
         if str_freq in SeasonalPeriod.__members__:

--- a/pycaret/tests/test_time_series_plots.py
+++ b/pycaret/tests/test_time_series_plots.py
@@ -223,9 +223,12 @@ def test_plot_model_customization(data):
         estimator=model, plot="forecast", data_kwargs={"fh": 24}, system=False
     )
 
+
 @pytest.mark.parametrize("data", _data_with_without_period_index)
-def test_plot_model_return_data(data):
-    """Tests whether the return_data parameter of the plot_model function works properly or not
+@pytest.mark.parametrize("plot", _ALL_PLOTS_DATA)
+def test_plot_model_return_data_original_data(data, plot):
+    """Tests whether the return_data parameter of the plot_model function works
+    properly or not for the original data
     """
     exp = TimeSeriesExperiment()
 
@@ -243,17 +246,42 @@ def test_plot_model_return_data(data):
         session_id=42,
         seasonal_period=sp,
     )
-    data_cv = exp.plot_model(
-        plot="cv",return_data=True, system=False
+
+    plot_data = exp.plot_model(plot=plot, return_data=True, system=False)
+    # If plot is successful, it will return a dictionary
+    # If plot is not possible (e.g. decomposition without index), then it will return None
+    assert isinstance(plot_data, dict) or plot_data is None
+
+
+@pytest.mark.parametrize("data", _data_with_without_period_index)
+@pytest.mark.parametrize("model_name", _model_names_for_plots)
+@pytest.mark.parametrize("plot", _ALL_PLOTS_ESTIMATOR)
+def test_plot_model_return_data_estimator(data, model_name, plot):
+    """Tests whether the return_data parameter of the plot_model function works
+    properly or not for the estimator
+    """
+    exp = TimeSeriesExperiment()
+
+    fh = np.arange(1, 13)
+    fold = 2
+
+    sp = 1 if isinstance(data.index, pd.RangeIndex) else None
+
+    exp.setup(
+        data=data,
+        fh=fh,
+        fold=fold,
+        fold_strategy="sliding",
+        verbose=False,
+        session_id=42,
+        seasonal_period=sp,
     )
-    data_train_test_split = exp.plot_model(
-        plot="train_test_split",return_data=True, system=False
+
+    model = exp.create_model(model_name)
+
+    plot_data = exp.plot_model(
+        estimator=model, plot=plot, return_data=True, system=False
     )
-    data_pacf = exp.plot_model(
-        plot="pacf",
-        return_data=True,
-        system=False,
-    )
-    data_decomp_classical = exp.plot_model(
-        plot="decomp_classical",return_data=True, system=False
-    )
+    # If plot is successful, it will return a dictionary
+    # If plot is not possible (e.g. decomposition without index), then it will return None
+    assert isinstance(plot_data, dict) or plot_data is None


### PR DESCRIPTION
## Related Issuse or bug

#2029 

Closes #2029

#### Describe the changes you've made

- Modularization of unit tests for `return_data` argument in `plot_model`
- Also fixed bug with plotting when the plot is not possible (e.g. decomp with RangeIndex). Earlier, it gave a print error message but also an error that stopped execution. This error is resolved now.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit tests have been added and updated. Pass locally


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

