### PR TITLE
Fix for breaking release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
 
     steps:
       - uses: actions/checkout@v2
@@ -205,7 +205,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/requirements-ts.txt
+++ b/requirements-ts.txt
@@ -1,4 +1,4 @@
 statsmodels~=0.12.1
-sktime>=0.9.0
+sktime>=0.9.0, <0.10.0
 tbats>=1.1.0
 pmdarima>=1.8.0


### PR DESCRIPTION
## Related Issues or bug

The new version of sktime 0.10.0 broke the pycaret release. Fixed the version so that it only takes 0.9.x for now.