### PR TITLE
Time Series - Metrics with missing data

### DIFF
--- a/pycaret/internal/preprocess/time_series/forecasting/preprocessor.py
+++ b/pycaret/internal/preprocess/time_series/forecasting/preprocessor.py
@@ -25,6 +25,13 @@ class TSForecastingPreprocessor:
         self.pipe_steps_target = []
         self.pipe_steps_exogenous = []
 
+        # Pipeline which is trained only on the training split
+        self.pipeline = None
+
+        # Pipeline which is trained only on the complete data
+        # Used when model has been finalized
+        self.pipeline_fully_trained = None
+
     def _imputation(
         self,
         numeric_imputation_target: Optional[Union[str, int, float]],

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -1391,20 +1391,6 @@ class _SupervisedExperiment(_TabularExperiment):
             self.logger.info("Declaring custom model")
 
             model = clone(estimator)
-
-            # WORKAROUND FOR https://github.com/alan-turing-institute/sktime/issues/910
-            # REMOVE AFTER FIX IS IN SKTIME
-            if "changepoint_prior_scale" in kwargs:
-                kwargs["changepoint_prior_scale"] = float(
-                    kwargs["changepoint_prior_scale"]
-                )
-            if "holidays_prior_scale" in kwargs:
-                kwargs["holidays_prior_scale"] = float(kwargs["holidays_prior_scale"])
-            if "seasonality_prior_scale" in kwargs:
-                kwargs["seasonality_prior_scale"] = float(
-                    kwargs["seasonality_prior_scale"]
-                )
-
             model.set_params(**kwargs)
 
             full_name = self._get_model_name(model)

--- a/pycaret/internal/pycaret_experiment/tabular_experiment.py
+++ b/pycaret/internal/pycaret_experiment/tabular_experiment.py
@@ -474,7 +474,7 @@ class _TabularExperiment(_PyCaretExperiment):
                     raise ImportError(message)
                 else:
                     self.logger.warning(message)
-                    
+
         return self
 
     @staticmethod
@@ -2603,11 +2603,16 @@ class _TabularExperiment(_PyCaretExperiment):
         Success_Message
 
         """
+        if self._ml_usecase == MLUsecase.TIME_SERIES:
+            pipeline_to_use = self._get_pipeline_to_use(estimator=model)
+        else:
+            pipeline_to_use = self.pipeline
+
         return pycaret.internal.persistence.save_model(
-            model,
-            model_name,
-            None if model_only else self.pipeline,
-            verbose,
+            model=model,
+            model_name=model_name,
+            prep_pipe_=None if model_only else pipeline_to_use,
+            verbose=verbose,
             use_case=self._ml_usecase,
             **kwargs,
         )

--- a/pycaret/tests/conftest.py
+++ b/pycaret/tests/conftest.py
@@ -16,6 +16,13 @@ from .time_series_test_utils import _BLEND_TEST_MODELS
 #############################
 
 
+@pytest.fixture(scope="session", name="load_pos_data")
+def load_pos_data():
+    """Load Pycaret Airline dataset."""
+    data = get_data("airline")
+    return data
+
+
 @pytest.fixture(scope="session", name="load_pos_and_neg_data")
 def load_pos_and_neg_data():
     """Load Pycaret Airline dataset (with some negative values)."""
@@ -39,6 +46,17 @@ def load_uni_exo_data_target_positive():
     data = data.clip(lower=0.1)
     target = "Consumption"
     return data, target
+
+
+@pytest.fixture(scope="session", name="load_pos_data_missing")
+def load_pos_data_missing():
+    """Load Pycaret Airline dataset (with missing values)."""
+    data = get_data("airline")
+    remove_n = int(0.4 * len(data))
+    np.random.seed(42)
+    na_indices = np.random.choice(data.index, remove_n, replace=False)
+    data[na_indices] = np.nan
+    return data
 
 
 @pytest.fixture(scope="session", name="load_pos_and_neg_data_missing")
@@ -76,13 +94,6 @@ def load_models_uni_mix_exo_noexo():
     # TODO: Later, get this dynamically from sktime
     models = ["naive", "ets", "arima"]
     return models
-
-
-@pytest.fixture(scope="session", name="load_pos_data")
-def load_pos_data():
-    """Load Pycaret Airline dataset."""
-    data = get_data("airline")
-    return data
 
 
 @pytest.fixture(scope="session", name="load_setup")

--- a/pycaret/tests/test_pipeline.py
+++ b/pycaret/tests/test_pipeline.py
@@ -8,7 +8,6 @@ Description: Unit tests for pipeline.py
 """
 
 import pytest
-import numpy as np
 import pandas as pd
 from sklearn.preprocessing import StandardScaler, LabelEncoder
 

--- a/pycaret/tests/test_time_series_blending.py
+++ b/pycaret/tests/test_time_series_blending.py
@@ -61,9 +61,9 @@ def test_blend_model_predict(load_setup, load_models):
     mean_voting_equal = np.array_equal(mean_blender_pred, voting_blender_pred)
     median_voting_equal = np.array_equal(median_blender_pred, voting_blender_pred)
 
-    assert mean_median_equal == False
-    assert mean_voting_equal == False
-    assert median_voting_equal == False
+    assert mean_median_equal is False
+    assert mean_voting_equal is False
+    assert median_voting_equal is False
 
 
 def test_blend_model_custom_folds(load_pos_and_neg_data):

--- a/pycaret/tests/test_time_series_metrics.py
+++ b/pycaret/tests/test_time_series_metrics.py
@@ -5,6 +5,8 @@ import pytest
 import numpy as np  # type: ignore
 import pandas as pd  # type: ignore
 
+from pycaret.datasets import get_data
+from pycaret.time_series import TSForecastingExperiment
 from pycaret.containers.metrics.time_series import coverage
 
 
@@ -17,8 +19,7 @@ pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 
 def test_cov_prob_loss():
-    """Tests inpi_loss
-    """
+    """Tests inpi_loss"""
 
     ##############################
     #### Regular Calculations ####
@@ -73,3 +74,112 @@ def test_cov_prob_loss():
     y_true = pd.Series([1, 2, 3, 4], index=[0, 1, 2, 4])
     loss = coverage(y_true=y_true, y_pred=y_pred, lower=lower, upper=upper)
     assert loss is np.nan
+
+
+def test_metrics_with_missing_values_noexo():
+    """Checks that metrics produced with data WITHOUT exogenous variables but
+    having missing data in CV and Test split does not produce NA values.
+    i.e. the metrics are computed using the imputed values.
+    """
+
+    #### Load data and simulate missing values ----
+    data = get_data("airline")
+    remove_n = int(0.4 * len(data))
+    np.random.seed(42)
+    na_indices = np.random.choice(data.index, remove_n, replace=False)
+    data[na_indices] = np.nan
+
+    FH = 12
+    # Check that there are missing values in CV splits
+    assert data[-2 * FH : -FH].isna().sum() > 0
+    # Check that here are missing values in test split
+    assert data[-FH:].isna().sum() > 0
+
+    #### Setup Forecasting Experiment (enable imputation) ----
+    exp = TSForecastingExperiment()
+    exp.setup(
+        data=data,
+        fh=FH,
+        session_id=42,
+        numeric_imputation_target="drift",
+    )
+
+    ##################################
+    #### 1: With Cross-Validation ####
+    ##################################
+
+    #### Create a model ----
+    model = exp.create_model("exp_smooth", cross_validation=True)
+    cv_results = exp.pull()
+    assert cv_results.drop(columns="cutoff").isna().sum().sum() == 0
+    _ = exp.predict_model(model)
+    test_results = exp.pull()
+    assert test_results.isna().sum().sum() == 0
+
+    #####################################
+    #### 1: Without Cross-Validation ####
+    #####################################
+
+    model = exp.create_model("exp_smooth", cross_validation=False)
+    test_results = exp.pull()
+    assert test_results.isna().sum().sum() == 0
+    _ = exp.predict_model(model)
+    test_results = exp.pull()
+    assert test_results.isna().sum().sum() == 0
+
+
+def test_metrics_with_missing_values_exo():
+    """Checks that metrics produced with data WITH exogenous variables but
+    having missing data in CV and Test split does not produce NA values.
+    i.e. the metrics are computed using the imputed values.
+    """
+
+    #### Load data and simulate missing values ----
+    data = get_data("uschange")
+    target = "Consumption"
+
+    remove_n = int(0.4 * len(data))
+    np.random.seed(42)
+    na_indices = np.random.choice(data.index, remove_n, replace=False)
+    data.iloc[na_indices] = np.nan
+
+    FH = 12
+    # Check that there are missing values in CV splits
+    assert data[-2 * FH : -FH].isna().sum().sum() > 0
+    # Check that here are missing values in test split
+    assert data[-FH:].isna().sum().sum() > 0
+
+    #### Setup Forecasting Experiment (enable imputation) ----
+    exp = TSForecastingExperiment()
+    exp.setup(
+        data=data,
+        target=target,
+        fh=FH,
+        seasonal_period=4,
+        session_id=42,
+        numeric_imputation_target="drift",
+        numeric_imputation_exogenous="drift",
+    )
+
+    ##################################
+    #### 1: With Cross-Validation ####
+    ##################################
+
+    #### Create a model ----
+    model = exp.create_model("lr_cds_dt", cross_validation=True)
+    cv_results = exp.pull()
+    assert cv_results.drop(columns="cutoff").isna().sum().sum() == 0
+    _ = exp.predict_model(model)
+    test_results = exp.pull()
+    assert test_results.isna().sum().sum() == 0
+
+    #####################################
+    #### 1: Without Cross-Validation ####
+    #####################################
+
+    model = exp.create_model("lr_cds_dt", cross_validation=False)
+    test_results = exp.pull()
+    assert test_results.isna().sum().sum() == 0
+    _ = exp.predict_model(model)
+    test_results = exp.pull()
+    assert test_results.isna().sum().sum() == 0

--- a/pycaret/tests/test_time_series_metrics.py
+++ b/pycaret/tests/test_time_series_metrics.py
@@ -175,7 +175,7 @@ def test_metrics_with_missing_values_exo():
     assert test_results.isna().sum().sum() == 0
 
     #####################################
-    #### 1: Without Cross-Validation ####
+    #### 2: Without Cross-Validation ####
     #####################################
 
     model = exp.create_model("lr_cds_dt", cross_validation=False)

--- a/pycaret/tests/test_time_series_models.py
+++ b/pycaret/tests/test_time_series_models.py
@@ -78,8 +78,10 @@ def test_custom_models(load_pos_data):
         return_tuner=True,
     )
     assert type(tuned_model) == type(forecaster)
