### PR TITLE
Missing Data plot fixes

### DIFF
--- a/pycaret/internal/pycaret_experiment/pycaret_experiment.py
+++ b/pycaret/internal/pycaret_experiment/pycaret_experiment.py
@@ -564,7 +564,10 @@ class _PyCaretExperiment:
             # In time series, the order of arguments and returns may be reversed.
             # When transforming the test set, we can and should use all data before that
             _, X = self.pipeline.transform(y=self.y, X=self.X)
-            return X.loc[self.X_test.index]
+            if X is None:
+                return None
+            else:
+                return X.loc[self.X_test.index]
 
     @property
     def y_train_transformed(self):

--- a/pycaret/internal/pycaret_experiment/pycaret_experiment.py
+++ b/pycaret/internal/pycaret_experiment/pycaret_experiment.py
@@ -562,7 +562,9 @@ class _PyCaretExperiment:
             return self.pipeline.transform(self.X_test, self.y_test)[0]
         else:
             # In time series, the order of arguments and returns may be reversed.
-            return self.pipeline.transform(y=self.y_test, X=self.X_test)[1]
+            # When transforming the test set, we can and should use all data before that
+            _, X = self.pipeline.transform(y=self.y, X=self.X)
+            return X.loc[self.X_test.index]
 
     @property
     def y_train_transformed(self):
@@ -580,4 +582,6 @@ class _PyCaretExperiment:
             return self.pipeline.transform(self.X_test, self.y_test)[1]
         else:
             # In time series, the order of arguments and returns may be reversed.
-            return self.pipeline.transform(y=self.y_test, X=self.X_test)[0]
+            # When transforming the test set, we can and should use all data before that
+            y, _ = self.pipeline.transform(y=self.y, X=self.X)
+            return y.loc[self.y_test.index]

--- a/pycaret/tests/test_time_series_plots.py
+++ b/pycaret/tests/test_time_series_plots.py
@@ -1,4 +1,4 @@
-"""Module to test time_series functionality
+"""Module to test time_series plotting functionality
 """
 import os
 from random import uniform

--- a/pycaret/tests/test_time_series_utils_plots.py
+++ b/pycaret/tests/test_time_series_utils_plots.py
@@ -1,0 +1,107 @@
+"""Module to test time_series plotting functionality
+"""
+import pytest
+
+import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
+
+from typing import List
+
+from .time_series_test_utils import _ALL_PLOTS
+
+from pycaret.internal.plots.utils.time_series import (
+    _resolve_hoverinfo,
+    _resolve_renderer,
+    _get_data_types_to_plot,
+    _reformat_dataframes_for_plots,
+    ALLOWED_PLOT_DATA_TYPES,
+    MULTIPLE_PLOT_TYPES_ALLOWED_AT_ONCE,
+)
+
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
+
+
+##########################
+#### Tests Start Here ####
+##########################
+
+
+@pytest.mark.parametrize("plot", _ALL_PLOTS)
+def test_get_data_types_to_plot(plot):
+    """_summary_"""
+    if plot is not None:
+        ############################################################
+        #### 1. Nothing requested explicitly - returns defaults ----
+        ############################################################
+        returned_val = _get_data_types_to_plot(plot=plot)
+        expected = [ALLOWED_PLOT_DATA_TYPES.get(plot)[0]]
+        assert isinstance(returned_val, List)
+        assert returned_val == expected
+
+        #####################################
+        #### 2. Allowed values requested ----
+        #####################################
+        data_types_requested = ALLOWED_PLOT_DATA_TYPES.get(plot)
+        returned_val = _get_data_types_to_plot(
+            plot=plot, data_types_requested=data_types_requested
+        )
+        assert isinstance(returned_val, List)
+
+        accepts_multiple = MULTIPLE_PLOT_TYPES_ALLOWED_AT_ONCE.get(plot)
+        if accepts_multiple:
+            #### 2A. Multiple data types can be plotted at once ----
+            assert returned_val == data_types_requested
+        else:
+            #### 2B. Only one data type can be plotted at once ----
+            assert returned_val == [data_types_requested[0]]
+
+        ######################################
+        #### 3. Incorrect value requested ----
+        ######################################
+        with pytest.raises(ValueError) as errmsg:
+            _ = _get_data_types_to_plot(plot=plot, data_types_requested="wrong")
+
+        # Capture Error message
+        exceptionmsg = errmsg.value.args[0]
+
+        # Check exact error received
+        assert (
+            "No data to plot. Please check to make sure that you have requested "
+            "an allowed data type for plot" in exceptionmsg
+        )
+
+
+def test_reformat_dataframes_for_plots():
+    """Tests for _reformat_dataframes_for_plots"""
+    df1 = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    df2 = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    input_dfs = [df1, df2]
+    labels_suffix = ["original", "imputed"]
+    expected_cols = [
+        ["a (original)", "a (imputed)"],
+        ["b (original)", "b (imputed)"],
+        ["c (original)", "c (imputed)"],
+    ]
+
+    #### 1. Correct Working ----
+    output_dfs = _reformat_dataframes_for_plots(
+        data=input_dfs, labels_suffix=labels_suffix
+    )
+
+    assert isinstance(output_dfs, List)
+    for item, expected_cols in zip(output_dfs, expected_cols):
+        assert isinstance(item, pd.DataFrame)
+        assert item.columns.to_list() == expected_cols
+
+    #### Error raised ----
+    with pytest.raises(ValueError) as errmsg:
+        labels_suffix = ["original"]
+        output_dfs = _reformat_dataframes_for_plots(
+            data=input_dfs, labels_suffix=labels_suffix
+        )
+
+    # Capture Error message
+    exceptionmsg = errmsg.value.args[0]
+
+    # Check exact error received
+    assert f"does not match the number of input dataframes" in exceptionmsg


### PR DESCRIPTION
## Related Issuse or bug

- Partially Implements #2364
- Also fixed a bug in the retrieval of test values

#### Describe the changes you've made

- Added ability for `ts` and `train_test_split` plots to accept different plot data types - "original", "imputed", "transformed"
- Also fixed a bug in the retrieval of test values - these should be computed by passing the entire dataset through the pipeline and then retrieving the transformed test set values instead of just the test set through the pipeline (since we can use all past data but no future data)dataset values


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit tests have been added for plotting as well as pipeline


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

