### PR TITLE
revamped optimize_threshold function in classification module

### DIFF
--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -1883,7 +1883,7 @@ def optimize_threshold(
     optimize: str = "Accuracy",
     grid_interval: float = 0.1,
     return_data: bool = False, 
-    plot_kwargs: dict = {},
+    plot_kwargs: Optional[dict] = None,
 ):
 
     """

--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -1880,71 +1880,67 @@ def calibrate_model(
 
 def optimize_threshold(
     estimator,
-    true_positive: int = 0,
-    true_negative: int = 0,
-    false_positive: int = 0,
-    false_negative: int = 0,
-    grid_interval: float = 0.0001,
+    optimize: str = "Accuracy",
+    grid_interval: float = 0.1,
+    return_data: bool = False, 
+    plot_kwargs: dict = {},
 ):
 
     """
-    This function optimizes probability threshold for a given estimator using
-    custom cost function. The function displays a plot of optimized cost as a
-    function of probability threshold between 0.0 to 1.0 and returns the
-    optimized threshold value as a numpy float.
+    This function optimizes probability threshold for a trained classifier. It 
+    iterates over performance metrics at different ``probability_threshold`` with
+    a step size defined in ``grid_interval`` parameter. This function will display
+    a plot of the performance metrics at each probability threshold and returns the
+    best model based on the metric defined under ``optimize`` parameter.
 
 
     Example
     -------
     >>> from pycaret.datasets import get_data
     >>> juice = get_data('juice')
-    >>> from pycaret.classification import *
-    >>> exp_name = setup(data = juice,  target = 'Purchase')
+    >>> experiment_name = setup(data = juice,  target = 'Purchase')
     >>> lr = create_model('lr')
-    >>> optimize_threshold(lr, true_negative = 10, false_negative = -100)
+    >>> best_lr_threshold = optimize_threshold(lr)
 
 
-    estimator: scikit-learn compatible object
-        Trained model object
+    Parameters
+    ----------
+    estimator : object
+        A trained model object should be passed as an estimator.
 
 
-    true_positive: int, default = 0
-        Cost function or returns for true positive.
+    optimize : str, default = 'Accuracy'
+        Metric to be used for selecting best model. 
 
 
-    true_negative: int, default = 0
-        Cost function or returns for true negative.
+    grid_interval : float, default = 0.0001
+        Grid interval for threshold grid search. Default 10 iterations.
 
 
-    false_positive: int, default = 0
-        Cost function or returns for false positive.
+    return_data :  bool, default = False
+        When set to True, data used for visualization is also returned.
 
 
-    false_negative: int, default = 0
-        Cost function or returns for false negative.
+    plot_kwargs :  dict, default = {} (empty dict)
+        Dictionary of arguments passed to the visualizer class.
 
 
-    grid_interval: float, default = 0.0001
-        Grid inerval for threshold grid search. Iteration count = 1.0/grid_interval. Default 10000 iterations.
-
-
-    Returns:
-        numpy.float64
+    Returns
+    -------
+    Trained Model
 
 
     Warnings
     --------
-    - This function is not supported when target is multiclass.
-
+    - This function does not support multiclass classification problems.
     """
 
     return pycaret.internal.tabular.optimize_threshold(
         estimator=estimator,
-        true_positive=true_positive,
-        true_negative=true_negative,
-        false_positive=false_positive,
-        false_negative=false_negative,
+        optimize=optimize,
         grid_interval=grid_interval,
+        return_data=return_data,
+        plot_kwargs=plot_kwargs
     )
 
 

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -8302,20 +8302,19 @@ def calibrate_model(
 
 def optimize_threshold(
     estimator,
-    true_positive: int = 0,
-    true_negative: int = 0,
-    false_positive: int = 0,
-    false_negative: int = 0,
-    grid_interval: float = 0.0001,
+    optimize: str = "Accuracy",
+    grid_interval: float = 0.1,
+    return_data: bool = False, 
+    plot_kwargs: dict = {},
 ):
 
     """
