### PR TITLE
Fix potential parameter leaking for ParallelBackend

### DIFF
--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -564,7 +564,7 @@ def setup(
     """
 
     global _pycaret_setup_call
-    _pycaret_setup_call = dict(func=setup, params=locals())
+    _pycaret_setup_call = dict(func=setup, params=dict(locals()))
 
     if not isinstance(data, pd.DataFrame):
         data = data()

--- a/pycaret/classification.py
+++ b/pycaret/classification.py
@@ -565,6 +565,7 @@ def setup(
 
     global _pycaret_setup_call
     _pycaret_setup_call = dict(func=setup, params=dict(locals()))
+    # no more python code should be added before this line
 
     if not isinstance(data, pd.DataFrame):
         data = data()

--- a/pycaret/regression.py
+++ b/pycaret/regression.py
@@ -566,7 +566,7 @@ def setup(
     """
 
     global _pycaret_setup_call
-    _pycaret_setup_call = dict(func=setup, params=locals())
+    _pycaret_setup_call = dict(func=setup, params=dict(locals()))
 
     if not isinstance(data, pd.DataFrame):
         data = data()

--- a/pycaret/regression.py
+++ b/pycaret/regression.py
@@ -567,6 +567,7 @@ def setup(
 
     global _pycaret_setup_call
     _pycaret_setup_call = dict(func=setup, params=dict(locals()))
+    # no more python code should be added before this line
 
     if not isinstance(data, pd.DataFrame):
         data = data()


### PR DESCRIPTION
## Related Issuse or bug

Info about Issue or bug

Closes #2322

#### Describe the changes you've made

Add `dict` out of `locals()` to prevent the following local variable to inject into the parameters:
```python
_pycaret_setup_call = dict(func=setup, params=dict(locals()))
```

## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I couldn't reproduce the issue on Databricks as reported in https://github.com/pycaret/pycaret/issues/2322
But this is the place that can potentially cause issues. So let's fix this and test on Databricks again.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

NA

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

