### PR TITLE
Bugfix for displaying inferred datatypes

### DIFF
--- a/pycaret/internal/preprocess.py
+++ b/pycaret/internal/preprocess.py
@@ -319,7 +319,14 @@ class DataTypes_Auto_infer(BaseEstimator, TransformerMixin):
             # if we added the dummy  target column , then drop it
             dt_print_out.drop(index="dummy_target", errors="ignore", inplace=True)
 
+            # increase maximum displayed rows to 1000
+            pd.set_option("display.max_rows", 1000)
+
             display(dt_print_out[["Data Type"]])
+
+            # reset pandas option
+            pd.reset_option("display.max_rows")
+            
             self.response = input()
 
             if self.response in [


### PR DESCRIPTION
This is my first contribution to a git project, I hope it's all ok.
## Related Issuse or bug



https://pycaret.slack.com/archives/C01HTQAAJER/p1642087232044700

Info about Issue or bug

If the dataset contains more than 60 columns, then the `setup()` function cannot display all inferred datatypes, because the intermediate output of the inferred datatypes is truncated.

Increasing the output with `pd.options.display.max_rows` does not work because the maximum number of rows is reset within the execution of `setup()`.

#### Describe the changes you've made

I have found the place in the code of `preprocess.py` where `display(dt_print_out[["Data Type"]])`
is executed and the inferred datatypes will be given out. I added 
`pd.set_option("display.max_rows", 1000)` before the execution of the `display(dt_print_out[["Data Type"]])` function and 
`pd.reset_option("display.max_rows")` after the excecution.


## Type of change

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Passes all existing unittests.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] ~~New~~ and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

I don't think the missing items on the checklist need to be ticked off, but if there is anything that needs to be done let me know.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
![Before](https://user-images.githubusercontent.com/89379061/151021693-63d9af2f-f09f-4d56-a438-27aa448f03ba.PNG) | ![After](https://user-images.githubusercontent.com/89379061/151021852-2a5681a3-c721-4a8f-b8aa-6e791ff3f0b1.PNG)

