### PR TITLE
Refactor import * reference to only import explicit functions #2434

### DIFF
--- a/pycaret/classification/oop.py
+++ b/pycaret/classification/oop.py
@@ -6,7 +6,7 @@ import warnings
 import traceback
 import numpy as np  # type: ignore
 import pandas as pd
-from typing import List, Tuple, Union, Any
+from typing import Tuple, Union, Optional, Dict, Any, List
 from joblib.memory import Memory
 import plotly.express as px  # type: ignore
 import plotly.graph_objects as go  # type: ignore
@@ -25,7 +25,6 @@ from pycaret.internal.meta_estimators import (
 from pycaret.internal.utils import color_df, get_label_encoder
 import pycaret.internal.patches.sklearn
 import pycaret.internal.patches.yellowbrick
-from pycaret.internal.distributions import *
 from pycaret.internal.logging import get_logger
 from pycaret.internal.validation import is_sklearn_cv_generator
 import pycaret.containers.metrics.classification

--- a/pycaret/clustering/oop.py
+++ b/pycaret/clustering/oop.py
@@ -5,7 +5,6 @@ from pycaret.internal.pycaret_experiment.unsupervised_experiment import (
 import pycaret.internal.patches.sklearn
 import pycaret.internal.patches.yellowbrick
 from pycaret.internal.logging import get_logger
-from pycaret.internal.distributions import *
 import pycaret.containers.metrics.clustering
 import pycaret.containers.models.clustering
 import pycaret.internal.preprocess

--- a/pycaret/containers/models/anomaly.py
+++ b/pycaret/containers/models/anomaly.py
@@ -10,7 +10,7 @@
 
 import logging
 import pycaret.internal.cuml_wrappers
-from typing import Any
+from typing import Optional, Dict, Any
 from pycaret.containers.models.base_model import (
     ModelContainer,
 )
@@ -18,7 +18,7 @@ from pycaret.internal.utils import (
     param_grid_to_lists,
     get_logger,
 )
-from pycaret.internal.distributions import *
+from pycaret.internal.distributions import Distribution
 import pycaret.containers.base_container
 import numpy as np
 

--- a/pycaret/containers/models/classification.py
+++ b/pycaret/containers/models/classification.py
@@ -22,7 +22,11 @@ from pycaret.internal.utils import (
     get_class_name,
     np_list_arange,
 )
-from pycaret.internal.distributions import *
+from pycaret.internal.distributions import (
+    Distribution,
+    UniformDistribution,
+    IntUniformDistribution,
+)
 import pycaret.containers.base_container
 import numpy as np
 from packaging import version
@@ -592,7 +596,18 @@ class GaussianProcessClassifierContainer(ClassifierContainer):
         }
         tune_args = {}
         tune_grid = {
-            "max_iter_predict": [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000,]
+            "max_iter_predict": [
+                100,
+                200,
+                300,
+                400,
+                500,
+                600,
+                700,
+                800,
+                900,
+                1000,
+            ]
         }
         tune_distributions = {"max_iter_predict": IntUniformDistribution(100, 1000)}
 
@@ -757,6 +772,7 @@ class RandomForestClassifierContainer(ClassifierContainer):
             }
         else:
             import cuml
+
             if version.parse(cuml.__version__) >= version.parse("0.19"):
                 args = {"random_state": experiment.seed}
             else:
@@ -1337,9 +1353,9 @@ class LGBMClassifierContainer(ClassifierContainer):
                             f"LightGBM GPU mode not available. Consult https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html."
                         )
 
-        if is_gpu_enabled=="gpu":
+        if is_gpu_enabled == "gpu":
             args["device"] = "gpu"
-        elif is_gpu_enabled=="cuda":
+        elif is_gpu_enabled == "cuda":
             args["device"] = "cuda"
 
         super().__init__(
@@ -1586,6 +1602,7 @@ class CalibratedClassifierCVContainer(ClassifierContainer):
             is_special=True,
             is_gpu_enabled=False,
         )
