### PR TITLE
fix for COV_PROB metric

### DIFF
--- a/pycaret/internal/pycaret_experiment/tabular_experiment.py
+++ b/pycaret/internal/pycaret_experiment/tabular_experiment.py
@@ -1847,11 +1847,11 @@ class _TabularExperiment(_PyCaretExperiment):
                 # at least 2 values
                 self.remove_metric("R2")
 
-            #### Remove INPI when enforce_pi is False ----
+            #### Remove COV_PROB when enforce_pi is False ----
             # User can add it manually if they want when enforce_pi is set to False.
             # Refer: https://github.com/pycaret/pycaret/issues/1900
-            if not self.enforce_pi and "inpi" in self._get_metrics():
-                self.remove_metric("INPI")
+            if not self.enforce_pi and "cov_prob" in self._get_metrics():
+                self.remove_metric("COV_PROB")
 
         self.logger.info(
             f"self.master_model_container: {len(self.master_model_container)}"


### PR DESCRIPTION
## Related Issuse or bug

Fix for #1914


#### Describe the changes you've made

`COV_PROB` was being displayed as a metric even when `enforce_pi = False`. Added fix so this is only displayed when `enforce_pi = True`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Existing unit tests pass


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