-    This function optimizes probability threshold for a trained model using custom cost
-    function that can be defined using combination of True Positives, True Negatives,
-    False Positives (also known as Type I error), and False Negatives (Type II error).
+    This function optimizes probability threshold for a trained classifier. It 
+    iterates over performance metrics at different ``probability_threshold`` with
+    a step size defined in ``grid_interval`` parameter. This function will display
+    a plot of the performance metrics at each probability threshold and returns the
+    best model based on the metric defined under ``optimize`` parameter.
 
-    This function returns a plot of optimized cost as a function of probability
-    threshold between 0 to 100.
 
     Example
     -------
@@ -8323,40 +8322,39 @@ def optimize_threshold(
     >>> juice = get_data('juice')
     >>> experiment_name = setup(data = juice,  target = 'Purchase')
     >>> lr = create_model('lr')
-    >>> optimize_threshold(lr, true_negative = 10, false_negative = -100)
+    >>> best_lr_threshold = optimize_threshold(lr)
 
-    This will return a plot of optimized cost as a function of probability threshold.
 
     Parameters
     ----------
     estimator : object
         A trained model object should be passed as an estimator.
 
-    true_positive : int, default = 0
-        Cost function or returns when prediction is true positive.
 
-    true_negative : int, default = 0
-        Cost function or returns when prediction is true negative.
+    optimize : str, default = 'Accuracy'
+        Metric to be used for selecting best model. 
 
-    false_positive : int, default = 0
-        Cost function or returns when prediction is false positive.
-
-    false_negative : int, default = 0
-        Cost function or returns when prediction is false negative.
 
     grid_interval : float, default = 0.0001
-        Grid inerval for threshold grid search. Iteration count = 1.0/grid_interval. Default 10000 iterations.
+        Grid interval for threshold grid search. Default 10 iterations.
+
+
+    return_data :  bool, default = False
+        When set to True, data used for visualization is also returned.
+
+
+    plot_kwargs :  dict, default = {} (empty dict)
+        Dictionary of arguments passed to the visualizer class.
+
 
     Returns
     -------
-    Visual_Plot
-        Prints the visual plot.
+    Trained Model
+
 
     Warnings
     --------
-    - This function is not supported for multiclass problems.
-
-
+    - This function does not support multiclass classification problems.
     """
 
     function_params_str = ", ".join([f"{k}={v}" for k, v in locals().items()])
@@ -8391,139 +8389,71 @@ def optimize_threshold(
                 "Estimator doesn't support predict_proba function and cannot be used in optimize_threshold()."
             )
 
-    # check cost function type
     allowed_types = [int, float]
-
-    if type(true_positive) not in allowed_types:
-        raise TypeError("true_positive parameter only accepts float or integer value.")
-
-    if type(true_negative) not in allowed_types:
-        raise TypeError("true_negative parameter only accepts float or integer value.")
-
-    if type(false_positive) not in allowed_types:
-        raise TypeError("false_positive parameter only accepts float or integer value.")
-
-    if type(false_negative) not in allowed_types:
-        raise TypeError("false_negative parameter only accepts float or integer value.")
 
     if type(grid_interval) not in allowed_types or grid_interval > 1.0:
         raise TypeError("grid_interval should be float and less than 1.0.")
+
+    if isinstance(optimize, str):
+        # checking optimize parameter
+        optimize = _get_metric(optimize).display_name
+        if optimize is None:
+            raise ValueError(
+                "Optimize method not supported. See docstring for list of available parameters."
+            )
 
     """
     ERROR HANDLING ENDS HERE
     """
 
-    # define model as estimator
-    model = get_estimator_from_meta_estimator(estimator)
+    logger.info("defining variables")
+    # get estimator name
+    model_name = _get_model_name(estimator)
 
-    model_name = _get_model_name(model)
+    # defines grid
+    grid = np.arange(0, 1.0001, grid_interval)
 
-    # generate predictions and store actual on y_test in numpy array
-    actual = np.array(y_test)
+    # defines empty list
+    models_by_threshold = []
+    results_df = []
 
-    predicted = model.predict_proba(X_test)
-    predicted = predicted[:, 1]
-
-    """
-    internal function to calculate loss starts here
-    """
-
-    logger.info("Defining loss function")
-
-    def calculate_loss(
-        actual,
-        predicted,
-        tp_cost=true_positive,
-        tn_cost=true_negative,
-        fp_cost=false_positive,
-        fn_cost=false_negative,
-    ):
-
-        # true positives
-        tp = predicted + actual
-        tp = np.where(tp == 2, 1, 0)
-        tp = tp.sum()
-
-        # true negative
-        tn = predicted + actual
-        tn = np.where(tn == 0, 1, 0)
-        tn = tn.sum()
-
-        # false positive
-        fp = (predicted > actual).astype(int)
-        fp = np.where(fp == 1, 1, 0)
-        fp = fp.sum()
-
-        # false negative
-        fn = (predicted < actual).astype(int)
-        fn = np.where(fn == 1, 1, 0)
-        fn = fn.sum()
-
-        total_cost = (tp_cost * tp) + (tn_cost * tn) + (fp_cost * fp) + (fn_cost * fn)
-
-        return total_cost
-
-    """
-    internal function to calculate loss ends here
-    """
-
-    grid = np.arange(0, 1, grid_interval)
-
+    logger.info("starting optimization loop")
     # loop starts here
-
-    cost = []
-    # global optimize_results
-
-    logger.info("Iteration starts at 0")
-
     for i in grid:
+        model = create_model_supervised(estimator, verbose=False, system=False, probability_threshold=i)
+        try:
+            models_by_threshold.append(model[0])
+        except:
+            models_by_threshold.append(model)
+        model_results = pull().loc[['Mean']]
+        model_results['probability_threshold'] = i
+        results_df.append(model_results)
 
-        pred_prob = (predicted >= i).astype(int)
-        cost.append(calculate_loss(actual, pred_prob))
+    logger.info("optimization loop finished successfully")
 
-    optimize_results = pd.DataFrame(
-        {"Probability Threshold": grid, "Cost Function": cost}
-    )
-    fig = px.line(
-        optimize_results,
-        x="Probability Threshold",
-        y="Cost Function",
-        line_shape="linear",
-    )
-    fig.update_layout(plot_bgcolor="rgb(245,245,245)")
-    title = f"{model_name} Probability Threshold Optimization"
+    results_concat = pd.concat(results_df, axis=0)
+    results_concat_melted = results_concat.melt(id_vars = ['probability_threshold'], value_vars=list(results_concat.columns[:-1]))
+    optimized_metric_index = np.array(results_concat_melted[results_concat_melted['variable'] == optimize]['value']).argmax()
+    best_model_by_metric = models_by_threshold[optimized_metric_index]
 
-    # calculate vertical line
-    y0 = optimize_results["Cost Function"].min()
-    y1 = optimize_results["Cost Function"].max()
-    x0 = optimize_results.sort_values(by="Cost Function", ascending=False).iloc[0][0]
-    x1 = x0
+    logger.info("plotting optimizartion threshold using plotly")
 
-    t = x0
-    if html_param:
+    # plotting threshold
+    import plotly.express as px
+    title = str(model_name) + " Probability Threshold Optimization (default = 0.5) "
+    fig = px.line(results_concat_melted, x="probability_threshold", y="value", title = title,\
+                    color='variable', **plot_kwargs)
+    logger.info("Figure ready for render")
+    fig.show()
 
-        fig.add_shape(
-            dict(
-                type="line", x0=x0, y0=y0, x1=x1, y1=y1, line=dict(color="red", width=2)
-            )
-        )
-        fig.update_layout(
-            title={
-                "text": title,
-                "y": 0.95,
-                "x": 0.45,
-                "xanchor": "center",
-                "yanchor": "top",
-            }
-        )
-        logger.info("Figure ready for render")
-        fig.show()
-    print(f"Optimized Probability Threshold: {t} | Optimized Cost Function: {y1}")
-    logger.info(
-        "optimize_threshold() succesfully completed......................................"
-    )
-
-    return float(t)
+    logger.info("returning model with best metric")
+    if return_data:
+        logger.info("also returning data as return_data = True")
+        logger.info("optimize_threshold() succesfully completed......................................")
+        return (results_concat_melted, best_model_by_metric)
+    else:
+        logger.info("optimize_threshold() succesfully completed......................................")
+        return best_model_by_metric
 
 
 def assign_model(

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -8305,7 +8305,7 @@ def optimize_threshold(
     optimize: str = "Accuracy",
     grid_interval: float = 0.1,
     return_data: bool = False, 
-    plot_kwargs: dict = {},
+    plot_kwargs: Optional[dict] = None,
 ):
 
     """
@@ -8396,11 +8396,12 @@ def optimize_threshold(
 
     if isinstance(optimize, str):
         # checking optimize parameter
-        optimize = _get_metric(optimize).display_name
+        optimize = _get_metric(optimize)
         if optimize is None:
             raise ValueError(
                 "Optimize method not supported. See docstring for list of available parameters."
             )
+        optimize = optimize.display_name
 
     """
     ERROR HANDLING ENDS HERE
@@ -8436,11 +8437,12 @@ def optimize_threshold(
     optimized_metric_index = np.array(results_concat_melted[results_concat_melted['variable'] == optimize]['value']).argmax()
     best_model_by_metric = models_by_threshold[optimized_metric_index]
 
-    logger.info("plotting optimizartion threshold using plotly")
+    logger.info("plotting optimization threshold using plotly")
 
     # plotting threshold
     import plotly.express as px
-    title = str(model_name) + " Probability Threshold Optimization (default = 0.5) "
+    title = f"{model_name} Probability Threshold Optimization (default = 0.5)"
+    plot_kwargs = plot_kwargs or {}
     fig = px.line(results_concat_melted, x="probability_threshold", y="value", title = title,\
                     color='variable', **plot_kwargs)
     logger.info("Figure ready for render")

--- a/pycaret/tests/test_optimize_threshold.py
+++ b/pycaret/tests/test_optimize_threshold.py
@@ -1,0 +1,37 @@
+import os, sys
+
+sys.path.insert(0, os.path.abspath(".."))
+
+import pandas as pd
+import numpy as np
+import pytest
+import pycaret.classification
+import pycaret.datasets
+
+
+def test_optimize_threshold():
+
+    # loading dataset
+    data = pycaret.datasets.get_data("blood")
+
+    # initialize setup
+    clf1 = pycaret.classification.setup(
+        data,
+        target="Class",
+        silent=True,
+        html=False,
+        n_jobs=1,
+    )
+
+    # train model
+    lr = pycaret.classification.create_model("lr")
+
+    # optimize threshold
+    optimized_data, optimized_model = pycaret.classification.optimize_threshold(
+        lr, return_data=True
+    )
+    assert isinstance(optimized_data, pd.core.frame.DataFrame)
+
+
+if __name__ == "__main__":
+    test_optimize_threshold()


### PR DESCRIPTION
Completely revamped `optimize_threshold` function. Only impact `pycaret.classification` module.

Prior to this revamp, the `optimize_threshold` function uses metrics on the hold-out set to determine the best metric. 

It also required `true_positive`, `false_positive`, `true_negative`, and `false_negative` to be entered as a parameter to the `optimize_threshold` function.

This revamp makes use of the `probability_threshold` parameter in the `create_model` (added in 2.3.5) and also uses the metrics from the metric container as opposed to asking the user to define tp,fp,tn,fn. It also works with custom metrics added to pycaret through the `add_metric` function.

Finally, previously we were only returning the float (Example: 0.66) at which point the custom cost function is optimized. Now we are returning the final object which is a PyCaret's custom class.

![image](https://user-images.githubusercontent.com/54699234/148702215-437d3f3f-fe84-4b6c-8f48-2c42f30473f8.png)

The only thing pending is the display monitor, as the loop runs it does not show anything and sometimes on the bigger dataset, this could be a while, especially if `grid_interval` is a very low number. 

@Yard1 See if you can quickly add a display monitor. I couldn't figure out the custom class thing. Sorry.