### PR TITLE
changes to `check_stats`, `setup` display & arguments

### DIFF
--- a/pycaret/internal/tests/stats.py
+++ b/pycaret/internal/tests/stats.py
@@ -51,6 +51,7 @@ def _summary_stats(
         distinct_counts = dict(data_.value_counts(normalize=True))
         results = {
             "Length": len(data_),
+            "# Missing Values": data_.isna().sum(),
             "Mean": data_.mean(),
             "Median": data_.median(),
             "Standard Deviation": data_.std(),
@@ -168,4 +169,3 @@ def _is_gaussian(
         return is_gaussian_list, results
     else:
         return is_gaussian_list
-

--- a/pycaret/tests/test_time_series_preprocess.py
+++ b/pycaret/tests/test_time_series_preprocess.py
@@ -83,19 +83,18 @@ def test_pipeline_types_no_exo(load_pos_and_neg_data):
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
     #### Transform Target only
-    exp.setup(data=data, preprocess=True, numeric_imputation_target=True)
+    exp.setup(data=data, numeric_imputation_target=True)
     assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
     #### Transform Exogenous only (but no exogenous present)
-    exp.setup(data=data, preprocess=True, numeric_imputation_exogenous=True)
+    exp.setup(data=data, numeric_imputation_exogenous=True)
     assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
     #### Transform Exogenous & Target (but no exogenous present)
     exp.setup(
         data=data,
-        preprocess=True,
         numeric_imputation_target=True,
         numeric_imputation_exogenous=True,
     )
@@ -103,7 +102,7 @@ def test_pipeline_types_no_exo(load_pos_and_neg_data):
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
     # No preprocessing (still sets empty pipeline internally)
-    exp.setup(data=data, preprocess=False)
+    exp.setup(data=data)
     assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
@@ -125,7 +124,6 @@ def test_pipeline_types_exo(load_uni_exo_data_target):
         data=data,
         target=target,
         seasonal_period=4,
-        preprocess=True,
         numeric_imputation_target=True,
     )
     assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
@@ -136,7 +134,6 @@ def test_pipeline_types_exo(load_uni_exo_data_target):
         data=data,
         target=target,
         seasonal_period=4,
-        preprocess=True,
         numeric_imputation_exogenous=True,
     )
     assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
@@ -147,7 +144,6 @@ def test_pipeline_types_exo(load_uni_exo_data_target):
         data=data,
         target=target,
         seasonal_period=4,
-        preprocess=True,
         numeric_imputation_target=True,
         numeric_imputation_exogenous=True,
     )
@@ -155,7 +151,7 @@ def test_pipeline_types_exo(load_uni_exo_data_target):
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
     # No preprocessing (still sets empty pipeline internally)
-    exp.setup(data=data, target=target, seasonal_period=4, preprocess=False)
+    exp.setup(data=data, target=target, seasonal_period=4)
     assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
@@ -168,12 +164,12 @@ def test_preprocess_setup_raises_missing_no_exo(load_pos_and_neg_data_missing):
     exp = TSForecastingExperiment()
 
     with pytest.raises(ValueError) as errmsg:
-        exp.setup(data=data, preprocess=False)
+        exp.setup(data=data)
     exceptionmsg = errmsg.value.args[0]
     assert "Please enable imputation to proceed" in exceptionmsg
 
     with pytest.raises(ValueError) as errmsg:
-        exp.setup(data=data, preprocess=True, numeric_imputation_target=None)
+        exp.setup(data=data, numeric_imputation_target=None)
     exceptionmsg = errmsg.value.args[0]
     assert "Please enable imputation to proceed" in exceptionmsg
 
@@ -186,7 +182,7 @@ def test_preprocess_setup_raises_missing_exo(load_uni_exo_data_target_missing):
 
     exp = TSForecastingExperiment()
     with pytest.raises(ValueError) as errmsg:
-        exp.setup(data=data, target=target, seasonal_period=4, preprocess=False)
+        exp.setup(data=data, target=target, seasonal_period=4)
     exceptionmsg = errmsg.value.args[0]
     assert "Please enable imputation to proceed" in exceptionmsg
 
@@ -196,7 +192,6 @@ def test_preprocess_setup_raises_missing_exo(load_uni_exo_data_target_missing):
             data=data,
             target=target,
             seasonal_period=4,
-            preprocess=True,
             numeric_imputation_target=None,
         )
     exceptionmsg = errmsg.value.args[0]
@@ -208,7 +203,6 @@ def test_preprocess_setup_raises_missing_exo(load_uni_exo_data_target_missing):
             data=data,
             target=target,
             seasonal_period=4,
-            preprocess=True,
             numeric_imputation_exogenous=None,
         )
     exceptionmsg = errmsg.value.args[0]
