### PR TITLE
Provide option to enforce models that support exogenous variables only

### DIFF
--- a/pycaret/containers/models/time_series.py
+++ b/pycaret/containers/models/time_series.py
@@ -45,10 +45,7 @@ from pycaret.utils.datetime import (
     coerce_period_to_datetime_index,
 )
 from pycaret.utils.time_series import TSModelTypes
-from pycaret.utils.time_series.forecasting.models import (
-    disable_pred_int_enforcement,
-    disable_exogenous_enforcement,
-)
+from pycaret.utils.time_series.forecasting.models import _check_enforcements
 
 
 class TimeSeriesContainer(ModelContainer):
@@ -254,16 +251,7 @@ class NaiveContainer(TimeSeriesContainer):
 
         #### Disable container if certain features are not supported but enforced ----
         dummy = NaiveForecaster()
-        self.active = disable_pred_int_enforcement(
-            forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
-        )
-        if not self.active:
-            return
-        self.active = disable_exogenous_enforcement(
-            forecaster=dummy,
-            enforce_exogenous=globals_dict["enforce_exogenous"],
-            exp_has_exogenous=globals_dict["exogenous_type"],
-        )
+        self.active = _check_enforcements(forecaster=dummy, globals_dict=globals_dict)
         if not self.active:
             return
 
@@ -324,17 +312,7 @@ class GrandMeansContainer(TimeSeriesContainer):
 
         #### Disable container if certain features are not supported but enforced ----
         dummy = NaiveForecaster()
-        self.active = disable_pred_int_enforcement(
-            forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
-        )
-        if not self.active:
-            return
-
-        self.active = disable_exogenous_enforcement(
-            forecaster=dummy,
-            enforce_exogenous=globals_dict["enforce_exogenous"],
-            exp_has_exogenous=globals_dict["exogenous_type"],
-        )
+        self.active = _check_enforcements(forecaster=dummy, globals_dict=globals_dict)
         if not self.active:
             return
 
@@ -395,17 +373,7 @@ class SeasonalNaiveContainer(TimeSeriesContainer):
 
         #### Disable container if certain features are not supported but enforced ----
         dummy = NaiveForecaster()
-        self.active = disable_pred_int_enforcement(
-            forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
-        )
-        if not self.active:
-            return
-
-        self.active = disable_exogenous_enforcement(
-            forecaster=dummy,
-            enforce_exogenous=globals_dict["enforce_exogenous"],
-            exp_has_exogenous=globals_dict["exogenous_type"],
-        )
+        self.active = _check_enforcements(forecaster=dummy, globals_dict=globals_dict)
         if not self.active:
             return
 
@@ -465,17 +433,7 @@ class PolyTrendContainer(TimeSeriesContainer):
 
         #### Disable container if certain features are not supported but enforced ----
         dummy = PolynomialTrendForecaster()
-        self.active = disable_pred_int_enforcement(
-            forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
-        )
-        if not self.active:
-            return
-
-        self.active = disable_exogenous_enforcement(
-            forecaster=dummy,
-            enforce_exogenous=globals_dict["enforce_exogenous"],
-            exp_has_exogenous=globals_dict["exogenous_type"],
-        )
+        self.active = _check_enforcements(forecaster=dummy, globals_dict=globals_dict)
         if not self.active:
             return
 
@@ -528,17 +486,7 @@ class ArimaContainer(TimeSeriesContainer):
 
         #### Disable container if certain features are not supported but enforced ----
         dummy = ARIMA()
-        self.active = disable_pred_int_enforcement(
-            forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
-        )
-        if not self.active:
-            return
-
-        self.active = disable_exogenous_enforcement(
-            forecaster=dummy,
-            enforce_exogenous=globals_dict["enforce_exogenous"],
-            exp_has_exogenous=globals_dict["exogenous_type"],
-        )
+        self.active = _check_enforcements(forecaster=dummy, globals_dict=globals_dict)
         if not self.active:
             return
 
@@ -699,17 +647,7 @@ class AutoArimaContainer(TimeSeriesContainer):
 
         #### Disable container if certain features are not supported but enforced ----
         dummy = AutoARIMA()
-        self.active = disable_pred_int_enforcement(
-            forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
-        )
-        if not self.active:
-            return
-
-        self.active = disable_exogenous_enforcement(
-            forecaster=dummy,
-            enforce_exogenous=globals_dict["enforce_exogenous"],
-            exp_has_exogenous=globals_dict["exogenous_type"],
-        )
+        self.active = _check_enforcements(forecaster=dummy, globals_dict=globals_dict)
         if not self.active:
             return
 
@@ -781,17 +719,7 @@ class ExponentialSmoothingContainer(TimeSeriesContainer):
 
         #### Disable container if certain features are not supported but enforced ----
         dummy = ExponentialSmoothing()
-        self.active = disable_pred_int_enforcement(
-            forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
-        )
-        if not self.active:
-            return
-
-        self.active = disable_exogenous_enforcement(
-            forecaster=dummy,
-            enforce_exogenous=globals_dict["enforce_exogenous"],
-            exp_has_exogenous=globals_dict["exogenous_type"],
-        )
+        self.active = _check_enforcements(forecaster=dummy, globals_dict=globals_dict)
         if not self.active:
             return
 
@@ -923,17 +851,7 @@ class CrostonContainer(TimeSeriesContainer):
 
         #### Disable container if certain features are not supported but enforced ----
         dummy = Croston()
-        self.active: bool = disable_pred_int_enforcement(
-            forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
-        )
-        if not self.active:
-            return
-
-        self.active = disable_exogenous_enforcement(
-            forecaster=dummy,
-            enforce_exogenous=globals_dict["enforce_exogenous"],
-            exp_has_exogenous=globals_dict["exogenous_type"],
-        )
+        self.active = _check_enforcements(forecaster=dummy, globals_dict=globals_dict)
         if not self.active:
             return
 
@@ -978,17 +896,7 @@ class ETSContainer(TimeSeriesContainer):
 
         #### Disable container if certain features are not supported but enforced ----
         dummy = AutoETS()
