### PR TITLE
Fix for prediction intervals with pipelines

### DIFF
--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -27,7 +27,7 @@ from pycaret.utils.time_series.forecasting import PyCaretForecastingHorizonTypes
 from pycaret.utils.time_series.forecasting.pipeline import (
     PyCaretForecastingPipeline,
     _add_model_to_pipeline,
-    _pipeline_tansformations_empty,
+    _are_pipeline_tansformations_empty,
 )
 from pycaret.utils.time_series.forecasting.models import DummyForecaster
 from sktime.forecasting.compose import TransformedTargetForecaster
@@ -3299,7 +3299,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         fh = self._predict_model_reconcile_fh(estimator=estimator_, fh=fh)
         X = self._predict_model_reconcile_X(estimator=estimator_, X=X)
 
-        if not _pipeline_tansformations_empty(pipeline=pipeline_with_model):
+        if not _are_pipeline_tansformations_empty(pipeline=pipeline_with_model):
             result = get_predictions_with_intervals(
                 forecaster=pipeline_with_model,
                 X=X,

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 
 import numpy as np
 import pandas as pd
+from IPython.display import display
 from IPython.utils import io
 from sklearn.base import clone
 from sktime.forecasting.base import ForecastingHorizon
@@ -1004,7 +1005,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         self.logger.info(f"Setup Display Container: {self.display_container[0]}")
         if self.verbose:
             pd.set_option("display.max_rows", 100)
-            print(self.display_container[0].style.apply(highlight_setup))
+            display(self.display_container[0].style.apply(highlight_setup))
             pd.reset_option("display.max_rows")  # Reset option
 
         return self

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -26,6 +26,7 @@ from pycaret.utils.time_series.forecasting import PyCaretForecastingHorizonTypes
 from pycaret.utils.time_series.forecasting.pipeline import (
     PyCaretForecastingPipeline,
     _add_model_to_pipeline,
+    _pipeline_tansformations_empty,
 )
 from pycaret.utils.time_series.forecasting.models import DummyForecaster
 from sktime.forecasting.compose import TransformedTargetForecaster
@@ -3297,7 +3298,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         fh = self._predict_model_reconcile_fh(estimator=estimator_, fh=fh)
         X = self._predict_model_reconcile_X(estimator=estimator_, X=X)
 
-        if not self.pipeline_empty:
+        if not _pipeline_tansformations_empty(pipeline=pipeline_with_model):
             result = get_predictions_with_intervals(
                 forecaster=pipeline_with_model,
                 X=X,
@@ -3614,9 +3615,6 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         PyCaretForecastingPipeline
             A PyCaret Time Series Forecasting Pipeline.
         """
-
-        #### Does the pipeline contains any preprocessing steps? ----
-        self.pipeline_empty = len(target_steps) == 0 and len(exogenous_steps) == 0
 
         # Set the pipeline from model
         # Add forecaster (model) to end of target steps ----

--- a/pycaret/utils/time_series/forecasting/pipeline.py
+++ b/pycaret/utils/time_series/forecasting/pipeline.py
@@ -60,7 +60,7 @@ def _add_model_to_pipeline(
     return pipeline_with_model
 
 
-def _pipeline_tansformations_empty(pipeline: PyCaretForecastingPipeline) -> bool:
+def _are_pipeline_tansformations_empty(pipeline: PyCaretForecastingPipeline) -> bool:
     """Returns whether the pipeline has transformations for either the target
     or exogenous variables or whether there are no transformatons for either.
 

--- a/pycaret/utils/time_series/forecasting/pipeline.py
+++ b/pycaret/utils/time_series/forecasting/pipeline.py
@@ -58,3 +58,29 @@ def _add_model_to_pipeline(
     pipeline_with_model.steps_[-1][1].steps_.extend([("model", model)])
 
     return pipeline_with_model
+
+
+def _pipeline_tansformations_empty(pipeline: PyCaretForecastingPipeline) -> bool:
+    """Returns whether the pipeline has transformations for either the target
+    or exogenous variables or whether there are no transformatons for either.
+
+    Reminder: The pipeline structure is as follows:
+        PyCaretForecastingPipeline
+            - exogenous_steps
+            - TransformedTargetForecaster
+            - target_steps
+            - model
+
+    Parameters
+    ----------
+    pipeline : PyCaretForecastingPipeline
+        PyCaret Pipeline
+
+    Returns
+    -------
+    bool
+        True if there are no transformations, False otherwise
+    """
+    num_steps_transform_X = len(pipeline.steps) - 1
+    num_steps_transform_y = len(pipeline.steps[-1][1].steps) - 1
+    return num_steps_transform_X == 0 and num_steps_transform_y == 0


### PR DESCRIPTION
## Related Issuse or bug

Closes #2337 

#### Describe the changes you've made

sktime 0.11.0 and below do not support prediction intervals in pipelines. This PR is a fix for this when the pipeline is empty. In this case, the underlying model is used directly for predictions so that we can get the intervals.

This is a temporary fix until the pipelines can support prediction intervals. Once that is done, we can remove this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit tests to be run on GH

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