-    assert "param_impute__method" in pd.DataFrame(tuner.cv_results_)
-    for index, method in enumerate(tuner.cv_results_.get("param_impute__method")):
+    assert "param_forecaster__model__impute__method" in pd.DataFrame(tuner.cv_results_)
+    for index, method in enumerate(
+        tuner.cv_results_.get("param_forecaster__model__impute__method")
+    ):
         assert method == impute_values[index]
 
     ############################

--- a/pycaret/tests/test_time_series_preprocess.py
+++ b/pycaret/tests/test_time_series_preprocess.py
@@ -45,12 +45,35 @@ _model_names_for_missing_data = _return_model_names_for_missing_data()
 ##########################
 
 
+def test_pipeline_no_exo_but_exo_steps(load_pos_and_neg_data):
+    """Tests preprocessing pipeline data types without exogenous variables"""
+    data = load_pos_and_neg_data
+
+    exp = TSForecastingExperiment()
+
+    #### Make sure that no exogenous steps are added to the pipeline when
+    # there is no exogenous data
+    exp.setup(data=data, numeric_imputation_exogenous=True)
+    assert len(exp.pipeline.steps) == 1
+
+    exp.setup(data=data, numeric_imputation_exogenous=True, transform_exogenous="cos")
+    assert len(exp.pipeline.steps) == 1
+
+    exp.setup(data=data, numeric_imputation_exogenous=True, scale_exogenous="min-max")
+    assert len(exp.pipeline.steps) == 1
+
+    exp.setup(
+        data=data,
+        numeric_imputation_exogenous=True,
+        transform_exogenous="cos",
+        scale_exogenous="min-max",
+    )
+    assert len(exp.pipeline.steps) == 1
+
+
 def test_pipeline_types_no_exo(load_pos_and_neg_data):
     """Tests preprocessing pipeline data types without exogenous variables"""