@@ -245,7 +239,6 @@ def test_preprocess_setup_raises_negative_exo(load_uni_exo_data_target, method):
             data=data,
             target=target,
             seasonal_period=4,
-            preprocess=True,
             transform_target=method,
         )
     exceptionmsg = errmsg.value.args[0]
@@ -259,7 +252,6 @@ def test_preprocess_setup_raises_negative_exo(load_uni_exo_data_target, method):
             data=data,
             target=target,
             seasonal_period=4,
-            preprocess=True,
             transform_exogenous=method,
         )
     exceptionmsg = errmsg.value.args[0]

--- a/pycaret/tests/test_time_series_stats.py
+++ b/pycaret/tests/test_time_series_stats.py
@@ -1,11 +1,14 @@
 import pytest
 
 from pycaret.time_series import TSForecastingExperiment
+from pycaret.utils.time_series.exceptions import MissingDataError
 
 from .time_series_test_utils import (
     _return_data_big_small,
     _return_model_names_for_plots_stats,
     _ALL_STATS_TESTS,
+    _ALL_DATA_TYPES,
+    _ALL_STATS_TESTS_MISSING_DATA,
 )
 
 
@@ -32,9 +35,10 @@ _model_names_for_stats = _return_model_names_for_plots_stats()
 ##########################
 
 
+@pytest.mark.parametrize("data_type", _ALL_DATA_TYPES)
 @pytest.mark.parametrize("test", _ALL_STATS_TESTS)
 @pytest.mark.parametrize("data", _data_big_small)
-def test_check_stats_data(data, test):
+def test_check_stats_data(data, test, data_type):
     """Tests the check_stats functionality on the data"""
 
     exp = TSForecastingExperiment()
@@ -61,9 +65,9 @@ def test_check_stats_data(data, test):
         "Value",
     ]
 
-    ##########################
-    #### Individual Tests ####
-    ##########################
+    ##############################################
+    #### Individual Tests (with all defaults) ####
+    ##############################################
     # Column Order ----
     results = exp.check_stats(test=test)
     column_names = list(results.columns)
@@ -71,22 +75,39 @@ def test_check_stats_data(data, test):
         assert column_names[i] == name
 
     # Data Names ----
-    expected_data_names = ["Actual"]
+    # Default data type should be "Transformed"
+    expected_data_names = ["Transformed"]
     data_names = results["Data"].unique().tolist()
-    for i, expected_name in enumerate(data_names):
+    for i, _ in enumerate(data_names):
+        assert data_names[i] in expected_data_names
+
+    ######################################################
+    #### Individual Default with different Data Types ####
+    ######################################################
+    results = exp.check_stats(test=test, data_type=data_type)
+    column_names = list(results.columns)
+    for i, name in enumerate(expected_column_order):
+        assert column_names[i] == name
+
+    # Data Names ----
+    expected_data_names = [data_type.capitalize()]
+    data_names = results["Data"].unique().tolist()
+    for i, _ in enumerate(data_names):
         assert data_names[i] in expected_data_names
 
     ###################################################
     #### Individual Tests with "order" differences ####
     ###################################################
     # Column Order ----
-    results = exp.check_stats(test=test, data_kwargs={"order_list": [1, 2]})
+    results = exp.check_stats(
+        test=test, data_type=data_type, data_kwargs={"order_list": [1, 2]}
+    )
     column_names = list(results.columns)
     for i, name in enumerate(expected_column_order):
         assert column_names[i] == name
 
     # Data Names ----
-    expected_data_names = ["Actual", "Order=1", "Order=2"]
+    expected_data_names = [data_type.capitalize(), "Order=1", "Order=2"]
     data_names = results["Data"].unique().tolist()
     for i, expected_name in enumerate(data_names):
         assert data_names[i] in expected_data_names
@@ -95,13 +116,15 @@ def test_check_stats_data(data, test):
     #### Individual Tests with "lags" differences ####
     ##################################################
     # Column Order ----
-    results = exp.check_stats(test=test, data_kwargs={"lags_list": [1, [1, 12]]})
+    results = exp.check_stats(
+        test=test, data_type=data_type, data_kwargs={"lags_list": [1, [1, 12]]}
+    )
     column_names = list(results.columns)
     for i, name in enumerate(expected_column_order):
         assert column_names[i] == name
 
     # Data Names ----
-    expected_data_names = ["Actual", "Lags=1", "Lags=[1, 12]"]
+    expected_data_names = [data_type.capitalize(), "Lags=1", "Lags=[1, 12]"]
     data_names = results["Data"].unique().tolist()
     for i, expected_name in enumerate(data_names):
         assert data_names[i] in expected_data_names