-        self.active = disable_pred_int_enforcement(
-            forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
-        )
-        if not self.active:
-            return
-
-        self.active = disable_exogenous_enforcement(
-            forecaster=dummy,
-            enforce_exogenous=globals_dict["enforce_exogenous"],
-            exp_has_exogenous=globals_dict["exogenous_type"],
-        )
+        self.active = _check_enforcements(forecaster=dummy, globals_dict=globals_dict)
         if not self.active:
             return
 
@@ -1065,17 +973,7 @@ class ThetaContainer(TimeSeriesContainer):
 
         #### Disable container if certain features are not supported but enforced ----
         dummy = ThetaForecaster()
-        self.active = disable_pred_int_enforcement(
-            forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
-        )
-        if not self.active:
-            return
-
-        self.active = disable_exogenous_enforcement(
-            forecaster=dummy,
-            enforce_exogenous=globals_dict["enforce_exogenous"],
-            exp_has_exogenous=globals_dict["exogenous_type"],
-        )
+        self.active = _check_enforcements(forecaster=dummy, globals_dict=globals_dict)
         if not self.active:
             return
 
@@ -1168,17 +1066,7 @@ class TBATSContainer(TimeSeriesContainer):
 
         #### Disable container if certain features are not supported but enforced ----
         dummy = TBATS()
-        self.active = disable_pred_int_enforcement(
-            forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
-        )
-        if not self.active:
-            return
-
-        self.active = disable_exogenous_enforcement(
-            forecaster=dummy,
-            enforce_exogenous=globals_dict["enforce_exogenous"],
-            exp_has_exogenous=globals_dict["exogenous_type"],
-        )
+        self.active = _check_enforcements(forecaster=dummy, globals_dict=globals_dict)
         if not self.active:
             return
 
@@ -1246,17 +1134,7 @@ class BATSContainer(TimeSeriesContainer):
 
         #### Disable container if certain features are not supported but enforced ----
         dummy = BATS()
-        self.active = disable_pred_int_enforcement(
-            forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
-        )
-        if not self.active:
-            return
-
-        self.active = disable_exogenous_enforcement(
-            forecaster=dummy,
-            enforce_exogenous=globals_dict["enforce_exogenous"],
-            exp_has_exogenous=globals_dict["exogenous_type"],
-        )
+        self.active = _check_enforcements(forecaster=dummy, globals_dict=globals_dict)
         if not self.active:
             return
 
@@ -1324,17 +1202,7 @@ class ProphetContainer(TimeSeriesContainer):
 
         #### Disable container if certain features are not supported but enforced ----
         dummy = Prophet()
-        self.active = disable_pred_int_enforcement(
-            forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
-        )
-        if not self.active:
-            return
-
-        self.active = disable_exogenous_enforcement(
-            forecaster=dummy,
-            enforce_exogenous=globals_dict["enforce_exogenous"],
-            exp_has_exogenous=globals_dict["exogenous_type"],
-        )
+        self.active = _check_enforcements(forecaster=dummy, globals_dict=globals_dict)
         if not self.active:
             return
 
@@ -1432,17 +1300,7 @@ class CdsDtContainer(TimeSeriesContainer):
 
         #### Disable container if certain features are not supported but enforced ----
         dummy = BaseCdsDtForecaster(regressor=self.regressor)
-        self.active = disable_pred_int_enforcement(
-            forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
-        )
-        if not self.active:
-            return
-
-        self.active = disable_exogenous_enforcement(
-            forecaster=dummy,
-            enforce_exogenous=globals_dict["enforce_exogenous"],
-            exp_has_exogenous=globals_dict["exogenous_type"],
-        )
+        self.active = _check_enforcements(forecaster=dummy, globals_dict=globals_dict)
         if not self.active:
             return
 

--- a/pycaret/containers/models/time_series.py
+++ b/pycaret/containers/models/time_series.py
@@ -16,7 +16,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np  # type: ignore
 import pandas as pd
