### PR TITLE
resolving bug when index is not ordinal number

### DIFF
--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -10419,7 +10419,7 @@ def check_fairness(estimator, sensitive_features: list, plot_kwargs: dict = {}):
 
     y_pred = estimator.predict(get_config("X_test"))
     y_true = np.array(get_config("y_test"))
-    X_test_before_transform = get_config("data_before_preprocess").iloc[
+    X_test_before_transform = get_config("data_before_preprocess").loc[
         get_config("X_test").index
     ]
 


### PR DESCRIPTION
Resolving bug #2054

```
from pycaret.datasets import get_data
income = get_data('income')
```
```
import random
income.index=random.sample(range(200000, 300000), income.shape[0])
```
```
from pycaret.classification import *
exp_name = setup(data = income,  target = 'income >50K')
lightgbm = create_model('lightgbm')
lightgbm_fairness = check_fairness(lightgbm, sensitive_features = ['sex', 'race'])
```

![image](https://user-images.githubusercontent.com/2202483/149336185-5495dc53-e010-41fc-991a-422fc23c4bff.png)