-    data = load_pos_and_neg_data  # _check_data_for_prophet(name, load_pos_and_neg_data)
-
-    # # Simulate misssing values
-    # data[10:20] = np.nan
+    data = load_pos_and_neg_data
 
     exp = TSForecastingExperiment()
 

--- a/pycaret/tests/test_time_series_preprocess.py
+++ b/pycaret/tests/test_time_series_preprocess.py
@@ -551,3 +551,29 @@ def test_scale_exo(load_uni_exo_data_target, method):
     assert not np.all(exp.X.values == exp.X_transformed.values)
     assert not np.all(exp.X_train.values == exp.X_train_transformed.values)
     assert not np.all(exp.X_test.values == exp.X_test_transformed.values)
+
+
+def test_pipeline_after_finalizing(load_pos_and_neg_data_missing):
+    """After finalizing the model, the data memory in the Forecasting Pipeline
+    must match with the memory in the model used in the pipeline (last step of pipeline)
+    """
+    data = load_pos_and_neg_data_missing
+
+    exp = TSForecastingExperiment()
+    FH = 12
+    exp.setup(data=data, fh=FH, numeric_imputation_target="drift")
+
+    model = exp.create_model("exp_smooth")
+    final = exp.finalize_model(model)
+
+    exp.save_model(final, "my_model")
+    loaded_model = exp.load_model("my_model")
+
+    # Check if pipeline data index (PyCaretForecastingPipeline) matches up with
+    # the actual model data
+    assert len(loaded_model._y.index) == len(
+        loaded_model.steps[-1][1].steps[-1][1]._y.index
+    )
+    assert np.array_equal(
+        loaded_model._y.index, loaded_model.steps[-1][1].steps[-1][1]._y.index
+    )