@@ -126,7 +149,6 @@ def test_check_stats_estimator(model_name, data, test):
         fold_strategy="sliding",
         verbose=False,
         session_id=42,
-        seasonal_period=1,  # TODO: Remove after models start using `primary_sp_to_use`
     )
     model = exp.create_model(model_name)
 
@@ -218,3 +240,41 @@ def test_check_stats_alpha(load_pos_and_neg_data):
         results.query("Test == 'Stationarity'").iloc[0]["Setting"].get("alpha") == alpha
     )
     assert results.query("Test == 'Normality'").iloc[0]["Setting"].get("alpha") == alpha
+
+
+@pytest.mark.parametrize("test, supports_missing", _ALL_STATS_TESTS_MISSING_DATA)
+def test_check_stats_data_raises(load_pos_data_missing, test, supports_missing):
+    """Tests the check_stats functionality on the data with missing values.
+    Not all tests support this and this checks that these tests flag this appropriately.
+    """
+
+    exp = TSForecastingExperiment()
+    data = load_pos_data_missing
+
+    # Reduced fh since we are testing with small dataset as well
+    fh = 1
+    fold = 2
+
+    exp.setup(
+        data=data,
+        fh=fh,
+        fold=fold,
+        fold_strategy="sliding",
+        numeric_imputation_target="drift",
+        verbose=False,
+        session_id=42,
+    )
+
+    # raise MissingValueError if test does not support it.
+    if not supports_missing:
+        with pytest.raises(MissingDataError) as errmsg:
+            _ = exp.check_stats(test=test, data_type="original")
+
+        # Capture Error message
+        exceptionmsg = errmsg.value.args[0]
+
+        # Check exact error received
+        assert (
+            "can not be run on data with missing values. Please check input data type."
+            in exceptionmsg
+        )

--- a/pycaret/tests/time_series_test_utils.py
+++ b/pycaret/tests/time_series_test_utils.py
@@ -23,6 +23,8 @@ _BLEND_TEST_MODELS = [
     "lightgbm_cds_dt",
 ]  # Test blend model functionality only in these models
 