+
 
 def get_all_model_containers(
     experiment: Any, raise_errors: bool = True

--- a/pycaret/containers/models/classification.py
+++ b/pycaret/containers/models/classification.py
@@ -596,18 +596,7 @@ class GaussianProcessClassifierContainer(ClassifierContainer):
         }
         tune_args = {}
         tune_grid = {
-            "max_iter_predict": [
-                100,
-                200,
-                300,
-                400,
-                500,
-                600,
-                700,
-                800,
-                900,
-                1000,
-            ]
+            "max_iter_predict": [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
         }
         tune_distributions = {"max_iter_predict": IntUniformDistribution(100, 1000)}
 

--- a/pycaret/containers/models/clustering.py
+++ b/pycaret/containers/models/clustering.py
@@ -11,11 +11,11 @@
 import logging
 import numpy as np
 import pycaret.internal.cuml_wrappers
-from typing import Any
+from typing import Optional, Dict, Any
 from pycaret.containers.models.base_model import ModelContainer
 from pycaret.internal.cuml_wrappers import get_dbscan, get_kmeans
 from pycaret.internal.utils import param_grid_to_lists, get_logger
-from pycaret.internal.distributions import *
+from pycaret.internal.distributions import Distribution
 import pycaret.containers.base_container
 
 

--- a/pycaret/containers/models/regression.py
+++ b/pycaret/containers/models/regression.py
@@ -9,10 +9,14 @@
 # to complete the process. Refer to the existing classes for examples.
 
 import logging
-from typing import Union, Any
+from typing import Union, Optional, Dict, Any
 
 import pycaret.containers.base_container
-from pycaret.internal.distributions import *
+from pycaret.internal.distributions import (
+    Distribution,
+    UniformDistribution,
+    IntUniformDistribution,
+)
 from pycaret.containers.models.base_model import (
     ModelContainer,
     leftover_parameters_to_categorical_distributions,
@@ -22,7 +26,6 @@ from pycaret.internal.utils import (
     get_logger,
     np_list_arange,
 )
-from pycaret.internal.distributions import *
 import pycaret.containers.base_container
 import numpy as np
 from packaging import version

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -20,7 +20,17 @@ from pycaret.internal.utils import (
 from pycaret.internal.utils import to_df, id_or_display_name, get_label_encoder
 import pycaret.internal.patches.sklearn
 import pycaret.internal.patches.yellowbrick
-from pycaret.internal.distributions import *
+from pycaret.internal.distributions import (
+    Distribution,
+    UniformDistribution,
+    CategoricalDistribution,
+    get_base_distributions,
+    get_skopt_distributions,
+    get_optuna_distributions,
+    get_hyperopt_distributions,
+    get_CS_distributions,
+    get_tune_distributions,
+)
 from pycaret.internal.logging import get_logger
 from pycaret.internal.validation import is_fitted, is_sklearn_cv_generator
 from pycaret.internal.tunable import TunableMixin

--- a/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
@@ -11,7 +11,7 @@ from joblib.memory import Memory
 from IPython.utils import io
 from sklearn.base import clone  # type: ignore
 from sklearn.preprocessing import LabelEncoder
-from typing import List, Any, Union
+from typing import Union, Optional, Dict, List, Any
 import plotly.express as px  # type: ignore
 import plotly.graph_objects as go  # type: ignore
 
@@ -27,7 +27,6 @@ from pycaret.internal.pipeline import (
 from pycaret.internal.utils import to_df, infer_ml_usecase, mlflow_remove_bad_chars
 import pycaret.internal.patches.sklearn
 import pycaret.internal.patches.yellowbrick
-from pycaret.internal.distributions import *
 from pycaret.internal.logging import get_logger
 from pycaret.internal.validation import is_sklearn_pipeline
 import pycaret.internal.preprocess


### PR DESCRIPTION
## Related Issuse or bug

Implements #2434 

#### Describe the changes you've made

According to the issue, I've refactored this line of code:
```python
from pycaret.internal.distributions import *
```
... To instead use only necessary functions in where it's present, a total of 8 files. 

- One file, ```clustering/oop.py```, didn't use anything from the reference.
- One file, ```models/regression.py```, had a duplicate of the reference.

Additionally, there was some very minor automatic code reformatting. I looked over it, and it shouldn't be an issue.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit tests tested locally using pytest.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.