-from sklearn.utils.validation import check_is_fitted  # type: ignore
 from sktime.forecasting.base import BaseForecaster  # type: ignore
 from sktime.forecasting.base._sktime import DEFAULT_ALPHA  # type: ignore
 from sktime.forecasting.compose import (  # type: ignore
@@ -46,6 +45,10 @@ from pycaret.utils.datetime import (
     coerce_period_to_datetime_index,
 )
 from pycaret.utils.time_series import TSModelTypes
+from pycaret.utils.time_series.forecasting.models import (
+    disable_pred_int_enforcement,
+    disable_exogenous_enforcement,
+)
 
 
 class TimeSeriesContainer(ModelContainer):
@@ -225,28 +228,6 @@ class TimeSeriesContainer(ModelContainer):
         tune_distributions: Dict[str, List[Any]] = {}
         return tune_distributions
 
-    def disable_pred_int_enforcement(self, forecaster, enforce_pi: bool) -> bool:
-        """Checks to see if prediction interbal should be enforced. If it should
-        but the forecaster does not support it, the container will be disabled
-
-        Parameters
-        ----------
-        forecaster : `sktime` compatible forecaster
-            forecaster to check for prediction interval capability.
-            Can be a dummy object of the forecasting class
-        enforce_pi : bool
-            Should prediction interval be enforced?
-
-        Returns
-        -------
-        bool
-            True if user wants to enforce prediction interval and forecaster
-            supports it. False otherwise.
-        """
-        if enforce_pi and not forecaster.get_tag("capability:pred_int"):
-            return False
-        return True
-
 
 #########################
 #### BASELINE MODELS ####
@@ -271,9 +252,17 @@ class NaiveContainer(TimeSeriesContainer):
 
         from sktime.forecasting.naive import NaiveForecaster  # type: ignore
 
+        #### Disable container if certain features are not supported but enforced ----
         dummy = NaiveForecaster()
-        self.active = self.disable_pred_int_enforcement(
+        self.active = disable_pred_int_enforcement(
             forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
+        )
+        if not self.active:
+            return
+        self.active = disable_exogenous_enforcement(
+            forecaster=dummy,
+            enforce_exogenous=globals_dict["enforce_exogenous"],
+            exp_has_exogenous=globals_dict["exogenous_type"],
         )
         if not self.active:
             return
@@ -333,9 +322,18 @@ class GrandMeansContainer(TimeSeriesContainer):
 
         from sktime.forecasting.naive import NaiveForecaster  # type: ignore
 
+        #### Disable container if certain features are not supported but enforced ----
         dummy = NaiveForecaster()
-        self.active = self.disable_pred_int_enforcement(
+        self.active = disable_pred_int_enforcement(
             forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
+        )
+        if not self.active:
+            return
+
+        self.active = disable_exogenous_enforcement(
+            forecaster=dummy,
+            enforce_exogenous=globals_dict["enforce_exogenous"],
+            exp_has_exogenous=globals_dict["exogenous_type"],
         )
         if not self.active:
             return
@@ -395,9 +393,18 @@ class SeasonalNaiveContainer(TimeSeriesContainer):
 
         from sktime.forecasting.naive import NaiveForecaster  # type: ignore
 
+        #### Disable container if certain features are not supported but enforced ----
         dummy = NaiveForecaster()
-        self.active = self.disable_pred_int_enforcement(
+        self.active = disable_pred_int_enforcement(
             forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
+        )
+        if not self.active:
+            return
+
+        self.active = disable_exogenous_enforcement(
+            forecaster=dummy,
+            enforce_exogenous=globals_dict["enforce_exogenous"],
+            exp_has_exogenous=globals_dict["exogenous_type"],
         )
         if not self.active:
             return
@@ -456,9 +463,18 @@ class PolyTrendContainer(TimeSeriesContainer):
 
         from sktime.forecasting.trend import PolynomialTrendForecaster  # type: ignore
 
+        #### Disable container if certain features are not supported but enforced ----
         dummy = PolynomialTrendForecaster()
-        self.active = self.disable_pred_int_enforcement(
+        self.active = disable_pred_int_enforcement(
             forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
+        )
+        if not self.active:
+            return
+
+        self.active = disable_exogenous_enforcement(
+            forecaster=dummy,
+            enforce_exogenous=globals_dict["enforce_exogenous"],
+            exp_has_exogenous=globals_dict["exogenous_type"],
         )
         if not self.active:
             return
@@ -510,9 +526,18 @@ class ArimaContainer(TimeSeriesContainer):
 
         from sktime.forecasting.arima import ARIMA  # type: ignore
 
+        #### Disable container if certain features are not supported but enforced ----
         dummy = ARIMA()
-        self.active = self.disable_pred_int_enforcement(
+        self.active = disable_pred_int_enforcement(
             forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
+        )
+        if not self.active:
+            return
+
+        self.active = disable_exogenous_enforcement(
+            forecaster=dummy,
+            enforce_exogenous=globals_dict["enforce_exogenous"],
+            exp_has_exogenous=globals_dict["exogenous_type"],
         )
         if not self.active:
             return
@@ -672,9 +697,18 @@ class AutoArimaContainer(TimeSeriesContainer):
 
         from sktime.forecasting.arima import AutoARIMA  # type: ignore
 
+        #### Disable container if certain features are not supported but enforced ----
         dummy = AutoARIMA()
-        self.active = self.disable_pred_int_enforcement(
+        self.active = disable_pred_int_enforcement(
             forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
+        )
+        if not self.active:
+            return
+
+        self.active = disable_exogenous_enforcement(
+            forecaster=dummy,
+            enforce_exogenous=globals_dict["enforce_exogenous"],
+            exp_has_exogenous=globals_dict["exogenous_type"],
         )
         if not self.active:
             return
@@ -745,9 +779,18 @@ class ExponentialSmoothingContainer(TimeSeriesContainer):
             ExponentialSmoothing,  # type: ignore
         )
 
+        #### Disable container if certain features are not supported but enforced ----
         dummy = ExponentialSmoothing()
-        self.active = self.disable_pred_int_enforcement(
+        self.active = disable_pred_int_enforcement(
             forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
+        )
+        if not self.active:
+            return
+
+        self.active = disable_exogenous_enforcement(
+            forecaster=dummy,
+            enforce_exogenous=globals_dict["enforce_exogenous"],
+            exp_has_exogenous=globals_dict["exogenous_type"],
         )
         if not self.active:
             return
@@ -878,13 +921,19 @@ class CrostonContainer(TimeSeriesContainer):
 
         from sktime.forecasting.croston import Croston  # type: ignore
 
+        #### Disable container if certain features are not supported but enforced ----
         dummy = Croston()
-        # check if pi is enforced.
-        self.active: bool = self.disable_pred_int_enforcement(
+        self.active: bool = disable_pred_int_enforcement(
             forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
         )
+        if not self.active:
+            return
 
-        # if not, make the model unavailiable
+        self.active = disable_exogenous_enforcement(
+            forecaster=dummy,
+            enforce_exogenous=globals_dict["enforce_exogenous"],
+            exp_has_exogenous=globals_dict["exogenous_type"],
+        )
         if not self.active:
             return
 
@@ -927,9 +976,18 @@ class ETSContainer(TimeSeriesContainer):
 
         from sktime.forecasting.ets import AutoETS  # type: ignore
 
+        #### Disable container if certain features are not supported but enforced ----
         dummy = AutoETS()
-        self.active = self.disable_pred_int_enforcement(
+        self.active = disable_pred_int_enforcement(
             forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
+        )
+        if not self.active:
+            return
+
+        self.active = disable_exogenous_enforcement(
+            forecaster=dummy,
+            enforce_exogenous=globals_dict["enforce_exogenous"],
+            exp_has_exogenous=globals_dict["exogenous_type"],
         )
         if not self.active:
             return
@@ -1005,9 +1063,18 @@ class ThetaContainer(TimeSeriesContainer):
 
         from sktime.forecasting.theta import ThetaForecaster  # type: ignore
 
+        #### Disable container if certain features are not supported but enforced ----
         dummy = ThetaForecaster()
-        self.active = self.disable_pred_int_enforcement(
+        self.active = disable_pred_int_enforcement(
             forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
+        )
+        if not self.active:
+            return
+
+        self.active = disable_exogenous_enforcement(
+            forecaster=dummy,
+            enforce_exogenous=globals_dict["enforce_exogenous"],
+            exp_has_exogenous=globals_dict["exogenous_type"],
         )
         if not self.active:
             return
@@ -1099,9 +1166,18 @@ class TBATSContainer(TimeSeriesContainer):
             self.active = False
             return
 
+        #### Disable container if certain features are not supported but enforced ----
         dummy = TBATS()
-        self.active = self.disable_pred_int_enforcement(
+        self.active = disable_pred_int_enforcement(
             forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
+        )
+        if not self.active:
+            return
+
+        self.active = disable_exogenous_enforcement(
+            forecaster=dummy,
+            enforce_exogenous=globals_dict["enforce_exogenous"],
+            exp_has_exogenous=globals_dict["exogenous_type"],
         )
         if not self.active:
             return
@@ -1168,9 +1244,18 @@ class BATSContainer(TimeSeriesContainer):
             self.active = False
             return
 
+        #### Disable container if certain features are not supported but enforced ----
         dummy = BATS()
-        self.active = self.disable_pred_int_enforcement(
+        self.active = disable_pred_int_enforcement(
             forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
+        )
+        if not self.active:
+            return
+
+        self.active = disable_exogenous_enforcement(
+            forecaster=dummy,
+            enforce_exogenous=globals_dict["enforce_exogenous"],
+            exp_has_exogenous=globals_dict["exogenous_type"],
         )
         if not self.active:
             return
@@ -1237,9 +1322,18 @@ class ProphetContainer(TimeSeriesContainer):
 
         from sktime.forecasting.fbprophet import Prophet
 
+        #### Disable container if certain features are not supported but enforced ----
         dummy = Prophet()
-        self.active = self.disable_pred_int_enforcement(
+        self.active = disable_pred_int_enforcement(
             forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
+        )
+        if not self.active:
+            return
+
+        self.active = disable_exogenous_enforcement(
+            forecaster=dummy,
+            enforce_exogenous=globals_dict["enforce_exogenous"],
+            exp_has_exogenous=globals_dict["exogenous_type"],
         )
         if not self.active:
             return
@@ -1336,9 +1430,18 @@ class CdsDtContainer(TimeSeriesContainer):
             self.active = False
             return
 
+        #### Disable container if certain features are not supported but enforced ----
         dummy = BaseCdsDtForecaster(regressor=self.regressor)
-        self.active = self.disable_pred_int_enforcement(
+        self.active = disable_pred_int_enforcement(
             forecaster=dummy, enforce_pi=globals_dict["enforce_pi"]
+        )
+        if not self.active:
+            return
+
+        self.active = disable_exogenous_enforcement(
+            forecaster=dummy,
+            enforce_exogenous=globals_dict["enforce_exogenous"],
+            exp_has_exogenous=globals_dict["exogenous_type"],
         )
         if not self.active:
             return
@@ -2687,7 +2790,6 @@ try:
                 )
             return y
 
-
 except ImportError:
     Prophet = None
     ProphetPeriodPatched = None
@@ -2731,4 +2833,3 @@ def get_all_model_containers(
     return pycaret.containers.base_container.get_all_containers(
         globals(), globals_dict, TimeSeriesContainer, raise_errors
     )
-

--- a/pycaret/internal/pycaret_experiment/time_series_experiment.py
+++ b/pycaret/internal/pycaret_experiment/time_series_experiment.py
@@ -45,7 +45,7 @@ from pycaret.utils.time_series.forecasting import (
     get_predictions_with_intervals,
     update_additional_scorer_kwargs,
 )
-from pycaret.utils.time_series import TSApproachTypes, TSExogenousTypes
+from pycaret.utils.time_series import TSApproachTypes, TSExogenousPresent
 from pycaret.utils.time_series.forecasting.model_selection import (
     ForecastingGridSearchCV,
     ForecastingRandomizedSearchCV,
@@ -85,7 +85,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
                 "enforce_pi",
                 "enforce_exogenous",
                 "approach_type",
-                "exogenous_type",
+                "exogenous_present",
                 "index_type",
             }
         )
@@ -138,7 +138,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
                 ["Original Data", self.data_before_preprocess.shape],
                 ["Missing Values", kwargs["missing_flag"]],
                 ["Approach", self.approach_type.value],
-                ["Exogenous Variables", self.exogenous_type.value],
+                ["Exogenous Variables", self.exogenous_present.value],
                 ["Transformed Train Target", self.y_train.shape],
                 ["Transformed Test Target", self.y_test.shape],
                 ["Transformed Train Exogenous", self.X_train.shape],
@@ -613,9 +613,9 @@ class TimeSeriesExperiment(_SupervisedExperiment):
 
         #### Data has exogenous variables or not ----
         if len(self.exogenous_variables) > 0:
-            self.exogenous_type = TSExogenousTypes.EXO
+            self.exogenous_present = TSExogenousPresent.YES
         else:
-            self.exogenous_type = TSExogenousTypes.NO_EXO
+            self.exogenous_present = TSExogenousPresent.NO
 
     def setup(
         self,

--- a/pycaret/internal/pycaret_experiment/time_series_experiment.py
+++ b/pycaret/internal/pycaret_experiment/time_series_experiment.py
@@ -45,6 +45,7 @@ from pycaret.utils.time_series.forecasting import (
     get_predictions_with_intervals,
     update_additional_scorer_kwargs,
 )
+from pycaret.utils.time_series import TSApproachTypes, TSExogenousTypes
 from pycaret.utils.time_series.forecasting.model_selection import (
     ForecastingGridSearchCV,
     ForecastingRandomizedSearchCV,
@@ -82,6 +83,9 @@ class TimeSeriesExperiment(_SupervisedExperiment):
                 "all_sp_values",
                 "strictly_positive",
                 "enforce_pi",
+                "enforce_exogenous",
+                "approach_type",
+                "exogenous_type",
                 "index_type",
             }
         )
@@ -133,7 +137,8 @@ class TimeSeriesExperiment(_SupervisedExperiment):
                 ["Target", self.target_param],
                 ["Original Data", self.data_before_preprocess.shape],
                 ["Missing Values", kwargs["missing_flag"]],
-                ["Forecasting Type", self.forecasting_type],
+                ["Approach", self.approach_type.value],
+                ["Exogenous Variables", self.exogenous_type.value],
                 ["Transformed Train Target", self.y_train.shape],
                 ["Transformed Test Target", self.y_test.shape],
                 ["Transformed Train Exogenous", self.X_train.shape],
@@ -590,8 +595,8 @@ class TimeSeriesExperiment(_SupervisedExperiment):
 
         return exo_variables
 
-    def _check_and_set_forecsting_type(self):
-        """Checks & sets the the forecasting type based on the number of Targets
+    def _check_and_set_forecsting_types(self):
+        """Checks & sets the the forecasting types based on the number of Targets
         and Exogenous Variables.
 
         Raises
@@ -599,17 +604,18 @@ class TimeSeriesExperiment(_SupervisedExperiment):
         ValueError
             If Forecasting type is unsupported (e.g. Multivariate Forecasting)
         """
+        #### Univariate or Multivariate ----
         if isinstance(self.target_param, str):
-            if len(self.exogenous_variables) > 0:
-                self.forecasting_type = "Univariate with Exogenous Variables"
-            else:
-                self.forecasting_type = "Univariate without Exogenous Variables"
+            self.approach_type = TSApproachTypes.UNI
         elif isinstance(self.target_param, list):
-            if len(self.exogenous_variables) > 0:
-                self.forecasting_type = "Multivariate with Exogenous Variables"
-            else:
-                self.forecasting_type = "Multivariate without Exogenous Variables"
+            self.approach_type = TSApproachTypes.MULTI
             raise ValueError("Multivariate forecasting is currently not supported")
+
+        #### Data has exogenous variables or not ----
+        if len(self.exogenous_variables) > 0:
+            self.exogenous_type = TSExogenousTypes.EXO
+        else:
+            self.exogenous_type = TSExogenousTypes.NO_EXO
 
     def setup(
         self,
@@ -619,13 +625,14 @@ class TimeSeriesExperiment(_SupervisedExperiment):
         ignore_features: Optional[List] = None,
         preprocess: bool = True,
         imputation_type: str = "simple",
-        #        transform_target: bool = False,
-        #        transform_target_method: str = "box-cox",
+        # transform_target: bool = False,
+        # transform_target_method: str = "box-cox",
         fold_strategy: Union[str, Any] = "expanding",
         fold: int = 3,
         fh: Optional[Union[List[int], int, np.array]] = 1,
         seasonal_period: Optional[Union[List[Union[int, str]], int, str]] = None,
         enforce_pi: bool = False,
+        enforce_exogenous: bool = True,
         n_jobs: Optional[int] = -1,
         use_gpu: bool = False,
         custom_pipeline: Union[
@@ -736,13 +743,22 @@ class TimeSeriesExperiment(_SupervisedExperiment):
             Alternatively you can provide a custom `seasonal_period` by passing
             it as an integer or a string corresponding to the keys above (e.g.
             'W' for weekly data, 'M' for monthly data, etc.). You can also provide
-            a list of such values to use in models that accept multple seasonal values
+            a list of such values to use in models that accept multiple seasonal values
             (currently TBATS). For models that don't accept multiple seasonal values, the
             first value of the list will be used as the seasonal period.
+
 
         enforce_pi: bool, default = False
             When set to True, only models that support prediction intervals are
             loaded in the environment.
+
+
+        enforce_exogenous: bool, default = True
+            When set to True and the data includes exogenous variables, only models
+            that support exogenous variables are loaded in the environment.When
+            set to False, all models are included and in this case, models that do
+            not support exogenous variables will model the data as a univariate
+            forecasting problem.
 
 
         n_jobs: int, default = -1
@@ -847,6 +863,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
         self.hoverinfo = hoverinfo
         self.renderer = renderer
         self.enforce_pi = enforce_pi
+        self.enforce_exogenous = enforce_exogenous
 
         #### Check and Clean Data ----
         data_ = self._check_and_clean_data(data)
@@ -865,7 +882,7 @@ class TimeSeriesExperiment(_SupervisedExperiment):
         )
 
         #### Set type of forecasting ----
-        self._check_and_set_forecsting_type()
+        self._check_and_set_forecsting_types()
 
         #### Set Forecast Horizon ----
         self._check_and_set_fh(fh=fh, fold_strategy=fold_strategy, fold=fold)

--- a/pycaret/tests/conftest.py
+++ b/pycaret/tests/conftest.py
@@ -6,6 +6,7 @@ import pandas as pd  # type: ignore
 from pycaret.datasets import get_data
 from pycaret.internal.pycaret_experiment import TimeSeriesExperiment
 from pycaret.containers.models.time_series import get_all_model_containers
+from pycaret.utils.time_series import TSExogenousPresent
 
 from .time_series_test_utils import _BLEND_TEST_MODELS
 
@@ -81,6 +82,8 @@ def load_ts_models(load_setup):
         "gpu_param": False,
         "X_train": pd.DataFrame(get_data("airline")),
         "enforce_pi": False,
+        "enforce_exogenous": True,
+        "exogenous_present": TSExogenousPresent.NO,
         "sp_to_use": 12,
     }
     ts_models = get_all_model_containers(globals_dict)

--- a/pycaret/tests/test_time_series_exogenous.py
+++ b/pycaret/tests/test_time_series_exogenous.py
@@ -4,7 +4,6 @@ import pytest
 import numpy as np  # type: ignore
 import pandas as pd  # type: ignore
 
-from pycaret.datasets import get_data
 from pycaret.internal.pycaret_experiment import TimeSeriesExperiment
 
 
@@ -85,8 +84,7 @@ def test_create_tune_predict_finalize_model(load_uni_exo_data_target):
 
 
 def test_blend_models(load_uni_exo_data_target, load_models_uni_mix_exo_noexo):
-    """test blending functionality
-    """
+    """test blending functionality"""
     data, target = load_uni_exo_data_target
 
     fh = 12
@@ -124,8 +122,7 @@ def test_blend_models(load_uni_exo_data_target, load_models_uni_mix_exo_noexo):
 
 
 def test_setup():
-    """Test the setup with exogenous variables
-    """
+    """Test the setup with exogenous variables"""
     length = 100
     data = pd.DataFrame(np.random.rand(length, 7))
     data.columns = "A B C D E F G".split()
@@ -191,8 +188,7 @@ def test_setup():
 
 
 def test_setup_raises():
-    """Test the setup with exogenous variables when it raises errors
-    """
+    """Test the setup with exogenous variables when it raises errors"""
     length = 100
     data = pd.DataFrame(np.random.rand(length, 7))
     data.columns = "A B C D E F G".split()
@@ -237,4 +233,3 @@ def test_setup_raises():
 
     exceptionmsg = errmsg.value.args[0]
     assert exceptionmsg == f"Target Column '{target}' is not present in the data."
-

--- a/pycaret/tests/test_time_series_exogenous.py
+++ b/pycaret/tests/test_time_series_exogenous.py
@@ -5,6 +5,7 @@ import numpy as np  # type: ignore
 import pandas as pd  # type: ignore
 
 from pycaret.internal.pycaret_experiment import TimeSeriesExperiment
+from pycaret.utils.time_series import TSApproachTypes, TSExogenousPresent
 
 
 pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
@@ -84,7 +85,12 @@ def test_create_tune_predict_finalize_model(load_uni_exo_data_target):
 
 
 def test_blend_models(load_uni_exo_data_target, load_models_uni_mix_exo_noexo):
-    """test blending functionality"""
+    """test blending functionality.
+    NOTE: compare models does not enforce exog here for now.
+    TODO: Later when Reduced Regression Models also support exogenous variables,
+    we can add a test with only models that support exogenous variables (i.e.
+    with enforce_exogenous=True).
+    """
     data, target = load_uni_exo_data_target
 
     fh = 12
@@ -100,7 +106,12 @@ def test_blend_models(load_uni_exo_data_target, load_models_uni_mix_exo_noexo):
 
     exp = TimeSeriesExperiment()
     exp.setup(
-        data=data_for_modeling, target=target, fh=fh, seasonal_period=4, session_id=42
+        data=data_for_modeling,
+        target=target,
+        fh=fh,
+        seasonal_period=4,
+        enforce_exogenous=False,
+        session_id=42,
     )
 
     models_to_include = load_models_uni_mix_exo_noexo
@@ -135,54 +146,63 @@ def test_setup():
     ######################################
     #### Univariate without exogenous ####
     ######################################
-    forecasting_type = "Univariate without Exogenous Variables"
+    approach_type = TSApproachTypes.UNI
+    exogenous_present = TSExogenousPresent.NO
 
     #### Case 1: pd.Series ----
     exp.setup(data=data[target], seasonal_period=1)
-    assert exp.forecasting_type == forecasting_type
+    assert exp.approach_type == approach_type
+    assert exp.exogenous_present == exogenous_present
     assert exp.target_param == target
     assert exp.exogenous_variables == []
 
     #### Case 2: pd.DataFrame with 1 column ----
     exp.setup(data=pd.DataFrame(data[target]), seasonal_period=1)
-    assert exp.forecasting_type == forecasting_type
+    assert exp.approach_type == approach_type
+    assert exp.exogenous_present == exogenous_present
     assert exp.target_param == target
     assert exp.exogenous_variables == []
 
     #### Case 3: # Target specified & correct ----
     exp.setup(data=data[target], target=target, seasonal_period=1)
-    assert exp.forecasting_type == forecasting_type
+    assert exp.approach_type == approach_type
+    assert exp.exogenous_present == exogenous_present
     assert exp.target_param == target
     assert exp.exogenous_variables == []
 
     ###################################
     #### Univariate with exogenous ####
     ###################################
-    forecasting_type = "Univariate with Exogenous Variables"
+    approach_type = TSApproachTypes.UNI
+    exogenous_present = TSExogenousPresent.YES
 
     #### Case 1: `target` provided, `index` not provided, `ignore_features` not provided ----
     exp.setup(data=data, target=target, seasonal_period=1)
-    assert exp.forecasting_type == forecasting_type
+    assert exp.approach_type == approach_type
+    assert exp.exogenous_present == exogenous_present
     assert exp.target_param == target
     assert exp.exogenous_variables == ["B", "C", "D", "E", "F", "G"]
 
     #### Case 2: `target` provided, `index` provided, `ignore_features` not provided ----
     exp.setup(data=data, target=target, index=index)
-    assert exp.forecasting_type == forecasting_type
+    assert exp.approach_type == approach_type
+    assert exp.exogenous_present == exogenous_present
     assert exp.target_param == target
     assert exp.exogenous_variables == ["C", "D", "E", "F", "G"]
     # TODO: Add check for index values
 
     #### Case 3: `target` provided, `index` provided, `ignore_features` provided ----
     exp.setup(data=data, target=target, index=index, ignore_features=["C", "E"])
-    assert exp.forecasting_type == forecasting_type
+    assert exp.approach_type == approach_type
+    assert exp.exogenous_present == exogenous_present
     assert exp.target_param == target
     assert exp.exogenous_variables == ["D", "F", "G"]
     # TODO: Add check for index values
 
     #### Case 4: `target` provided, `index` not provided, `ignore_features` provided ----
     exp.setup(data=data, target=target, ignore_features=["C", "E"], seasonal_period=1)
-    assert exp.forecasting_type == forecasting_type
+    assert exp.approach_type == approach_type
+    assert exp.exogenous_present == exogenous_present
     assert exp.target_param == target
     assert exp.exogenous_variables == ["B", "D", "F", "G"]
 

--- a/pycaret/tests/time_series_test_utils.py
+++ b/pycaret/tests/time_series_test_utils.py
@@ -8,7 +8,7 @@ import pandas as pd
 from pycaret.internal.pycaret_experiment import TimeSeriesExperiment
 from pycaret.datasets import get_data
 from pycaret.containers.models.time_series import get_all_model_containers
-from pycaret.utils.time_series import SeasonalPeriod, TSExogenousTypes
+from pycaret.utils.time_series import SeasonalPeriod, TSExogenousPresent
 
 _BLEND_TEST_MODELS = [
     "naive",
@@ -109,7 +109,7 @@ def _return_model_names():
         "X_train": pd.DataFrame(get_data("airline")),
         "enforce_pi": False,
         "enforce_exogenous": True,
-        "exogenous_type": TSExogenousTypes.NO_EXO,
+        "exogenous_present": TSExogenousPresent.NO,
         "seasonal_period": 2,
         "sp_to_use": 2,
     }

--- a/pycaret/tests/time_series_test_utils.py
+++ b/pycaret/tests/time_series_test_utils.py
@@ -8,7 +8,7 @@ import pandas as pd
 from pycaret.internal.pycaret_experiment import TimeSeriesExperiment
 from pycaret.datasets import get_data
 from pycaret.containers.models.time_series import get_all_model_containers
-from pycaret.utils.time_series import SeasonalPeriod
+from pycaret.utils.time_series import SeasonalPeriod, TSExogenousTypes
 
 _BLEND_TEST_MODELS = [
     "naive",
@@ -82,7 +82,7 @@ def _get_seasonal_values():
 
 
 def _get_seasonal_values_alphanumeric():
-    """ Check if frequency is alphanumeric and process it as needed """
+    """Check if frequency is alphanumeric and process it as needed"""
     choice_list = ["10", "20", "30", "40", "50", "60"]
     return [
         (random.choice(choice_list), k, v.value)
@@ -108,6 +108,8 @@ def _return_model_names():
         "gpu_param": False,
         "X_train": pd.DataFrame(get_data("airline")),
         "enforce_pi": False,
+        "enforce_exogenous": True,
+        "exogenous_type": TSExogenousTypes.NO_EXO,
         "seasonal_period": 2,
         "sp_to_use": 2,
     }
@@ -157,8 +159,7 @@ def _return_model_parameters():
 
 
 def _return_splitter_args():
-    """fold, fh, fold_strategy
-    """
+    """fold, fh, fold_strategy"""
     parametrize_list = [
         ## fh: Integer
         (random.randint(2, 5), random.randint(5, 10), "expanding"),
@@ -200,8 +201,7 @@ def _return_compare_model_args():
 
 
 def _return_setup_args_raises():
-    """
-    """
+    """ """
     setup_raises_list = [
         (random.randint(50, 100), random.randint(10, 20), "expanding"),
         (random.randint(50, 100), random.randint(10, 20), "rolling"),
@@ -221,10 +221,10 @@ def _return_data_with_without_period_index():
 
 def _return_model_names_for_plots_stats():
     """Returns models to be used for testing plots. Needs
-        - 1 model that has prediction interval ("theta")
-        - 1 model that does not have prediction interval ("lr_cds_dt")
-        - 1 model that has in-sample forecasts ("theta")
-        - 1 model that does not have in-sample forecasts ("lr_cds_dt")
+    - 1 model that has prediction interval ("theta")
+    - 1 model that does not have prediction interval ("lr_cds_dt")
+    - 1 model that has in-sample forecasts ("theta")
+    - 1 model that does not have in-sample forecasts ("lr_cds_dt")
     """
     model_names = ["theta", "lr_cds_dt"]
     return model_names

--- a/pycaret/time_series.py
+++ b/pycaret/time_series.py
@@ -33,6 +33,7 @@ def setup(
     fh: Optional[Union[List[int], int, np.array]] = 1,
     seasonal_period: Optional[Union[List[Union[int, str]], int, str]] = None,
     enforce_pi: bool = False,
+    enforce_exogenous: bool = True,
     n_jobs: Optional[int] = -1,
     use_gpu: bool = False,
     custom_pipeline: Union[
@@ -143,13 +144,22 @@ def setup(
         Alternatively you can provide a custom `seasonal_period` by passing
         it as an integer or a string corresponding to the keys above (e.g.
         'W' for weekly data, 'M' for monthly data, etc.). You can also provide
-        a list of such values to use in models that accept multple seasonal values
+        a list of such values to use in models that accept multiple seasonal values
         (currently TBATS). For models that don't accept multiple seasonal values, the
         first value of the list will be used as the seasonal period.
+
 
     enforce_pi: bool, default = False
         When set to True, only models that support prediction intervals are
         loaded in the environment.
+
+
+    enforce_exogenous: bool, default = True
+        When set to True and the data includes exogenous variables, only models
+        that support exogenous variables are loaded in the environment.When
+        set to False, all models are included and in this case, models that do
+        not support exogenous variables will model the data as a univariate
+        forecasting problem.
 
 
     n_jobs: int, default = -1
@@ -256,6 +266,7 @@ def setup(
         fh=fh,
         seasonal_period=seasonal_period,
         enforce_pi=enforce_pi,
+        enforce_exogenous=enforce_exogenous,
         n_jobs=n_jobs,
         use_gpu=use_gpu,
         custom_pipeline=custom_pipeline,

--- a/pycaret/utils/time_series/__init__.py
+++ b/pycaret/utils/time_series/__init__.py
@@ -231,9 +231,9 @@ class TSModelTypes(Enum):
     TREE = "tree"
 
 
-class TSExogenousTypes(Enum):
-    EXO = "Present"
-    NO_EXO = "Not Present"
+class TSExogenousPresent(Enum):
+    YES = "Present"
+    NO = "Not Present"
 
 
 class TSApproachTypes(Enum):

--- a/pycaret/utils/time_series/__init__.py
+++ b/pycaret/utils/time_series/__init__.py
@@ -229,3 +229,13 @@ class TSModelTypes(Enum):
     LINEAR = "linear"
     NEIGHBORS = "neighbors"
     TREE = "tree"
+
+
+class TSExogenousTypes(Enum):
+    EXO = "Present"
+    NO_EXO = "Not Present"
+
+
+class TSApproachTypes(Enum):
+    UNI = "Univariate"
+    MULTI = "Multivariate"

--- a/pycaret/utils/time_series/forecasting/models.py
+++ b/pycaret/utils/time_series/forecasting/models.py
@@ -1,0 +1,59 @@
+from pycaret.utils.time_series import TSExogenousTypes
+
+
+def disable_pred_int_enforcement(forecaster, enforce_pi: bool) -> bool:
+    """Checks to see if prediction interval should be enforced. If it should
+    but the forecaster does not support it, the container will be disabled.
+
+    Parameters
+    ----------
+    forecaster : `sktime` compatible forecaster
+        forecaster to check for prediction interval capability.
+        Can be a dummy object of the forecasting class
+    enforce_pi : bool
+        Should prediction interval be enforced?
+
+    Returns
+    -------
+    bool
+        True if user wants to enforce prediction interval and forecaster
+        supports it. False otherwise.
+    """
+    if enforce_pi and not forecaster.get_tag("capability:pred_int"):
+        return False
+    return True
+
+
+def disable_exogenous_enforcement(
+    forecaster, enforce_exogenous: bool, exp_has_exogenous: TSExogenousTypes
+) -> bool:
+    """Checks to see if exogenous support should be enforced. If it should
+    but the forecaster does not support it, the container will be disabled.
+    NOTE: Only enforced if the experiment has exogenous variables. If it does not,
+    then no models are disabled.
+
+    Parameters
+    ----------
+    forecaster : `sktime` compatible forecaster
+        forecaster to check for prediction interval capability.
+        Can be a dummy object of the forecasting class
+    enforce_exogenous : bool
+        Should exogenous support be enforced?
+    exp_has_exogenous : TSExogenousTypes
+        Whether the experiment has exogenous variables or not?
+
+    Returns
+    -------
+    bool
+        True if user wants to enforce exogenous support and forecaster
+        supports it. False otherwise.
+    """
+
+    # Disable models only if the experiment has exogenous variables
+    if (
+        exp_has_exogenous == TSExogenousTypes.EXO
+        and enforce_exogenous
+        and forecaster.get_tag("ignores-exogeneous-X")
+    ):
+        return False
+    return True

--- a/pycaret/utils/time_series/forecasting/models.py
+++ b/pycaret/utils/time_series/forecasting/models.py
@@ -1,7 +1,7 @@
-from pycaret.utils.time_series import TSExogenousTypes
+from pycaret.utils.time_series import TSExogenousPresent
 
 
-def disable_pred_int_enforcement(forecaster, enforce_pi: bool) -> bool:
+def _disable_pred_int_enforcement(forecaster, enforce_pi: bool) -> bool:
     """Checks to see if prediction interval should be enforced. If it should
     but the forecaster does not support it, the container will be disabled.
 
@@ -17,15 +17,15 @@ def disable_pred_int_enforcement(forecaster, enforce_pi: bool) -> bool:
     -------
     bool
         True if user wants to enforce prediction interval and forecaster
-        supports it. False otherwise.
+        does not supports it. False otherwise.
     """
     if enforce_pi and not forecaster.get_tag("capability:pred_int"):
-        return False
-    return True
+        return True
+    return False
 
 
-def disable_exogenous_enforcement(
-    forecaster, enforce_exogenous: bool, exp_has_exogenous: TSExogenousTypes
+def _disable_exogenous_enforcement(
+    forecaster, enforce_exogenous: bool, exp_has_exogenous: TSExogenousPresent
 ) -> bool:
     """Checks to see if exogenous support should be enforced. If it should
     but the forecaster does not support it, the container will be disabled.
@@ -46,14 +46,53 @@ def disable_exogenous_enforcement(
     -------
     bool
         True if user wants to enforce exogenous support and forecaster
-        supports it. False otherwise.
+        does not supports it. False otherwise.
     """
 
     # Disable models only if the experiment has exogenous variables
     if (
-        exp_has_exogenous == TSExogenousTypes.EXO
+        exp_has_exogenous == TSExogenousPresent.YES
         and enforce_exogenous
         and forecaster.get_tag("ignores-exogeneous-X")
     ):
-        return False
-    return True
+        return True
+    return False
+
+
+def _check_enforcements(forecaster, globals_dict) -> bool:
+    """Checks whether the model supports certain features such as
+    (1) Prediction Interval, and (2) support for exogenous variables. The checks
+    depend on what features are requested by the user during the experiment setup.
+
+    Parameters
+    ----------
+    forecaster : sktime compatible forecaster
+        The forecaster which needs to be checked for feature support
+    globals_dict : dict_
+        Used to check what features are requested by the user during setup.
+        TODO: To be replaced with experiment object after preprocessing is added.
+
+    Returns
+    -------
+    bool
+        True if the model should remain active in the experiment, False otherwise.
+    """
+
+    active = True
+
+    #### Pred Interval Enforcement ----
+    disable_pred_int = _disable_pred_int_enforcement(
+        forecaster=forecaster, enforce_pi=globals_dict["enforce_pi"]
+    )
+
+    #### Exogenous variable support Enforcement ----
+    disable_exog_enforcement = _disable_exogenous_enforcement(
+        forecaster=forecaster,
+        enforce_exogenous=globals_dict["enforce_exogenous"],
+        exp_has_exogenous=globals_dict["exogenous_present"],
+    )
+
+    if disable_pred_int or disable_exog_enforcement:
+        active = False
+
+    return active


### PR DESCRIPTION
## Related Issuse or bug

Closes #2133 

#### Describe the changes you've made

- Added an argument to setup called `enforce_exogenous`. If True and the data has exogenous variables, then only models that support exogenous variables are enabled.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit tests have been added

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