--- a/pycaret/tests/test_time_series_utils_pipeline.py
+++ b/pycaret/tests/test_time_series_utils_pipeline.py
@@ -1,0 +1,398 @@
+"""Module to test time_series forecasting pipleine utils
+"""
+import pytest
+import numpy as np
+
+from sktime.forecasting.naive import NaiveForecaster
+
+from pycaret.utils.time_series.forecasting.pipeline import (
+    _add_model_to_pipeline,
+    _are_pipeline_tansformations_empty,
+    _get_imputed_data,
+)
+from pycaret.utils.time_series.forecasting.models import DummyForecaster
+from pycaret.time_series import TSForecastingExperiment
+
+
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
+
+##############################
+#### Functions Start Here ####
+##############################
+
+# NOTE: Fixtures can not be used to parameterize tests
+# https://stackoverflow.com/questions/52764279/pytest-how-to-parametrize-a-test-with-a-list-that-is-returned-from-a-fixture
+# Hence, we have to create functions and create the parameterized list first
+# (must happen during collect phase) before passing it to mark.parameterize.
+
+############################
+#### Functions End Here ####
+############################
+
+
+##########################
+#### Tests Start Here ####
+##########################
+
+
+def test_get_imputed_data_noexo(load_pos_data_missing):
+    """Tests _get_imputed_data WITHOUT exogenous variables"""
+    y = load_pos_data_missing
+
+    exp = TSForecastingExperiment()
+    FH = 12
+
+    ###################################
+    #### 1: Missing Values Present ####
+    ###################################
+    # Due to imputation, the imputed values will not be same as original
+
+    #### 1A: Missing Values Present: Only Imputation Steps in Pipeline ----
+    exp.setup(data=y, fh=FH, numeric_imputation_target="drift")
+    y_imputed, X_imputed = _get_imputed_data(pipeline=exp.pipeline, y=y)
+    assert not np.array_equal(y_imputed, y)
+    assert X_imputed is None
+
+    #### 1B: Missing Values Present: Imputation + Other Steps in Pipeline ----
+    y_imputed_expected = y_imputed.copy()
+    exp.setup(
+        data=y,
+        fh=FH,
+        numeric_imputation_target="drift",
+        transform_target="exp",
+    )
+    y_imputed, X_imputed = _get_imputed_data(pipeline=exp.pipeline, y=y)
+    assert not np.array_equal(y_imputed, y)
+    assert np.array_equal(y_imputed, y_imputed_expected)
+    assert X_imputed is None
+
+    #######################################
+    #### 2: Missing Values not Present ####
+    #######################################
+    # There are no missing values, so imputation should return original values
+
+    y_no_miss = y.copy()
+    y_no_miss.fillna(10, inplace=True)
+
+    #### 2A: Missing Values not Present: No imputation step in Pipeline ----
+    exp.setup(data=y_no_miss, fh=FH)
+    y_imputed, X_imputed = _get_imputed_data(pipeline=exp.pipeline, y=y_no_miss)
+    assert np.array_equal(y_imputed, y_no_miss)
+    assert X_imputed is None
+
+    #### 2B: Missing Values not Present: Only Imputation Steps in Pipeline ----
+    exp.setup(data=y_no_miss, fh=FH, numeric_imputation_target="drift")
+    y_imputed, X_imputed = _get_imputed_data(pipeline=exp.pipeline, y=y_no_miss)
+    assert np.array_equal(y_imputed, y_no_miss)
+    assert X_imputed is None
+
+    #### 2C: Missing Values not Present: Imputation + Other Steps in Pipeline ----
+    exp.setup(
+        data=y_no_miss,
+        fh=FH,
+        numeric_imputation_target="drift",
+        transform_target="exp",
+    )
+    y_imputed, X_imputed = _get_imputed_data(pipeline=exp.pipeline, y=y_no_miss)
+    assert np.array_equal(y_imputed, y_no_miss)
+    assert X_imputed is None
+
+
+def test_get_imputed_data_exo(load_uni_exo_data_target_missing):
+    """Tests _get_imputed_data WITH exogenous variables"""
+    data, target = load_uni_exo_data_target_missing
+    y = data[target]
+    X = data.drop(columns=target)
+
+    exp = TSForecastingExperiment()
+    FH = 12
+
+    ###################################
+    #### 1: Missing Values Present ####
+    ###################################
+    # Due to imputation, the imputed values will not be same as original
+
+    #### 1A: Missing Values Present: Only Imputation Steps in Pipeline ----
+    exp.setup(
+        data=data,
+        target=target,
+        fh=FH,
+        seasonal_period=4,
+        numeric_imputation_target="drift",
+        numeric_imputation_exogenous="drift",
+    )
+    y_imputed, X_imputed = _get_imputed_data(pipeline=exp.pipeline, y=y, X=X)
+    assert not np.array_equal(y_imputed, y)
+    assert not X_imputed.equals(X)
+
+    #### 1B: Missing Values Present: Imputation + Other Steps in Pipeline ----
+    y_imputed_expected = y_imputed.copy()
+    exp.setup(
+        data=data,
+        target=target,
+        fh=FH,
+        seasonal_period=4,
+        numeric_imputation_target="drift",
+        numeric_imputation_exogenous="drift",
+        transform_target="exp",
+        transform_exogenous="exp",
+    )
+    y_imputed, X_imputed = _get_imputed_data(pipeline=exp.pipeline, y=y, X=X)
+    assert not np.array_equal(y_imputed, y)
+    assert np.array_equal(y_imputed, y_imputed_expected)
+    assert not X_imputed.equals(X)
+
+    #######################################
+    #### 2: Missing Values not Present ####
+    #######################################
+    # There are no missing values, so imputation should return original values
+
+    data_no_miss = data.copy()
+    data_no_miss.fillna(10, inplace=True)
+    y_no_miss = data_no_miss[target]
+    X_no_miss = data_no_miss.drop(columns=target)
+
+    #### 2A: Missing Values not Present: No imputation step in Pipeline ----
+    exp.setup(data=data_no_miss, target=target, fh=FH, seasonal_period=4)
+    y_imputed, X_imputed = _get_imputed_data(
+        pipeline=exp.pipeline, y=y_no_miss, X=X_no_miss
+    )
+    assert np.array_equal(y_imputed, y_no_miss)
+    assert X_imputed.equals(X_no_miss)
+
+    #### 2B: Missing Values not Present: Only Imputation Steps in Pipeline ----
+    exp.setup(
+        data=data_no_miss,
+        target=target,
+        fh=FH,
+        seasonal_period=4,
+        numeric_imputation_target="drift",
+        numeric_imputation_exogenous="drift",
+    )
+    y_imputed, X_imputed = _get_imputed_data(
+        pipeline=exp.pipeline, y=y_no_miss, X=X_no_miss
+    )
+    assert np.array_equal(y_imputed, y_no_miss)
+    assert X_imputed.equals(X_no_miss)
+
+    #### 2C: Missing Values not Present: Imputation + Other Steps in Pipeline ----
+    exp.setup(
+        data=data_no_miss,
+        target=target,
+        fh=FH,
+        seasonal_period=4,
+        numeric_imputation_target="drift",
+        numeric_imputation_exogenous="drift",
+        transform_target="exp",
+        transform_exogenous="exp",
+    )
+    y_imputed, X_imputed = _get_imputed_data(
+        pipeline=exp.pipeline, y=y_no_miss, X=X_no_miss
+    )
+    assert np.array_equal(y_imputed, y_no_miss)
+    assert X_imputed.equals(X_no_miss)
+
+
+def test_are_pipeline_tansformations_empty_noexo(load_pos_data_missing):
+    """Tests _are_pipeline_tansformations_empty WITHOUT exogenous variables"""
+    y = load_pos_data_missing
+
+    y_no_miss = y.copy()
+    y_no_miss.fillna(10, inplace=True)
+
+    exp = TSForecastingExperiment()
+    FH = 12
+
+    ###############################
+    #### 1: Not Empty Pipeline ####
+    ###############################
+
+    #### 1A: Data has missing values ----
+    exp.setup(data=y, fh=FH, numeric_imputation_target="drift")
+    assert not _are_pipeline_tansformations_empty(pipeline=exp.pipeline)
+
+    #### 1B: Data has no missing values, but y impute step added ----
+    # Even though data has no missing values, imputation step is added as user has requested
+    exp.setup(data=y_no_miss, fh=FH, numeric_imputation_target="drift")
+    assert not _are_pipeline_tansformations_empty(pipeline=exp.pipeline)
+
+    ###########################
+    #### 2: Empty Pipeline ####
+    ###########################
+
+    #### 2A: No Imputation in Pipeline ----
+    exp.setup(data=y_no_miss, fh=FH)
+    assert _are_pipeline_tansformations_empty(pipeline=exp.pipeline)
+
+
+def test_are_pipeline_tansformations_empty_exo(load_uni_exo_data_target_missing):
+    """Tests _are_pipeline_tansformations_empty WITH exogenous variables"""
+    data, target = load_uni_exo_data_target_missing
+    data_no_miss = data.copy()
+    data_no_miss.fillna(10, inplace=True)
+
+    exp = TSForecastingExperiment()
+    FH = 12
+
+    ###############################
+    #### 1: Not Empty Pipeline ####
+    ###############################
+
+    #### 1A: Both y and X have missing values ----
+    exp.setup(
+        data=data,
+        target=target,
+        fh=FH,
+        seasonal_period=4,
+        numeric_imputation_target="drift",
+        numeric_imputation_exogenous="drift",
+    )
+    assert not _are_pipeline_tansformations_empty(pipeline=exp.pipeline)
+
+    #### 1B: Data has no missing values, but y impute step added ----
+    # Even though data has no missing values, imputation step y is added as user has requested
+    exp.setup(
+        data=data_no_miss,
+        target=target,
+        fh=FH,
+        seasonal_period=4,
+        numeric_imputation_target="drift",
+    )
+    assert not _are_pipeline_tansformations_empty(pipeline=exp.pipeline)
+
+    #### 1C: Data has no missing values, but X impute step added ----
+    # Even though data has no missing values, imputation step X is added as user has requested
+    exp.setup(
+        data=data_no_miss,
+        target=target,
+        fh=FH,
+        seasonal_period=4,
+        numeric_imputation_exogenous="drift",
+    )
+    assert not _are_pipeline_tansformations_empty(pipeline=exp.pipeline)
+
+    ###########################
+    #### 2: Empty Pipeline ####
+    ###########################
+
+    #### 2A: No Imputation in Pipeline ----
+    exp.setup(data=data_no_miss, target=target, fh=FH, seasonal_period=4)
+    assert _are_pipeline_tansformations_empty(pipeline=exp.pipeline)
+
+
+def test_add_model_to_pipeline_noexo(load_pos_and_neg_data):
+    """Tests _add_model_to_pipeline WITHOUT exogenous variables"""
+    y = load_pos_and_neg_data
+
+    exp = TSForecastingExperiment()
+    FH = 12
+    model = NaiveForecaster()
+
+    ###########################
+    #### 1: Empty Pipeline ####
+    ###########################
+
+    exp.setup(data=y, fh=FH)
+
+    # Check that the final model has changed ----
+    assert isinstance(exp.pipeline.steps[-1][1].steps[-1][1], DummyForecaster)
+    pipeline = _add_model_to_pipeline(pipeline=exp.pipeline, model=model)
+    assert isinstance(pipeline.steps[-1][1].steps[-1][1], NaiveForecaster)
+
+    # Check that the steps for X in the Forecasting Pipeline have not changed ----
+    for i in np.arange(len(exp.pipeline.steps_)):
+        assert type(exp.pipeline.steps_[i][1]) is type(pipeline.steps_[i][1])
+
+    # Check that the steps for y in the Forecasting Pipeline have not changed ----
+    tgt_fcst_org = exp.pipeline.steps_[-1][1]
+    tgt_fcst_new = pipeline.steps_[-1][1]
+    # Check except last step which has been checked above (Dummy vs Naive)
+    for i in np.arange(len(tgt_fcst_org.steps_) - 1):
+        assert type(tgt_fcst_org.steps_[i][1]) is type(tgt_fcst_new.steps_[i][1])
+
+    ###############################
+    #### 2: Not Empty Pipeline ####
+    ###############################
+
+    exp.setup(data=y, fh=FH, numeric_imputation_target="drift")
+
+    # Check that the final model has changed ----
+    assert isinstance(exp.pipeline.steps[-1][1].steps[-1][1], DummyForecaster)
+    pipeline = _add_model_to_pipeline(pipeline=exp.pipeline, model=model)
+    assert isinstance(pipeline.steps[-1][1].steps[-1][1], NaiveForecaster)
+
+    # Check that the steps for X in the Forecasting Pipeline have not changed ----
+    for i in np.arange(len(exp.pipeline.steps_)):
+        assert type(exp.pipeline.steps_[i][1]) is type(pipeline.steps_[i][1])
+
+    # Check that the steps for y in the Forecasting Pipeline have not changed ----
+    tgt_fcst_org = exp.pipeline.steps_[-1][1]
+    tgt_fcst_new = pipeline.steps_[-1][1]
+    # Check except last step which has been checked above (Dummy vs Naive)
+    for i in np.arange(len(tgt_fcst_org.steps_) - 1):
+        assert type(tgt_fcst_org.steps_[i][1]) is type(tgt_fcst_new.steps_[i][1])
+
+
+def test_add_model_to_pipeline_exo(load_uni_exo_data_target):
+    """Tests _add_model_to_pipeline WITH exogenous variables"""
+    data, target = load_uni_exo_data_target
+
+    exp = TSForecastingExperiment()
+    FH = 12
+    model = NaiveForecaster()
+
+    ###########################
+    #### 1: Empty Pipeline ####
+    ###########################
+
+    exp.setup(
+        data=data,
+        target=target,
+        fh=FH,
+        seasonal_period=4,
+    )
+
+    # Check that the final model has changed ----
+    assert isinstance(exp.pipeline.steps[-1][1].steps[-1][1], DummyForecaster)
+    pipeline = _add_model_to_pipeline(pipeline=exp.pipeline, model=model)
+    assert isinstance(pipeline.steps[-1][1].steps[-1][1], NaiveForecaster)
+
+    # Check that the steps for X in the Forecasting Pipeline have not changed ----
+    for i in np.arange(len(exp.pipeline.steps_)):
+        assert type(exp.pipeline.steps_[i][1]) is type(pipeline.steps_[i][1])
+
+    # Check that the steps for y in the Forecasting Pipeline have not changed ----
+    tgt_fcst_org = exp.pipeline.steps_[-1][1]
+    tgt_fcst_new = pipeline.steps_[-1][1]
+    # Check except last step which has been checked above (Dummy vs Naive)
+    for i in np.arange(len(tgt_fcst_org.steps_) - 1):
+        assert type(tgt_fcst_org.steps_[i][1]) is type(tgt_fcst_new.steps_[i][1])
+
+    ###############################
+    #### 2: Not Empty Pipeline ####
+    ###############################
+
+    exp.setup(
+        data=data,
+        target=target,
+        fh=FH,
+        seasonal_period=4,
+        numeric_imputation_target="drift",
+        numeric_imputation_exogenous="drift",
+    )
+
+    # Check that the final model has changed ----
+    assert isinstance(exp.pipeline.steps[-1][1].steps[-1][1], DummyForecaster)
+    pipeline = _add_model_to_pipeline(pipeline=exp.pipeline, model=model)
+    assert isinstance(pipeline.steps[-1][1].steps[-1][1], NaiveForecaster)
+
+    # Check that the steps for X in the Forecasting Pipeline have not changed ----
+    for i in np.arange(len(exp.pipeline.steps_)):
+        assert type(exp.pipeline.steps_[i][1]) is type(pipeline.steps_[i][1])
+
+    # Check that the steps for y in the Forecasting Pipeline have not changed ----
+    tgt_fcst_org = exp.pipeline.steps_[-1][1]
+    tgt_fcst_new = pipeline.steps_[-1][1]
+    # Check except last step which has been checked above (Dummy vs Naive)
+    for i in np.arange(len(tgt_fcst_org.steps_) - 1):
+        assert type(tgt_fcst_org.steps_[i][1]) is type(tgt_fcst_new.steps_[i][1])

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -910,9 +910,12 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
                 exogenous_present=self.exogenous_present,
             )
 
