### PR TITLE
Updated ACF and PACF plots to reuse subplot logic directly

### DIFF
--- a/pycaret/internal/plots/time_series.py
+++ b/pycaret/internal/plots/time_series.py
@@ -459,7 +459,8 @@ def plot_acf(
     fig_defaults : Dict[str, Any]
         The defaults dictionary containing keys for "width" and "height" (mandatory)
     model_name : Optional[str]
-        The name of the model, by default None
+        The model_name must be passed to model residuals, while it should be left None
+        for the original data and the name of the data is passed
     data_kwargs : Dict[str, Any]
         A dictionary containing options keys for "nlags"
     fig_kwargs : Dict[str, Any]
@@ -474,11 +475,10 @@ def plot_acf(
     fig_kwargs = fig_kwargs or {}
 
     nlags = data_kwargs.get("nlags", None)
-    name = "ACF"
 
     subplots = make_subplots(rows=1, cols=1)
     fig, acf_data = corr_subplot(
-        fig=subplots, data=data, col=1, row=1, name=name, plot="acf", nlags=nlags
+        fig=subplots, data=data, col=1, row=1, plot="acf", nlags=nlags
     )
 
     time_series_name = data.name
@@ -490,16 +490,19 @@ def plot_acf(
 
     with fig.batch_update():
         fig.update_xaxes(title_text="Lags", row=1, col=1)
-        fig.update_yaxes(title_text=name, row=1, col=1)
+        fig.update_yaxes(title_text="ACF", row=1, col=1)
         template = _resolve_dict_keys(
             dict_=fig_kwargs, key="template", defaults=fig_defaults
         )
         fig.update_layout(title=title, showlegend=False, template=template)
+        fig.update_traces(marker={"size": 12})
         fig = _update_fig_dimensions(
             fig=fig, fig_kwargs=fig_kwargs, fig_defaults=fig_defaults
         )
 
-    return_data_dict = {"acf": acf(data, alpha=0.05, nlags=nlags)}
+    return_data_dict = {
+        "acf": (acf_data[0], np.column_stack((acf_data[2], acf_data[3])))
+    }
 
     return fig, return_data_dict
 
@@ -520,7 +523,8 @@ def plot_pacf(
     fig_defaults : Dict[str, Any]
         The defaults dictionary containing keys for "width" and "height" (mandatory)
     model_name : Optional[str]
-        The name of the model, by default None
+        The model_name must be passed to model residuals, while it should be left None
+        for the original data and the name of the data is passed
     data_kwargs : Dict[str, Any]
         A dictionary containing options keys for "nlags"
     fig_kwargs : Dict[str, Any]
@@ -535,11 +539,10 @@ def plot_pacf(
     fig_kwargs = fig_kwargs or {}
 
     nlags = data_kwargs.get("nlags", None)
-    name = "PACF"
 
     subplots = make_subplots(rows=1, cols=1)
-    fig, acf_data = corr_subplot(
-        fig=subplots, data=data, col=1, row=1, name=name, plot="pacf", nlags=nlags
+    fig, pacf_data = corr_subplot(
+        fig=subplots, data=data, col=1, row=1, plot="pacf", nlags=nlags
     )
 
     time_series_name = data.name
@@ -551,16 +554,19 @@ def plot_pacf(
 
     with fig.batch_update():
         fig.update_xaxes(title_text="Lags", row=1, col=1)
-        fig.update_yaxes(title_text=name, row=1, col=1)
+        fig.update_yaxes(title_text="PACF", row=1, col=1)
         template = _resolve_dict_keys(
             dict_=fig_kwargs, key="template", defaults=fig_defaults
         )
         fig.update_layout(title=title, showlegend=False, template=template)
+        fig.update_traces(marker={"size": 12})
         fig = _update_fig_dimensions(
             fig=fig, fig_kwargs=fig_kwargs, fig_defaults=fig_defaults
         )
 
-    return_data_dict = {"pacf": pacf(data, alpha=0.05, nlags=nlags)}
+    return_data_dict = {
+        "pacf": (pacf_data[0], np.column_stack((pacf_data[2], pacf_data[3])))
+    }
 
     return fig, return_data_dict
 

--- a/pycaret/internal/plots/time_series.py
+++ b/pycaret/internal/plots/time_series.py
@@ -459,8 +459,10 @@ def plot_acf(
     fig_defaults : Dict[str, Any]
         The defaults dictionary containing keys for "width" and "height" (mandatory)
     model_name : Optional[str]
-        The model_name must be passed to model residuals, while it should be left None
-        for the original data and the name of the data is passed
+        If the correlation plot is for model residuals, then, model_name must be 
+        passed for proper display of results. If the correlation plot is for the 
+        original data, model_name should be left None (name is derived from the 
+        data passed in this case).
     data_kwargs : Dict[str, Any]
         A dictionary containing options keys for "nlags"
     fig_kwargs : Dict[str, Any]
@@ -495,13 +497,13 @@ def plot_acf(
             dict_=fig_kwargs, key="template", defaults=fig_defaults
         )
         fig.update_layout(title=title, showlegend=False, template=template)
-        fig.update_traces(marker={"size": 12})
+        fig.update_traces(marker={"size": 10})
         fig = _update_fig_dimensions(
             fig=fig, fig_kwargs=fig_kwargs, fig_defaults=fig_defaults
         )
 
     return_data_dict = {
-        "acf": (acf_data[0], np.column_stack((acf_data[2], acf_data[3])))
+        "acf": acf_data
     }
 
     return fig, return_data_dict
@@ -523,8 +525,10 @@ def plot_pacf(
     fig_defaults : Dict[str, Any]
         The defaults dictionary containing keys for "width" and "height" (mandatory)
     model_name : Optional[str]
-        The model_name must be passed to model residuals, while it should be left None
-        for the original data and the name of the data is passed
+        If the correlation plot is for model residuals, then, model_name must be 
+        passed for proper display of results. If the correlation plot is for the 
+        original data, model_name should be left None (name is derived from the 
+        data passed in this case).
     data_kwargs : Dict[str, Any]
         A dictionary containing options keys for "nlags"
     fig_kwargs : Dict[str, Any]
@@ -559,13 +563,13 @@ def plot_pacf(
             dict_=fig_kwargs, key="template", defaults=fig_defaults
         )
         fig.update_layout(title=title, showlegend=False, template=template)
-        fig.update_traces(marker={"size": 12})
+        fig.update_traces(marker={"size": 10})
         fig = _update_fig_dimensions(
             fig=fig, fig_kwargs=fig_kwargs, fig_defaults=fig_defaults
         )
 
     return_data_dict = {
-        "pacf": (pacf_data[0], np.column_stack((pacf_data[2], pacf_data[3])))
+        "pacf": pacf_data
     }
 
     return fig, return_data_dict


### PR DESCRIPTION
## Related Issues or Bug

Implemented #[2343](https://github.com/pycaret/pycaret/issues/2343)

#### Describe the changes you've made

Updated plot_acf and plot_pacf to reuse the corr_subplot component instead of replicating the code to create these plots again.

## Type of change

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested locally with `pytest`

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

NA

## Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
