### PR TITLE
added support for multiple model forecasts per #1616

### DIFF
--- a/pycaret/internal/plots/time_series.py
+++ b/pycaret/internal/plots/time_series.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, Union, Dict, Tuple
+from typing import Optional, Any, Union, Dict, Tuple, List
 
 import numpy as np
 import pandas as pd
@@ -41,9 +41,9 @@ def _get_plot(
     train: Optional[pd.Series] = None,
     test: Optional[pd.Series] = None,
     X: Optional[pd.DataFrame] = None,
-    predictions: Optional[pd.Series] = None,
+    predictions: Optional[List[Union[pd.Series, pd.DataFrame]]] = None,
     cv: Optional[Union[ExpandingWindowSplitter, SlidingWindowSplitter]] = None,
-    model_name: Optional[str] = None,
+    model_names: Optional[List[str]] = None,
     return_pred_int: bool = False,
     data_kwargs: Optional[Dict] = None,
     fig_kwargs: Optional[Dict] = None,
@@ -98,7 +98,7 @@ def _get_plot(
         fig, plot_data = plot_time_series_decomposition(
             data=data,
             fig_defaults=fig_defaults,
-            model_name=model_name,
+            model_name=model_names,
             plot="decomp",
             data_kwargs=data_kwargs,
             fig_kwargs=fig_kwargs,
@@ -108,7 +108,7 @@ def _get_plot(
         fig, plot_data = plot_time_series_decomposition(
             data=data,
             fig_defaults=fig_defaults,
-            model_name=model_name,
+            model_name=model_names,
             plot="decomp_stl",
             data_kwargs=data_kwargs,
             fig_kwargs=fig_kwargs,
@@ -118,7 +118,7 @@ def _get_plot(
         fig, plot_data = plot_acf(
             data=data,
             fig_defaults=fig_defaults,
-            model_name=model_name,
+            model_name=model_names,
             data_kwargs=data_kwargs,
             fig_kwargs=fig_kwargs,
         )
@@ -126,7 +126,7 @@ def _get_plot(
         fig, plot_data = plot_pacf(
             data=data,
             fig_defaults=fig_defaults,
-            model_name=model_name,
+            model_name=model_names,
             data_kwargs=data_kwargs,
             fig_kwargs=fig_kwargs,
         )
@@ -134,7 +134,7 @@ def _get_plot(
         fig, plot_data = plot_diagnostics(
             data=data,
             fig_defaults=fig_defaults,
-            model_name=model_name,
+            model_name=model_names,
             data_kwargs=data_kwargs,
             fig_kwargs=fig_kwargs,
         )
@@ -144,7 +144,7 @@ def _get_plot(
             fig_defaults=fig_defaults,
             X=X,
             hoverinfo=hoverinfo,
-            model_name=model_name,
+            model_name=model_names,
             data_kwargs=data_kwargs,
             fig_kwargs=fig_kwargs,
         )
@@ -152,11 +152,9 @@ def _get_plot(
         if return_pred_int:
             fig, plot_data = plot_predictions_with_confidence(
                 data=data,
-                predictions=predictions["y_pred"],
-                upper_interval=predictions["upper"],
-                lower_interval=predictions["lower"],
+                predictions=predictions,
                 fig_defaults=fig_defaults,
-                model_name=model_name,
+                model_names=model_names,
                 data_kwargs=data_kwargs,
                 fig_kwargs=fig_kwargs,
             )
@@ -166,7 +164,7 @@ def _get_plot(
                 predictions=predictions,
                 fig_defaults=fig_defaults,
                 type_=plot,
-                model_name=model_name,
+                model_names=model_names,
                 data_kwargs=data_kwargs,
                 fig_kwargs=fig_kwargs,
             )
@@ -174,7 +172,7 @@ def _get_plot(
         fig, plot_data = plot_time_series_differences(
             data=data,
             fig_defaults=fig_defaults,
-            model_name=model_name,
+            model_name=model_names,
             hoverinfo=hoverinfo,
             data_kwargs=data_kwargs,
             fig_kwargs=fig_kwargs,
@@ -183,7 +181,7 @@ def _get_plot(
         fig, plot_data = plot_frequency_components(
             data=data,
             fig_defaults=fig_defaults,
-            model_name=model_name,
+            model_name=model_names,
             plot=plot,
             hoverinfo=hoverinfo,
             data_kwargs=data_kwargs,
@@ -628,10 +626,10 @@ def plot_pacf(
 
 def plot_predictions(
     data: pd.Series,
-    predictions: pd.Series,
+    predictions: List[Union[pd.Series, pd.DataFrame]],
     type_: str,
     fig_defaults: Dict[str, Any],
-    model_name: Optional[str] = None,
+    model_names: Optional[str] = None,
     data_kwargs: Optional[Dict] = None,
     fig_kwargs: Optional[Dict] = None,
 ) -> PlotReturnType:
@@ -647,20 +645,32 @@ def plot_predictions(
     if time_series_name is not None:
         title = f"{title} | {time_series_name}"
 
-    x = (
-        predictions.index.to_timestamp()
-        if isinstance(predictions.index, pd.PeriodIndex)
-        else predictions.index
-    )
-    mean = go.Scatter(
-        name=f"Forecast | {model_name}",
-        x=x,
-        y=predictions,
-        mode="lines+markers",
-        line=dict(color="#1f77b4"),
-        marker=dict(size=5),
-        showlegend=True,
-    )
+    prediction_plot_data = []
+    for i, prediction in enumerate(predictions):
+        # Insample predictions can be None for some of the models ----
+        if prediction is not None:
+            x = (
+                prediction.index.to_timestamp()
+                if isinstance(prediction.index, pd.PeriodIndex)
+                else prediction.index
+            )
+
+            # TODO: Temporarily (fix after merging https://github.com/pycaret/pycaret/pull/2279)
+            if isinstance(prediction, pd.DataFrame):
+                preds = prediction["y_pred"].values
+            else:
+                preds = prediction.values
+
+            mean = go.Scatter(
+                name=f"Forecast | {model_names[i]}",
+                x=x,
+                y=preds,
+                mode="lines+markers",
+                # line=dict(color="#1f77b4"),
+                marker=dict(size=5),
+                showlegend=True,
+            )
+            prediction_plot_data.append(mean)
 
     x = (
         data.index.to_timestamp()
@@ -676,7 +686,7 @@ def plot_predictions(
         showlegend=True,
     )
 
-    data_for_fig = [mean, original]
+    data_for_fig = prediction_plot_data + [original]
 
     layout = go.Layout(
         yaxis=dict(title="Values"), xaxis=dict(title="Time"), title=title
@@ -783,16 +793,24 @@ def plot_diagnostics(
 
 def plot_predictions_with_confidence(
     data: pd.Series,
-    predictions: pd.Series,
-    upper_interval: pd.Series,
-    lower_interval: pd.Series,
+    predictions: List[pd.DataFrame],
     fig_defaults: Dict[str, Any],
-    model_name: Optional[str] = None,
+    model_names: Optional[str] = None,
     data_kwargs: Optional[Dict] = None,
     fig_kwargs: Optional[Dict] = None,
 ) -> PlotReturnType:
     """Plots the original data and the predictions provided with confidence"""
     fig, return_data_dict = None, None
+
+    if len(predictions) != 1:
+        raise ValueError(
+            "Plotting with predictions only supports one estimator. Please pass only one estimator to fix"
+        )
+
+    preds = predictions[0]["y_pred"]
+    upper_interval = predictions[0]["upper"]
+    lower_interval = predictions[0]["lower"]
+    model_name = model_names[0]
 
     data_kwargs = data_kwargs or {}
     fig_kwargs = fig_kwargs or {}
@@ -820,14 +838,14 @@ def plot_predictions_with_confidence(
     )
 
     x = (
-        predictions.index.to_timestamp()
-        if isinstance(predictions.index, pd.PeriodIndex)
-        else predictions.index
+        preds.index.to_timestamp()
+        if isinstance(preds.index, pd.PeriodIndex)
+        else preds.index
     )
     mean = go.Scatter(
         name=f"Forecast | {model_name}",
         x=x,
-        y=predictions,
+        y=preds,
         mode="lines+markers",
         line=dict(color="#1f77b4"),
         marker=dict(size=5),

--- a/pycaret/internal/plots/time_series.py
+++ b/pycaret/internal/plots/time_series.py
@@ -41,7 +41,7 @@ def _get_plot(
     train: Optional[pd.Series] = None,
     test: Optional[pd.Series] = None,
     X: Optional[pd.DataFrame] = None,
-    predictions: Optional[List[Union[pd.Series, pd.DataFrame]]] = None,
+    predictions: Optional[List[pd.DataFrame]] = None,
     cv: Optional[Union[ExpandingWindowSplitter, SlidingWindowSplitter]] = None,
     model_names: Optional[List[str]] = None,
     return_pred_int: bool = False,
@@ -235,7 +235,8 @@ def plot_series(
                 plot_data = pd.DataFrame(data)
             else:
                 # Residual
-                plot_data = pd.DataFrame(data, columns=[f"Residuals | {model_name}"])
+                plot_data = pd.DataFrame(data)
+                plot_data.columns = [f"Residuals | {model_name}"]
 
     rows = plot_data.shape[1]
     subplot_titles = plot_data.columns
@@ -634,7 +635,7 @@ def plot_pacf(
 
 def plot_predictions(
     data: pd.Series,
-    predictions: List[Union[pd.Series, pd.DataFrame]],
+    predictions: List[pd.DataFrame],
     type_: str,
     fig_defaults: Dict[str, Any],
     model_names: Optional[str] = None,
@@ -663,16 +664,10 @@ def plot_predictions(
                 else prediction.index
             )
 
-            # TODO: Temporarily (fix after merging https://github.com/pycaret/pycaret/pull/2279)
-            if isinstance(prediction, pd.DataFrame):
-                preds = prediction["y_pred"].values
-            else:
-                preds = prediction.values
-
             mean = go.Scatter(
                 name=f"Forecast | {model_names[i]}",
                 x=x,
-                y=preds,
+                y=prediction["y_pred"].values,
                 mode="lines+markers",
                 # line=dict(color="#1f77b4"),
                 marker=dict(size=5),

--- a/pycaret/internal/plots/time_series.py
+++ b/pycaret/internal/plots/time_series.py
@@ -210,7 +210,7 @@ def plot_series(
     data_kwargs: Optional[Dict] = None,
     fig_kwargs: Optional[Dict] = None,
 ) -> PlotReturnType:
-    """Plots the original time series"""
+    """Plots the original time series or residuals"""
     fig, return_data_dict = None, None
 
     data_kwargs = data_kwargs or {}
@@ -225,9 +225,17 @@ def plot_series(
             title = f"{title} | Target = {time_series_name}"
 
     if X is not None:
+        # Exogenous Variables present (predictions).
         plot_data = pd.concat([data, X], axis=1)
     else:
-        plot_data = pd.DataFrame(data, columns=[f"Residuals | {model_name}"])
+        # Exogenous Variables not present (Original Time series or residuals).
+        if isinstance(data, pd.Series):
+            if model_name is None:
+                # Original Time series
+                plot_data = pd.DataFrame(data)
+            else:
+                # Residual
+                plot_data = pd.DataFrame(data, columns=[f"Residuals | {model_name}"])
 
     rows = plot_data.shape[1]
     subplot_titles = plot_data.columns

--- a/pycaret/tests/test_time_series_base.py
+++ b/pycaret/tests/test_time_series_base.py
@@ -74,7 +74,7 @@ def test_create_predict_finalize_model(name, fh, load_pos_and_neg_data):
     ########################
     # Default prediction
     y_pred = exp.predict_model(model)
-    assert isinstance(y_pred, pd.Series)
+    assert isinstance(y_pred, pd.DataFrame)
     assert np.all(y_pred.index == expected_period_index)
 
     # With Prediction Interval (default alpha = 0.05)

--- a/pycaret/tests/test_time_series_exogenous.py
+++ b/pycaret/tests/test_time_series_exogenous.py
@@ -58,7 +58,7 @@ def test_create_tune_predict_finalize_model(load_uni_exo_data_target):
     ########################
     # Default prediction
     y_pred = exp.predict_model(model)
-    assert isinstance(y_pred, pd.Series)
+    assert isinstance(y_pred, pd.DataFrame)
     assert np.all(y_pred.index == expected_period_index)
 
     #####################
@@ -71,7 +71,7 @@ def test_create_tune_predict_finalize_model(load_uni_exo_data_target):
     ########################
     # Default prediction
     y_pred = exp.predict_model(tuned_model)
-    assert isinstance(y_pred, pd.Series)
+    assert isinstance(y_pred, pd.DataFrame)
     assert np.all(y_pred.index == expected_period_index)
 
     #########################
@@ -119,7 +119,7 @@ def test_blend_models(load_uni_exo_data_target, load_models_uni_mix_exo_noexo):
 
     blender = exp.blend_models(best_models)
     y_pred = exp.predict_model(blender)
-    assert isinstance(y_pred, pd.Series)
+    assert isinstance(y_pred, pd.DataFrame)
     assert np.all(y_pred.index == expected_period_index)
 
     #########################

--- a/pycaret/tests/test_time_series_tune_base.py
+++ b/pycaret/tests/test_time_series_tune_base.py
@@ -101,7 +101,7 @@ def test_tune_model_alternate_metric(load_pos_and_neg_data, metric):
 
     tuned_model_obj = exp.tune_model(model_obj, optimize=metric)
     y_pred = exp.predict_model(tuned_model_obj)
-    assert isinstance(y_pred, pd.Series)
+    assert isinstance(y_pred, pd.DataFrame)
 
     expected_period_index = load_pos_and_neg_data.iloc[-fh:].index
     assert np.all(y_pred.index == expected_period_index)

--- a/pycaret/tests/test_time_series_tune_grid.py
+++ b/pycaret/tests/test_time_series_tune_grid.py
@@ -46,7 +46,7 @@ def test_tune_model_grid(model, load_pos_and_neg_data):
     model_obj = exp.create_model(model)
     tuned_model_obj = exp.tune_model(model_obj, search_algorithm="grid")
     y_pred = exp.predict_model(tuned_model_obj)
-    assert isinstance(y_pred, pd.Series)
+    assert isinstance(y_pred, pd.DataFrame)
 
     expected_period_index = data.iloc[-fh:].index
     assert np.all(y_pred.index == expected_period_index)

--- a/pycaret/tests/test_time_series_tune_random.py
+++ b/pycaret/tests/test_time_series_tune_random.py
@@ -46,7 +46,7 @@ def test_tune_model_random(model, load_pos_and_neg_data):
     model_obj = exp.create_model(model)
     tuned_model_obj = exp.tune_model(model_obj)  # default search_algorithm = "random"
     y_pred = exp.predict_model(tuned_model_obj)
-    assert isinstance(y_pred, pd.Series)
+    assert isinstance(y_pred, pd.DataFrame)
 
     expected_period_index = data.iloc[-fh:].index
     assert np.all(y_pred.index == expected_period_index)

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -2560,11 +2560,12 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
                 # it will not have self._get_model_name
                 model_names = [estimator.__class__.__name__ for estimator in estimators]
 
-            if len(estimators) > 1 and plot not in _support_multiple_estimators:
-                msg = f"Plot '{plot}' does not support multiple estimators. The first estimator will be used."
-                self.logger.warning(msg)
-                print(msg)
-                estimator = estimators[0]
+            if plot not in _support_multiple_estimators:
+                if len(estimators) > 1:
+                    msg = f"Plot '{plot}' does not support multiple estimators. The first estimator will be used."
+                    self.logger.warning(msg)
+                    print(msg)
+                estimators = estimators[0]
                 model_names = model_names[0]
 
             require_insample_predictions = ["insample"]
@@ -2622,7 +2623,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
                 return_pred_int = False
 
             elif plot in require_residuals:
-                resid = self.get_residuals(estimator=estimator)
+                resid = self.get_residuals(estimator=estimators)
                 if resid is None:
                     return
                 resid = self.check_and_clean_resid(resid=resid)

--- a/pycaret/utils/time_series/forecasting/__init__.py
+++ b/pycaret/utils/time_series/forecasting/__init__.py
@@ -11,7 +11,7 @@ def get_predictions_with_intervals(
     alpha: float = 0.05,
     merge: bool = False,
     round: Optional[int] = None,
-) -> Union[pd.DataFrame, Tuple[pd.Series, pd.Series, pd.Series]]:
+) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]]:
     """Returns the predictions, lower and upper interval values for a
     forecaster. If the forecaster does not support prediction intervals,
     then NAN is returned for lower and upper intervals.
@@ -33,7 +33,7 @@ def get_predictions_with_intervals(
 
     Returns
     -------
-    Union[pd.DataFrame, Tuple[pd.Series, pd.Series, pd.Series]]
+    Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]]
         Predictions, Lower and Upper Interval Values
     """
     # Predict and get lower and upper intervals
@@ -44,13 +44,13 @@ def get_predictions_with_intervals(
     )
 
     if return_pred_int:
-        y_pred = return_values[0]
-        lower = return_values[1]["lower"]
-        upper = return_values[1]["upper"]
+        y_pred = pd.DataFrame({"y_pred": return_values[0]})
+        lower = pd.DataFrame({"lower": return_values[1]["lower"]})
+        upper = pd.DataFrame({"upper": return_values[1]["upper"]})
     else:
-        y_pred = return_values
-        lower = pd.Series([np.nan] * len(y_pred))
-        upper = pd.Series([np.nan] * len(y_pred))
+        y_pred = pd.DataFrame({"y_pred": return_values})
+        lower = pd.DataFrame({"lower": [np.nan] * len(y_pred)})
+        upper = pd.DataFrame({"upper": [np.nan] * len(y_pred)})
         lower.index = y_pred.index
         upper.index = y_pred.index
 
@@ -68,7 +68,6 @@ def get_predictions_with_intervals(
 
     if merge:
         results = pd.concat([y_pred, lower, upper], axis=1)
-        results.columns = ["y_pred", "lower", "upper"]
         return results
     else:
         return y_pred, lower, upper


### PR DESCRIPTION
## Related Issue or bug

Closes #1616 

#### Describe the changes you've made

- Added support for multiple estimators in "forecast" and "insample" plots.
- If estimator does not support insample predictions, it is simply ignored.
- If the user provides multiple models for plots that do not support it, the first one is used.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Local testing. 
- [ ] Unit tests need to be added

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