-        # # Add custom transformers to the pipeline
+        # TODO Add custom transformers to the pipeline
         # if custom_pipeline:
         #     self._add_custom_pipeline(custom_pipeline)
+        # TODO: When adding custom pipeline, also add checks to make sure:
+        # (1) 1st step for both X and y is Imputer
+        # (2) If 1st step is imputer, there can be other imputers as well.
 
         self.pipeline = self._create_pipeline(
             model=DummyForecaster(),

--- a/pycaret/utils/time_series/forecasting/model_selection.py
+++ b/pycaret/utils/time_series/forecasting/model_selection.py
@@ -20,6 +20,11 @@ from sklearn.model_selection._search import _check_param_grid  # type: ignore
 from sklearn.model_selection._validation import _aggregate_score_dicts  # type: ignore
 from sktime.utils.validation.forecasting import check_y_X  # type: ignore
 
+from sktime.forecasting.model_selection import (
+    ExpandingWindowSplitter,
+    SlidingWindowSplitter,
+)
+
 from pycaret.internal.utils import get_function_params
 from pycaret.utils import _get_metrics_dict
 from pycaret.utils.time_series.forecasting import (
@@ -44,19 +49,19 @@ def get_folds(cv, y) -> Generator[Tuple[pd.Series, pd.Series], None, None]:
 
 
 def _fit_and_score(
-    forecaster: PyCaretForecastingPipeline,
+    pipeline: PyCaretForecastingPipeline,
     y: pd.Series,
     X: Optional[Union[pd.Series, pd.DataFrame]],
     scoring: Dict[str, Union[str, _PredictScorer]],
     train: np.ndarray,
     test: np.ndarray,
-    parameters,
-    fit_params,
-    return_train_score,
+    parameters: Optional[Dict[str, Any]],
+    fit_params: Dict[str, Any],
+    return_train_score: bool,
     error_score=0,
     **additional_scorer_kwargs,
-):
-    """Fits the forecaster on a single train split and scores on the test split
+) -> Tuple[Dict[str, float], float, float, Union[pd.PeriodIndex, Any]]:
+    """Fits the pipeline on a single train split and scores on the test split
     Similar to _fit_and_score from `sklearn` [1] (and to some extent `sktime` [2]).
     Difference is that [1] operates on a single fold only, whereas [2] operates on all cv folds.
     Ref:
@@ -65,29 +70,48 @@ def _fit_and_score(
 
     Parameters
     ----------
-    forecaster : [type]
-        Time Series Forecaster that is compatible with sktime
+    pipeline : PyCaretForecastingPipeline
+        Pycaret Forecasting Pipeline that needs to be fitted and scored.
     y : pd.Series
-        The variable of interest for forecasting
+        Target variable values that need to be used for forecasting. This should be the
+        untransformed (original) values. Transformation will happen in the fitting process.
     X : Optional[Union[pd.Series, pd.DataFrame]]
-        Exogenous Variables
+        Exogenous Variable values to be used for forecasting. This should be the
+        untransformed (original) values. Transformation will happen in the fitting process.
     scoring : Dict[str, Union[str, _PredictScorer]]
         Scoring Dictionary. Values can be valid strings that can be converted to
         callable metrics or the callable metrics directly
+        e.g.
+            {
+                'mae': make_scorer(mean_absolute_error, greater_is_better=False)
+                ,'r2': make_scorer(r2_score)
+            }
     train : np.ndarray
         Indices of training samples (integer based indexing).
     test : np.ndarray
         Indices of test samples (integer based indexing).
-    parameters : [type]
-        Parameter to set for the forecaster
-    fit_params : [type]
-        Fit parameters to be used when training
-    return_train_score : [type]
+    parameters : Optional[Dict[str, Any]]
+        Parameter to set for the pipeline. e.g.
+        {'forecaster__model__use_boxcox': True, 'forecaster__model__trend': 'mul'}
+    fit_params : Dict[str, Any]
+        Fit parameters to be used when training the model
+        e.g. {'fh': ForecastingHorizon([1, 2, 3], is_relative=True)}
+    return_train_score : bool
         Should the training scores be returned. Unused for now.
-    error_score : int, optional
+    error_score : float, optional
         Unused for now, by default 0
     **additional_scorer_kwargs: Dict[str, Any]
-            Additional scorer kwargs such as {`sp`:12} required by metrics like MASE
+        Additional scorer kwargs such as {`sp`:12} required by metrics like MASE
+
+    Returns
+    -------
+    Tuple[Dict[str, float], float, float, Union[pd.PeriodIndex, Any]]
+        In order
+        (1) Metrics: e.g. {'mae': 31.66, 'rmse': 38.18, 'mape': 0.083}
+        (2) Fit Time Taken
+        (3) Score Time taken
+        (4) Cutoff Index value between training and test (based on `train` and `test`
+            arguments), e.g. Period('1956-12', 'M')
 
     Raises
     ------
@@ -96,9 +120,9 @@ def _fit_and_score(
         for internal checks and should not be raised when used by external users
     """
     if parameters is not None:
-        forecaster.set_params(**parameters)
+        pipeline.set_params(**parameters)
 
-    y_imputed, _ = _get_imputed_data(pipeline=forecaster, y=y, X=X)
+    y_imputed, _ = _get_imputed_data(pipeline=pipeline, y=y, X=X)
 
     # y_train, X_train, X_test can have missing values since pipeline will impute them
     y_train = y[train]
@@ -122,9 +146,9 @@ def _fit_and_score(
     #### Fit the forecaster ----
     start = time.time()
     try:
-        forecaster.fit(y_train, X_train, **fit_params)
+        pipeline.fit(y_train, X_train, **fit_params)
     except Exception as error:
-        logging.error(f"Fit failed on {forecaster}")
+        logging.error(f"Fit failed on {pipeline}")
         logging.error(error)
 
         if error_score == "raise":
@@ -134,15 +158,15 @@ def _fit_and_score(
 
     #### Determine Cutoff ----
     # NOTE: Cutoff is available irrespective of whether fit passed or failed
-    cutoff = forecaster.cutoff
+    cutoff = pipeline.cutoff
 
     #### Score the model ----
     lower = pd.Series([])
     upper = pd.Series([])
-    if forecaster.is_fitted:
+    if pipeline.is_fitted:
         # TODO: Add alpha here???
         y_pred, lower, upper = get_predictions_with_intervals(
-            forecaster=forecaster, X=X_test
+            forecaster=pipeline, X=X_test
         )
 
         if (y_test_imputed.index.values != y_pred.index.values).any():
@@ -168,7 +192,7 @@ def _fit_and_score(
         upper=upper,
     )
     for scorer_name, scorer in scoring.items():
-        if forecaster.is_fitted:
+        if pipeline.is_fitted:
             # get all kwargs in additional_scorer_kwargs
             # that correspond to parameters in function signature
             kwargs = {
@@ -195,18 +219,18 @@ def _fit_and_score(
 
 
 def cross_validate(
-    forecaster,
+    pipeline: PyCaretForecastingPipeline,
     y: pd.Series,
     X: Optional[Union[pd.Series, pd.DataFrame]],
-    cv,
+    cv: Union[ExpandingWindowSplitter, SlidingWindowSplitter],
     scoring: Dict[str, Union[str, _PredictScorer]],
-    fit_params,
-    n_jobs,
-    return_train_score,
-    error_score=0,
+    fit_params: Dict[str, Any],
+    n_jobs: Optional[int],
+    return_train_score: bool,
+    error_score: float = 0,
     verbose: int = 0,
     **additional_scorer_kwargs,
-) -> Dict[str, np.array]:
+) -> Tuple[Dict[str, np.ndarray], Tuple[Union[pd.PeriodIndex, Any]]]:
     """Performs Cross Validation on time series data
 
     Parallelization is based on `sklearn` cross_validate function [1]
@@ -216,24 +240,32 @@ def cross_validate(
 
     Parameters
     ----------
-    forecaster : [type]
-        Time Series Forecaster that is compatible with sktime
+    pipeline : PyCaretForecastingPipeline
+        Pycaret Forecasting Pipeline that needs to be cross-validated.
     y : pd.Series
-        The variable of interest for forecasting
+        Target variable values that need to be used for forecasting. This should be the
+        untransformed (original) values. Transformation will happen in the fitting process.
     X : Optional[Union[pd.Series, pd.DataFrame]]
-        Exogenous Variables
-    cv : [type]
-        [description]
+        Exogenous Variable values to be used for forecasting. This should be the
+        untransformed (original) values. Transformation will happen in the fitting process.
+    cv : Union[ExpandingWindowSplitter, SlidingWindowSplitter]
+        The sktime compatible cross-validation object.
     scoring : Dict[str, Union[str, _PredictScorer]]
         Scoring Dictionary. Values can be valid strings that can be converted to
         callable metrics or the callable metrics directly
-    fit_params : [type]
-        Fit parameters to be used when training
-    n_jobs : [type]
+        e.g.
+            {
+                'mae': make_scorer(mean_absolute_error, greater_is_better=False)
+                ,'r2': make_scorer(r2_score)
+            }
+    fit_params : Dict[str, Any]
+        Fit parameters to be used when training the model
+        e.g. {'fh': ForecastingHorizon([1, 2, 3], is_relative=True)}
+    n_jobs : Optional[int]
         Number of cores to use to parallelize. Refer to sklearn for details
-    return_train_score : [type]
+    return_train_score : bool
         Should the training scores be returned. Unused for now.
-    error_score : int, optional
+    error_score : float, optional
         Unused for now, by default 0
     verbose : int
         Sets the verbosity level. Unused for now
@@ -242,8 +274,12 @@ def cross_validate(
 
     Returns
     -------
-    [type]
-        [description]
+    Tuple[Dict[str, np.ndarray], Tuple[Union[pd.PeriodIndex, Any]]]
+        In order
+        (1) Metrics for all folds, e.g.
+            {'mae': array([28.32, 30.24, 21.42]), 'rmse': array([33.34, 87.48, 71.21])}
+        (2) Cutoff Index value between training and test for each fold, e.g.
+            (Period('1956-12', 'M'), Period('1957-12', 'M'), Period('1958-12', 'M'))
 
     Raises
     ------
@@ -251,14 +287,12 @@ def cross_validate(
         If fit and score raises any exceptions
     """
     try:
-        # # For Debug
-        # n_jobs = 1
         scoring = _get_metrics_dict(scoring)
         parallel = Parallel(n_jobs=n_jobs)
 
         out = parallel(
             delayed(_fit_and_score)(
-                forecaster=clone(forecaster),
+                pipeline=clone(pipeline),
                 y=y,
                 X=X,
                 scoring=scoring,
@@ -294,8 +328,8 @@ class BaseGridSearch:
 
     def __init__(
         self,
-        forecaster,
-        cv,
+        pipeline: PyCaretForecastingPipeline,
+        cv: Union[ExpandingWindowSplitter, SlidingWindowSplitter],
         n_jobs=None,
         pre_dispatch=None,
         refit: bool = False,
@@ -305,7 +339,40 @@ class BaseGridSearch:
         error_score=None,
         return_train_score=None,
     ):
-        self.forecaster = forecaster
+        """Base Grid Search Object
+
+        Parameters
+        ----------
+        pipeline : PyCaretForecastingPipeline
+            Pycaret Forecasting Pipeline that needs to be used for Grid Search.
+        cv : Union[ExpandingWindowSplitter, SlidingWindowSplitter]
+            The sktime compatible cross-validation object.
+        n_jobs : Optional[int]
+            Number of cores to use to parallelize. Refer to sklearn for details,
+            by default None
+        pre_dispatch : _type_, optional
+            Pre dispatch to use for Parallelization, by default None
+        refit : bool, optional
+            Should the pipeline be refit on the best parameters from the grid search,
+            by default False
+        refit_metric : str, optional
+            Metric to use to decide the best parameters for refitting, by default "smape"
+        scoring : Dict[str, Union[str, _PredictScorer]]
+            Scoring Dictionary. Values can be valid strings that can be converted to
+            callable metrics or the callable metrics directly
+            e.g.
+                {
+                    'mae': make_scorer(mean_absolute_error, greater_is_better=False)
+                    ,'r2': make_scorer(r2_score)
+                }
+        verbose : int, optional
+            Verbosity to use, by default 0
+        error_score : float, optional
+            Unused for now, by default 0
+        return_train_score : bool
+            Should the training scores be returned. Unused for now, by default None
+        """
+        self.pipeline = pipeline
         self.cv = cv
         self.n_jobs = n_jobs
         self.pre_dispatch = pre_dispatch
@@ -331,9 +398,12 @@ class BaseGridSearch:
         Parameters
         ----------
         y : pd.Series
-            Target
-        X : Optional[pd.DataFrame], optional
-            Exogenous Variables, by default None
+            Target variable values that need to be used for forecasting. This should be the
+            untransformed (original) values. Transformation will happen in the fitting process.
+        X : Optional[Union[pd.Series, pd.DataFrame]]
+            Exogenous Variable values to be used for forecasting. This should be the
+            untransformed (original) values. Transformation will happen in the fitting process,
+            by default None
         additional_scorer_kwargs: Dict[str, Any]
             Additional scorer kwargs such as {`sp`:12} required by metrics like MASE
         **fit_params: Dict[str, Any]
@@ -359,7 +429,7 @@ class BaseGridSearch:
 
         # validate cross-validator
         cv = check_cv(self.cv)
-        base_forecaster = clone(self.forecaster)
+        base_pipeline = clone(self.pipeline)
 
         # This checker is sktime specific and only support 1 metric
         # Removing for now since we can have multiple metrics
@@ -385,7 +455,7 @@ class BaseGridSearch:
             n_splits = cv.get_n_splits(y)
 
             if self.verbose > 0:
-                print(  # noqa
+                print(
                     f"Fitting {n_splits} folds for each of {n_candidates} "
                     f"candidates, totalling {n_candidates * n_splits} fits"
                 )
@@ -395,7 +465,7 @@ class BaseGridSearch:
             )
             out = parallel(
                 delayed(_fit_and_score)(
-                    forecaster=clone(base_forecaster),
+                    pipeline=clone(base_pipeline),
                     y=y,
                     X=X,
                     scoring=scorers,
@@ -433,11 +503,11 @@ class BaseGridSearch:
         self.best_score_ = results["mean_test_%s" % refit_metric][self.best_index_]
         self.best_params_ = results["params"][self.best_index_]
 
-        self.best_forecaster_ = clone(base_forecaster).set_params(**self.best_params_)
+        self.best_pipeline_ = clone(base_pipeline).set_params(**self.best_params_)
 
         if self.refit:
             refit_start_time = time.time()
-            self.best_forecaster_.fit(y, X, **fit_params)
+            self.best_pipeline_.fit(y, X, **fit_params)
             self.refit_time_ = time.time() - refit_start_time
 
         # Store the only scorer not as a dict for single metric evaluation
@@ -561,7 +631,7 @@ class ForecastingGridSearchCV(BaseGridSearch):
         return_train_score=False,
     ):
         super(ForecastingGridSearchCV, self).__init__(
-            forecaster=forecaster,
+            pipeline=forecaster,
             cv=cv,
             n_jobs=n_jobs,
             pre_dispatch=pre_dispatch,
@@ -604,7 +674,7 @@ class ForecastingRandomizedSearchCV(BaseGridSearch):
         return_train_score=False,
     ):
         super(ForecastingRandomizedSearchCV, self).__init__(
-            forecaster=forecaster,
+            pipeline=forecaster,
             cv=cv,
             n_jobs=n_jobs,
             pre_dispatch=pre_dispatch,

--- a/pycaret/utils/time_series/forecasting/pipeline.py
+++ b/pycaret/utils/time_series/forecasting/pipeline.py
@@ -126,11 +126,17 @@ def _get_imputed_data(
         Imputed y and X values respectively
     """
 
-    X_imputed = X.copy() if X is not None else None
-    for _, transformer_X in pipeline.steps_:
-        if isinstance(transformer_X, Imputer):
-            X_imputed = transformer_X.fit_transform(X)
-            continue
+    if X is None:
+        # No exogenous variables
+        # Note: fit_transform does not work when X is None
+        X_imputed = None
+    else:
+        # Exogenous variables present
+        X_imputed = X.copy()
+        for _, transformer_X in pipeline.steps_:
+            if isinstance(transformer_X, Imputer):
+                X_imputed = transformer_X.fit_transform(X, y)
+                continue
 
     y_imputed = y.copy()
     for _, transformer_y in pipeline.steps_[-1][1].steps_:

--- a/pycaret/utils/time_series/forecasting/pipeline.py
+++ b/pycaret/utils/time_series/forecasting/pipeline.py
@@ -145,3 +145,31 @@ def _get_imputed_data(
             continue
 
     return y_imputed, X_imputed
+
+
+def _get_pipeline_estimator_label(
+    pipeline: PyCaretForecastingPipeline,
+) -> str:
+    """Returns the name of the Transformed Target Forecaster in the pipeline along
+    with the name of the final model step in the pipeline.
+
+    These names can be used to adjust the search space while tuning the pipeline in
+    tune_models (defined search space is only for the models, but we pass the entire
+    pipeline for tuning. Hence the model search space has to be adjusted appropriately
+    by adding the step names in front).
+
+    Parameters
+    ----------
+    pipeline : PyCaretForecastingPipeline
+        The pipeline used for modeling
+
+    Returns
+    -------
+    str
+        Name of the TransformedTargetForecaster in the pipeline and the name of
+        the final model inside the TransformedTargetForecaster. Returns a single
+        string appended with "__".
+    """
+    name_ttf, transformed_target_forecaster = pipeline.steps_[-1]
+    name_model, _ = transformed_target_forecaster.steps_[-1]
+    return name_ttf + "__" + name_model


### PR DESCRIPTION
## Related Issuse or bug

Closes #2369 
Closes #2400 

#### Describe the changes you've made

- Metric calculation now uses the imputed data on the entire dataset as ground truth value.
- Fixed `tune_model` to make it work with pipeline
- Fix for finalized model having wrong memory in the `PyCaretForecastingPipeline`, but correct one in the internal model.
- Cleaned up documentation
- Added checks in code to avoid unexpected conditions
- Added many tests including some for critical pipeline functions.
- Updated docstring to make data type clear with examples

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- New unit tests have been added.
- Existing checks run locally

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