+_ALL_DATA_TYPES = ["transformed", "imputed", "original"]
+
 _ALL_STATS_TESTS = [
     "summary",
     "white_noise",
@@ -31,6 +33,17 @@ _ALL_STATS_TESTS = [
     "normality",
     "stationarity",
     "all",
+]
+
+# Does the test support missing data?
+_ALL_STATS_TESTS_MISSING_DATA = [
+    ("summary", True),
+    ("white_noise", False),
+    ("adf", False),
+    ("kpss", False),
+    ("normality", True),
+    ("stationarity", False),
+    ("all", False),
 ]
 
 _IMPUTE_METHODS_STR = [

--- a/pycaret/time_series/forecasting/functional.py
+++ b/pycaret/time_series/forecasting/functional.py
@@ -979,14 +979,14 @@ def plot_model(
         plot_data_type: When plotting the data used for modeling, user may
             wish to see plots with the original data set provided, the imputed
             dataset (if imputation is set) or the transformed dataset (which
-            included any imputation and transformation set by the user). This
+            includes any imputation and transformation set by the user). This
             keyword can be used to specify which data type to use.
 
             NOTE:
             (1) If no imputation is specified, then plotting the "imputed"
-            data type will produce the same results as the "original" data type.
+                data type will produce the same results as the "original" data type.
             (2) If no transforations are specified, then plotting the "transformed"
-            data type will produce the same results as the "imputed" data type.
+                data type will produce the same results as the "imputed" data type.
 
             Allowed values are (if not specified, defaults to the first one in the list):
 
@@ -1808,6 +1808,25 @@ def check_stats(
         * 'all' - Complete Dataset
         * 'train' - The Training Split of the dataset
         * 'test' - The Test Split of the dataset
+
+
+    data_type : str, optional
+        The data type to use for the statistical test, by default "transformed".
+
+        User may wish to perform the tests on the original data set provided,
+        the imputed dataset (if imputation is set) or the transformed dataset
+        (which includes any imputation and transformation set by the user).
+        This keyword can be used to specify which data type to use.
+
+        Allowed values are: ["original", "imputed", "transformed"]
+
+        NOTE:
+        (1) If no imputation is specified, then testing on the "imputed"
+            data type will produce the same results as the "original" data type.
+        (2) If no transformations are specified, then testing the "transformed"
+            data type will produce the same results as the "imputed" data type.
+        (3) By default, tests are done on the "transformed" data since that
+            is the data that is fed to the model during training.
 
 
     data_kwargs : Optional[Dict], optional

--- a/pycaret/time_series/forecasting/functional.py
+++ b/pycaret/time_series/forecasting/functional.py
@@ -31,7 +31,6 @@ def setup(
     target: Optional[str] = None,
     index: Optional[str] = None,
     ignore_features: Optional[List] = None,
-    preprocess: bool = True,
     numeric_imputation_target: Optional[Union[int, float, str]] = None,
     numeric_imputation_exogenous: Optional[Union[int, float, str]] = None,
     transform_target: Optional[str] = None,
@@ -95,12 +94,6 @@ def setup(
         List of features to ignore for modeling when the data is a pandas
         Dataframe with more than 1 column. Ignored when data is a pandas Series
         or Dataframe with 1 column.
-
-
-    preprocess: bool, default = True
-        Should preprocessing be done on the data (includes imputation,
-        transformation, scaling)? By default True, but all steps are disabled.
-        Enable the steps that need to be preprocessed using appropriate arguments.
 
 
     numeric_imputation_target: Optional[Union[int, float, str]], default = None
@@ -339,7 +332,6 @@ def setup(
         target=target,
         index=index,
         ignore_features=ignore_features,
-        preprocess=preprocess,
         numeric_imputation_target=numeric_imputation_target,
         numeric_imputation_exogenous=numeric_imputation_exogenous,
         transform_target=transform_target,

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -989,7 +989,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             The experiment object to allow chaining of methods
         """
         self.white_noise = None
-        wn_results = self.check_stats(test="white_noise")
+        wn_results = self.check_stats(test="white_noise", data_type="transformed")
         wn_values = wn_results.query("Property == 'White Noise'")["Value"]
 
         # There can be multiple lags values tested.
@@ -3035,14 +3035,14 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             plot_data_type: When plotting the data used for modeling, user may
                 wish to see plots with the original data set provided, the imputed
                 dataset (if imputation is set) or the transformed dataset (which
-                included any imputation and transformation set by the user). This
+                includes any imputation and transformation set by the user). This
                 keyword can be used to specify which data type to use.
 
                 NOTE:
                 (1) If no imputation is specified, then plotting the "imputed"
-                data type will produce the same results as the "original" data type.
+                    data type will produce the same results as the "original" data type.
                 (2) If no transforations are specified, then plotting the "transformed"
-                data type will produce the same results as the "imputed" data type.
+                    data type will produce the same results as the "imputed" data type.
 
                 Allowed values are (if not specified, defaults to the first one in the list):
 
@@ -4394,6 +4394,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         test: str = "all",
         alpha: float = 0.05,
         split: str = "all",
+        data_type: str = "transformed",
         data_kwargs: Optional[Dict] = None,
     ) -> pd.DataFrame:
         """This function is used to get summary statistics and run statistical
@@ -4445,6 +4446,24 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             * 'train' - The Training Split of the dataset
             * 'test' - The Test Split of the dataset
 
+        data_type : str, optional
+            The data type to use for the statistical test, by default "transformed".
+
+            User may wish to perform the tests on the original data set provided,
+            the imputed dataset (if imputation is set) or the transformed dataset
+            (which includes any imputation and transformation set by the user).
+            This keyword can be used to specify which data type to use.
+
+            Allowed values are: ["original", "imputed", "transformed"]
+
+            NOTE:
+            (1) If no imputation is specified, then testing on the "imputed"
+                data type will produce the same results as the "original" data type.
+            (2) If no transformations are specified, then testing the "transformed"
+                data type will produce the same results as the "imputed" data type.
+            (3) By default, tests are done on the "transformed" data since that
+                is the data that is fed to the model during training.
+
 
         data_kwargs : Optional[Dict], optional
             Users can specify `lags list` or `order_list` to run the test for the
@@ -4459,11 +4478,10 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         pd.DataFrame
             Dataframe with the test results
         """
-
         #### Step 1: Get the data to be tested ----
         if estimator is None:
-            data = self._get_y_data(split=split)
-            data_name = "Actual"
+            data = self._get_y_data(split=split, data_type=data_type)
+            data_name = data_type.capitalize()
         else:
             data = self.get_residuals(estimator=estimator)
             if data is None:

--- a/pycaret/utils/time_series/exceptions.py
+++ b/pycaret/utils/time_series/exceptions.py
@@ -1,0 +1,6 @@
+class MissingDataError(Exception):
+    """
+    Error raised if variables contain missing values when forbidden
+    """
+
+    pass


### PR DESCRIPTION
## Related Issue or bug

Closes #2427 
Closes #2430 
Closes #2431 

#### Describe the changes you've made

- Added option to run the statistical tests on various data types - "original", "imputed", "transformed"
- Appropriate error handling for missing data when running tests
- Added unit tests for missing data when running tests
- Enhanced Setup Display for preprocessing options
- Removed redundant `preprocess` argument form setup

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit tests have been added and existing ones modified for new default (previously worked on "original" data; now works on "transformed" data by default)

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

