### PR TITLE
drift_report for new data

### DIFF
--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -1995,6 +1995,7 @@ def predict_model(
     drift_report: bool = False,
     round: int = 4,
     verbose: bool = True,
+    drift_kwargs:Optional[dict] = None
 ) -> pd.DataFrame:
 
     """
@@ -2074,6 +2075,7 @@ def predict_model(
         round=round,
         verbose=verbose,
         ml_usecase=MLUsecase.CLASSIFICATION,
+        drift_kwargs=drift_kwargs
     )
 
 

--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -8660,6 +8660,7 @@ def predict_model(
     verbose: bool = True,
     ml_usecase: Optional[MLUsecase] = None,
     display: Optional[Display] = None,  # added in pycaret==2.2.0
+    drift_kwargs:Optional[Display] = None
 ) -> pd.DataFrame:
 
     """
@@ -8822,22 +8823,32 @@ def predict_model(
 
     # generate drift report
     if drift_report:
+        if not data is None and drift_kwargs:# IF data is set
+            if 'reference' in drift_kwargs.keys():
+                data_before_preprocess_=None    # refrence data
+                X_train_=drift_kwargs['reference']# transformed refrence data
+                X_test_=data                    # transformed unseen data
+            else:
+                raise ValueError("Please set drift_kwargs = {'reference' : training_df}")
+        else:
+            data_before_preprocess_=data_before_preprocess
+            X_train_=X_train
+
         if ml_usecase == MLUsecase.CLASSIFICATION:
             create_classification_drift_report(
                 _get_model_name(estimator),
                 prep_pipe,
-                data_before_preprocess,
-                X_train,
+                X_train_,
                 X_test_,
+                data_before_preprocess_,
             )
-
         elif ml_usecase == MLUsecase.REGRESSION:
             create_regression_drift_report(
                 _get_model_name(estimator),
                 prep_pipe,
-                data_before_preprocess,
-                X_train,
+                X_train_,
                 X_test_,
+                data_before_preprocess_,
             )
 
     # function to replace encoded labels with their original values

--- a/pycaret/regression.py
+++ b/pycaret/regression.py
@@ -1746,6 +1746,7 @@ def predict_model(
     drift_report: bool = False,
     round: int = 4,
     verbose: bool = True,
+    drift_kwargs:Optional[dict] = None
 ) -> pd.DataFrame:
 
     """
@@ -1809,6 +1810,7 @@ def predict_model(
         round=round,
         verbose=verbose,
         ml_usecase=MLUsecase.REGRESSION,
+        drift_kwargs=drift_kwargs
     )
 
 


### PR DESCRIPTION
Patch for #2150. It works with the below snippet:
``` python
from pycaret.datasets import get_data
data = get_data('juice')
un_seen=data[1000:]
data=data[:1000]
# init setup
from pycaret.classification import *
exp_name = setup(data = data,  target = 'Purchase', verbose=False, silent=True)


# train model
dt = create_model('lightgbm')
# generate report
preds = predict_model(dt, data=un_seen,drift_report = True, drift_kwargs = {'reference' : data})
```

![image](https://user-images.githubusercontent.com/2202483/154786162-8240bcb2-2371-482c-95ca-ceecf40912fd.png)
 
