### PR TITLE
Updated pipeline to use sktime directly

### DIFF
--- a/pycaret/internal/preprocess/time_series/forecasting/preprocessor.py
+++ b/pycaret/internal/preprocess/time_series/forecasting/preprocessor.py
@@ -14,23 +14,11 @@ from sktime.transformations.series.boxcox import BoxCoxTransformer, LogTransform
 from sktime.transformations.series.exponent import ExponentTransformer, SqrtTransformer
 from sktime.transformations.series.cos import CosineTransformer
 
-from pycaret.utils.time_series import TSApproachTypes, TSExogenousPresent
+from pycaret.utils.time_series import TSExogenousPresent
 
 
 class TSForecastingPreprocessor:
     """Class for preprocessing Time Series Forecasting Experiments."""
-
-    def __init__(self):
-        # Initialize empty steps ----
-        self.pipe_steps_target = []
-        self.pipe_steps_exogenous = []
-
-        # Pipeline which is trained only on the training split
-        self.pipeline = None
-
-        # Pipeline which is trained only on the complete data
-        # Used when model has been finalized
-        self.pipeline_fully_trained = None
 
     def _imputation(
         self,
@@ -108,9 +96,11 @@ class TSForecastingPreprocessor:
             )
 
         if target:
-            self.pipe_steps_target.extend([("numerical_imputer", num_estimator)])
+            self.transformer_steps_target.extend([("numerical_imputer", num_estimator)])
         else:
-            self.pipe_steps_exogenous.extend([("numerical_imputer", num_estimator)])
+            self.transformer_steps_exogenous.extend(
+                [("numerical_imputer", num_estimator)]
+            )
 
     def _transformation(
         self,
@@ -178,10 +168,10 @@ class TSForecastingPreprocessor:
 
         if target:
             transformer = transform_dict[transform]
-            self.pipe_steps_target.extend([("transformer", transformer)])
+            self.transformer_steps_target.extend([("transformer", transformer)])
         else:
             transformer = ColumnwiseTransformer(transform_dict[transform])
-            self.pipe_steps_exogenous.extend([("transformer", transformer)])
+            self.transformer_steps_exogenous.extend([("transformer", transformer)])
 
     def _scaling(
         self,
@@ -242,9 +232,9 @@ class TSForecastingPreprocessor:
             )
 
         if target:
-            self.pipe_steps_target.extend([("scaler", scaler)])
+            self.transformer_steps_target.extend([("scaler", scaler)])
         else:
-            self.pipe_steps_exogenous.extend([("scaler", scaler)])
+            self.transformer_steps_exogenous.extend([("scaler", scaler)])
 
     # def _feature_selection(
     #     self,

--- a/pycaret/tests/test_time_series_base.py
+++ b/pycaret/tests/test_time_series_base.py
@@ -6,7 +6,7 @@ import pandas as pd
 from pandas.testing import assert_frame_equal
 
 from pycaret.time_series import TSForecastingExperiment
-from pycaret.utils.time_series.forecasting.pipeline import PyCaretForecastingPipeline
+from sktime.forecasting.compose import ForecastingPipeline
 
 from .time_series_test_utils import (
     _return_model_parameters,
@@ -57,7 +57,7 @@ def test_create_predict_finalize_model(name, fh, load_pos_and_neg_data):
     ## Test Create Model ##
     #######################
     model = exp.create_model(name)
-    assert not isinstance(model, PyCaretForecastingPipeline)
+    assert not isinstance(model, ForecastingPipeline)
 
     #########################
     #### Expected Values ####
@@ -103,7 +103,7 @@ def test_create_predict_finalize_model(name, fh, load_pos_and_neg_data):
     #########################
 
     final_model = exp.finalize_model(model)
-    assert not isinstance(final_model, PyCaretForecastingPipeline)
+    assert not isinstance(final_model, ForecastingPipeline)
 
     y_pred = exp.predict_model(final_model)
     assert np.all(y_pred.index == final_expected_period_index)
@@ -195,7 +195,7 @@ def test_create_model_no_cv(load_pos_and_neg_data):
     ## Test Create Model without cv ##
     ##################################
     model = exp.create_model("naive", cross_validation=False)
-    assert not isinstance(model, PyCaretForecastingPipeline)
+    assert not isinstance(model, ForecastingPipeline)
     metrics = exp.pull()
 
     # Should return only 1 row for the test set (since no CV)
@@ -252,7 +252,7 @@ def test_compare_models(cross_validation, log_experiment, load_pos_and_neg_data)
     )
     assert len(best_baseline_models) == 3
     for best in best_baseline_models:
-        assert not isinstance(best, PyCaretForecastingPipeline)
+        assert not isinstance(best, ForecastingPipeline)
 
 
 def test_save_load_model_no_setup(load_pos_and_neg_data):

--- a/pycaret/tests/test_time_series_preprocess.py
+++ b/pycaret/tests/test_time_series_preprocess.py
@@ -3,9 +3,7 @@
 import pytest
 import numpy as np
 
-# from sktime.forecasting.compose import ForecastingPipeline
-from pycaret.utils.time_series.forecasting.pipeline import PyCaretForecastingPipeline
-from sktime.forecasting.compose import TransformedTargetForecaster
+from sktime.forecasting.compose import ForecastingPipeline, TransformedTargetForecaster
 
 from .time_series_test_utils import (
     _return_model_names_for_missing_data,
@@ -79,17 +77,17 @@ def test_pipeline_types_no_exo(load_pos_and_neg_data):
 
     #### Default
     exp.setup(data=data)
-    assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
+    assert isinstance(exp.pipeline, ForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
     #### Transform Target only
     exp.setup(data=data, numeric_imputation_target=True)
-    assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
+    assert isinstance(exp.pipeline, ForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
     #### Transform Exogenous only (but no exogenous present)
     exp.setup(data=data, numeric_imputation_exogenous=True)
-    assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
+    assert isinstance(exp.pipeline, ForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
     #### Transform Exogenous & Target (but no exogenous present)
@@ -98,12 +96,12 @@ def test_pipeline_types_no_exo(load_pos_and_neg_data):
         numeric_imputation_target=True,
         numeric_imputation_exogenous=True,
     )
-    assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
+    assert isinstance(exp.pipeline, ForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
     # No preprocessing (still sets empty pipeline internally)
     exp.setup(data=data)
-    assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
+    assert isinstance(exp.pipeline, ForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
 
@@ -116,7 +114,7 @@ def test_pipeline_types_exo(load_uni_exo_data_target):
 
     #### Default
     exp.setup(data=data, target=target, seasonal_period=4)
-    assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
+    assert isinstance(exp.pipeline, ForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
     #### Transform Target only
@@ -126,7 +124,7 @@ def test_pipeline_types_exo(load_uni_exo_data_target):
         seasonal_period=4,
         numeric_imputation_target=True,
     )
-    assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
+    assert isinstance(exp.pipeline, ForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
     #### Transform Exogenous only
@@ -136,7 +134,7 @@ def test_pipeline_types_exo(load_uni_exo_data_target):
         seasonal_period=4,
         numeric_imputation_exogenous=True,
     )
-    assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
+    assert isinstance(exp.pipeline, ForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
     #### Transform Exogenous & Target
@@ -147,12 +145,12 @@ def test_pipeline_types_exo(load_uni_exo_data_target):
         numeric_imputation_target=True,
         numeric_imputation_exogenous=True,
     )
-    assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
+    assert isinstance(exp.pipeline, ForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
     # No preprocessing (still sets empty pipeline internally)
     exp.setup(data=data, target=target, seasonal_period=4)
-    assert isinstance(exp.pipeline, PyCaretForecastingPipeline)
+    assert isinstance(exp.pipeline, ForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
 
@@ -584,7 +582,7 @@ def test_pipeline_after_finalizing(load_pos_and_neg_data_missing):
     exp.save_model(final, "my_model")
     loaded_model = exp.load_model("my_model")
 
-    # Check if pipeline data index (PyCaretForecastingPipeline) matches up with
+    # Check if pipeline data index (ForecastingPipeline) matches up with
     # the actual model data
     assert len(loaded_model._y.index) == len(
         loaded_model.steps[-1][1].steps[-1][1]._y.index

--- a/pycaret/tests/test_time_series_tune_base.py
+++ b/pycaret/tests/test_time_series_tune_base.py
@@ -6,7 +6,8 @@ import numpy as np
 import pandas as pd
 
 from pycaret.time_series import TSForecastingExperiment
-from pycaret.utils.time_series.forecasting.pipeline import PyCaretForecastingPipeline
+from sktime.forecasting.compose import ForecastingPipeline
+
 
 from .time_series_test_utils import _ALL_METRICS
 
@@ -57,8 +58,8 @@ def test_tune_custom_grid_and_choose_better(load_pos_and_neg_data):
     # set to False. So pick worse value itself.
     assert tuned_model2.strategy != model.strategy
 
-    assert not isinstance(tuned_model1, PyCaretForecastingPipeline)
-    assert not isinstance(tuned_model2, PyCaretForecastingPipeline)
+    assert not isinstance(tuned_model1, ForecastingPipeline)
+    assert not isinstance(tuned_model2, ForecastingPipeline)
 
 
 def test_tune_model_custom_folds(load_pos_and_neg_data):

--- a/pycaret/tests/test_time_series_utils_forecasting_pipeline.py
+++ b/pycaret/tests/test_time_series_utils_forecasting_pipeline.py
@@ -7,6 +7,8 @@ from sktime.forecasting.naive import NaiveForecaster
 
 from pycaret.utils.time_series.forecasting.pipeline import (
     _add_model_to_pipeline,
+    _transformations_present_X,
+    _transformations_present_y,
     _are_pipeline_tansformations_empty,
     _get_imputed_data,
 )
@@ -194,7 +196,8 @@ def test_get_imputed_data_exo(load_uni_exo_data_target_missing):
 
 
 def test_are_pipeline_tansformations_empty_noexo(load_pos_data_missing):
-    """Tests _are_pipeline_tansformations_empty WITHOUT exogenous variables"""
+    """Tests _are_pipeline_tansformations_empty, _transformations_present_X, and
+    _transformations_present_y WITHOUT exogenous variables"""
     y = load_pos_data_missing
 
     y_no_miss = y.copy()
@@ -209,6 +212,8 @@ def test_are_pipeline_tansformations_empty_noexo(load_pos_data_missing):
 
     #### 1A: Data has missing values ----
     exp.setup(data=y, fh=FH, numeric_imputation_target="drift")
+    assert not _transformations_present_X(pipeline=exp.pipeline)
+    assert _transformations_present_y(pipeline=exp.pipeline)
     assert not _are_pipeline_tansformations_empty(pipeline=exp.pipeline)
 
     #### 1B: Data has no missing values, but y impute step added ----
@@ -222,11 +227,14 @@ def test_are_pipeline_tansformations_empty_noexo(load_pos_data_missing):
 
     #### 2A: No Imputation in Pipeline ----
     exp.setup(data=y_no_miss, fh=FH)
+    assert not _transformations_present_X(pipeline=exp.pipeline)
+    assert not _transformations_present_y(pipeline=exp.pipeline)
     assert _are_pipeline_tansformations_empty(pipeline=exp.pipeline)
 
 
 def test_are_pipeline_tansformations_empty_exo(load_uni_exo_data_target_missing):
-    """Tests _are_pipeline_tansformations_empty WITH exogenous variables"""
+    """Tests _are_pipeline_tansformations_empty, _transformations_present_X, and
+    _transformations_present_y WITH exogenous variables"""
     data, target = load_uni_exo_data_target_missing
     data_no_miss = data.copy()
     data_no_miss.fillna(10, inplace=True)
@@ -247,6 +255,8 @@ def test_are_pipeline_tansformations_empty_exo(load_uni_exo_data_target_missing)
         numeric_imputation_target="drift",
         numeric_imputation_exogenous="drift",
     )
+    assert _transformations_present_X(pipeline=exp.pipeline)
+    assert _transformations_present_y(pipeline=exp.pipeline)
     assert not _are_pipeline_tansformations_empty(pipeline=exp.pipeline)
 
     #### 1B: Data has no missing values, but y impute step added ----
@@ -258,6 +268,8 @@ def test_are_pipeline_tansformations_empty_exo(load_uni_exo_data_target_missing)
         seasonal_period=4,
         numeric_imputation_target="drift",
     )
+    assert not _transformations_present_X(pipeline=exp.pipeline)
+    assert _transformations_present_y(pipeline=exp.pipeline)
     assert not _are_pipeline_tansformations_empty(pipeline=exp.pipeline)
 
     #### 1C: Data has no missing values, but X impute step added ----
@@ -269,6 +281,8 @@ def test_are_pipeline_tansformations_empty_exo(load_uni_exo_data_target_missing)
         seasonal_period=4,
         numeric_imputation_exogenous="drift",
     )
+    assert _transformations_present_X(pipeline=exp.pipeline)
+    assert not _transformations_present_y(pipeline=exp.pipeline)
     assert not _are_pipeline_tansformations_empty(pipeline=exp.pipeline)
 
     ###########################
@@ -277,6 +291,8 @@ def test_are_pipeline_tansformations_empty_exo(load_uni_exo_data_target_missing)
 
     #### 2A: No Imputation in Pipeline ----
     exp.setup(data=data_no_miss, target=target, fh=FH, seasonal_period=4)
+    assert not _transformations_present_X(pipeline=exp.pipeline)
+    assert not _transformations_present_y(pipeline=exp.pipeline)
     assert _are_pipeline_tansformations_empty(pipeline=exp.pipeline)
 
 

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -25,19 +25,18 @@ from sktime.transformations.series.impute import Imputer
 
 from pycaret.utils._dependencies import _check_soft_dependencies
 
-# from sktime.forecasting.compose import ForecastingPipeline
 from pycaret.utils.time_series.forecasting import (
     PyCaretForecastingHorizonTypes,
     _check_and_clean_coverage,
 )
 from pycaret.utils.time_series.forecasting.pipeline import (
-    PyCaretForecastingPipeline,
     _add_model_to_pipeline,
     _get_imputed_data,
     _get_pipeline_estimator_label,
 )
 from pycaret.utils.time_series.forecasting.models import DummyForecaster
-from sktime.forecasting.compose import TransformedTargetForecaster
+from sktime.transformations.compose import TransformerPipeline
+from sktime.forecasting.compose import ForecastingPipeline, TransformedTargetForecaster
 
 from pycaret.internal.preprocess.time_series.forecasting.preprocessor import (
     TSForecastingPreprocessor,
@@ -65,7 +64,6 @@ from pycaret.internal.pycaret_experiment.supervised_experiment import (
 from pycaret.internal.pycaret_experiment.utils import MLUsecase, highlight_setup
 from pycaret.internal.tests.time_series import run_test
 from pycaret.internal.tunable import TunableMixin
-from pycaret.internal.utils import color_df
 from pycaret.internal.validation import is_sklearn_cv_generator
 from pycaret.utils import _coerce_empty_dataframe_to_none, _resolve_dict_keys
 from pycaret.utils.datetime import coerce_datetime_to_period_index
@@ -995,8 +993,8 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             )
 
         # Initialize empty steps ----
-        self.pipe_steps_target = []
-        self.pipe_steps_exogenous = []
+        self.transformer_steps_target = []
+        self.transformer_steps_exogenous = []
 
         if self.preprocess:
             self.logger.info("Preparing preprocessing pipeline...")
@@ -1031,8 +1029,8 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
 
         self.pipeline = self._create_pipeline(
             model=DummyForecaster(),
-            target_steps=self.pipe_steps_target,
-            exogenous_steps=self.pipe_steps_exogenous,
+            transformer_steps_target=self.transformer_steps_target,
+            transformer_steps_exogenous=self.transformer_steps_exogenous,
         )
         self._check_pipeline()
 
@@ -1935,13 +1933,13 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         return fit_kwargs
 
     def _get_final_model_from_pipeline(
-        self, pipeline: PyCaretForecastingPipeline, check_is_fitted: bool = False
+        self, pipeline: ForecastingPipeline, check_is_fitted: bool = False
     ) -> BaseForecaster:
         """Extracts and returns the final model from the pipeline.
 
         Parameters
         ----------
-        pipeline : PyCaretForecastingPipeline
+        pipeline : ForecastingPipeline
             The pipeline with a final model
         check_is_fitted : bool
             If True, will check if final model is fitted and raise an exception
@@ -1952,7 +1950,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         BaseForecaster
             The final model in the pipeline
         """
-        # Pipeline will always be of type PyCaretForecastingPipeline with final
+        # Pipeline will always be of type ForecastingPipeline with final
         # forecaster being of type TransformedTargetForecaster
         final_forecaster_only = pipeline.steps_[-1][1].steps_[-1][1]
         if check_is_fitted:
@@ -3528,8 +3526,8 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         return return_obj
 
     def _predict_model_reconcile_pipe_estimator(
-        self, estimator: Union[BaseForecaster, PyCaretForecastingPipeline]
-    ) -> Tuple[PyCaretForecastingPipeline, BaseForecaster]:
+        self, estimator: Union[BaseForecaster, ForecastingPipeline]
+    ) -> Tuple[ForecastingPipeline, BaseForecaster]:
         """Returns the pipeline along with the final model in the pipeline.
 
         # Use Cases:
@@ -3548,12 +3546,12 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
 
         Parameters
         ----------
-        estimator : Union[BaseForecaster, PyCaretForecastingPipeline]
+        estimator : Union[BaseForecaster, ForecastingPipeline]
             Estimator passed by user
 
         Returns
         -------
-        Tuple[PyCaretForecastingPipeline, BaseForecaster]
+        Tuple[ForecastingPipeline, BaseForecaster]
             The pipeline and the final model in the pipeline
 
         Raises
@@ -3562,7 +3560,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             When a model (without pipeline) is loaded into an experiment where
             setup has not been run, but user wants to make a prediction.
         """
-        if isinstance(estimator, PyCaretForecastingPipeline):
+        if isinstance(estimator, ForecastingPipeline):
             # Use Case 3
             pipeline_with_model = deepcopy(estimator)
             estimator_ = self._get_final_model_from_pipeline(
@@ -3741,7 +3739,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
 
     def _predict_model_get_test_metrics(
         self,
-        pipeline: PyCaretForecastingPipeline,
+        pipeline: ForecastingPipeline,
         estimator: BaseForecaster,
         result: pd.DataFrame,
     ) -> dict:
@@ -3751,7 +3749,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
 
         Parameters
         ----------
-        pipeline : PyCaretForecastingPipeline
+        pipeline : ForecastingPipeline
             The pipeline used to get the imputed values for metrics
         estimator : BaseForecaster
             Estimator used to decide if the model has been finalized or not.
@@ -4160,41 +4158,52 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
     def _create_pipeline(
         self,
         model: BaseForecaster,
-        target_steps: List,
-        exogenous_steps: List,
-    ) -> PyCaretForecastingPipeline:
+        transformer_steps_target: List,
+        transformer_steps_exogenous: List,
+    ) -> ForecastingPipeline:
         """Creates a PyCaret pipeline based on the steps and model passed.
         The pipeline structure is as follows
 
-        PyCaretForecastingPipeline
-          - exogenous_steps
-          - TransformedTargetForecaster
-            - target_steps
-            - model
+        ForecastingPipeline
+            - TransformerPipeline(exogenous_steps) [Optional]
+            - TransformedTargetForecaster
+                - TransformerPipeline(target_steps) [Optional]
+                - model
 
         Parameters
         ----------
         model : BaseForecaster
             Final model to use for prediction
-        target_steps : List
+        transformer_steps_target : List
             List of transformation steps to apply to the target - y
-        exogenous_steps : List
+        transformer_steps_exogenous : List
             List of transformations to apply to the exogenous variables - X
 
         Returns
         -------
-        PyCaretForecastingPipeline
-            A PyCaret Time Series Forecasting Pipeline.
+        ForecastingPipeline
+            A Time Series Forecasting Pipeline.
         """
 
-        # Set the pipeline from model
+        #### Set the pipeline from model
+
         # Add forecaster (model) to end of target steps ----
-        target_steps.extend([("model", model)])
-        forecaster = TransformedTargetForecaster(target_steps)
+        steps_target = []
+        if len(transformer_steps_target) > 0:
+            transformer_target = TransformerPipeline(steps=transformer_steps_target)
+            steps_target.extend([("transformer_target", transformer_target)])
+        steps_target.extend([("model", model)])
+        forecaster = TransformedTargetForecaster(steps_target)
 
         # Create Forecasting Pipeline ----
-        exogenous_steps.extend([("forecaster", forecaster)])
-        pipeline = PyCaretForecastingPipeline(exogenous_steps)
+        steps_exogenous = []
+        if len(transformer_steps_exogenous) > 0:
+            transformer_exogenous = TransformerPipeline(
+                steps=transformer_steps_exogenous
+            )
+            steps_exogenous.extend([("transformer_exogenous", transformer_exogenous)])
+        steps_exogenous.extend([("forecaster", forecaster)])
+        pipeline = ForecastingPipeline(steps_exogenous)
 
         return pipeline
 
@@ -5009,9 +5018,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         additional_scorer_kwargs = {"sp": self.primary_sp_to_use}
         return additional_scorer_kwargs
 
-    def _get_pipeline_to_use(
-        self, estimator: BaseForecaster
-    ) -> PyCaretForecastingPipeline:
+    def _get_pipeline_to_use(self, estimator: BaseForecaster) -> ForecastingPipeline:
         """Depending on the estimator that must be added to the pipeline, this
         method will fetch the correct pipeline with the right memory in it. If
         the estimator has not been finalized, this will fetch the pipeline with
@@ -5025,7 +5032,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
 
         Returns
         -------
-        PyCaretForecastingPipeline
+        ForecastingPipeline
             The pipeline with the correct memory based on the estimator
         """
 

--- a/pycaret/utils/time_series/forecasting/model_selection.py
+++ b/pycaret/utils/time_series/forecasting/model_selection.py
@@ -16,6 +16,7 @@ from sklearn.model_selection import (  # type: ignore
     ParameterSampler,
     check_cv,
 )
+from sktime.forecasting.compose import ForecastingPipeline
 from sklearn.model_selection._search import _check_param_grid  # type: ignore
 from sklearn.model_selection._validation import _aggregate_score_dicts  # type: ignore
 from sktime.utils.validation.forecasting import check_y_X  # type: ignore
@@ -32,10 +33,7 @@ from pycaret.utils.time_series.forecasting import (
     update_additional_scorer_kwargs,
 )
 
-from pycaret.utils.time_series.forecasting.pipeline import (
-    PyCaretForecastingPipeline,
-    _get_imputed_data,
-)
+from pycaret.utils.time_series.forecasting.pipeline import _get_imputed_data
 
 from pycaret.internal.logging import get_logger
 
@@ -53,7 +51,7 @@ def get_folds(cv, y) -> Generator[Tuple[pd.Series, pd.Series], None, None]:
 
 
 def _fit_and_score(
-    pipeline: PyCaretForecastingPipeline,
+    pipeline: ForecastingPipeline,
     y: pd.Series,
     X: Optional[Union[pd.Series, pd.DataFrame]],
     scoring: Dict[str, Union[str, _PredictScorer]],
@@ -76,8 +74,8 @@ def _fit_and_score(
 
     Parameters
     ----------
-    pipeline : PyCaretForecastingPipeline
-        Pycaret Forecasting Pipeline that needs to be fitted and scored.
+    pipeline : ForecastingPipeline
+        Forecasting Pipeline that needs to be fitted and scored.
     y : pd.Series
         Target variable values that need to be used for forecasting. This should be the
         untransformed (original) values. Transformation will happen in the fitting process.
@@ -228,7 +226,7 @@ def _fit_and_score(
 
 
 def cross_validate(
-    pipeline: PyCaretForecastingPipeline,
+    pipeline: ForecastingPipeline,
     y: pd.Series,
     X: Optional[Union[pd.Series, pd.DataFrame]],
     cv: Union[ExpandingWindowSplitter, SlidingWindowSplitter],
@@ -251,8 +249,8 @@ def cross_validate(
 
     Parameters
     ----------
-    pipeline : PyCaretForecastingPipeline
-        Pycaret Forecasting Pipeline that needs to be cross-validated.
+    pipeline : ForecastingPipeline
+        Forecasting Pipeline that needs to be cross-validated.
     y : pd.Series
         Target variable values that need to be used for forecasting. This should be the
         untransformed (original) values. Transformation will happen in the fitting process.
@@ -345,7 +343,7 @@ class BaseGridSearch:
 
     def __init__(
         self,
-        pipeline: PyCaretForecastingPipeline,
+        pipeline: ForecastingPipeline,
         cv: Union[ExpandingWindowSplitter, SlidingWindowSplitter],
         alpha: Optional[float],
         coverage: Union[float, List[float]],
@@ -362,8 +360,8 @@ class BaseGridSearch:
 
         Parameters
         ----------
-        pipeline : PyCaretForecastingPipeline
-            Pycaret Forecasting Pipeline that needs to be used for Grid Search.
+        pipeline : ForecastingPipeline
+            Forecasting Pipeline that needs to be used for Grid Search.
         cv : Union[ExpandingWindowSplitter, SlidingWindowSplitter]
             The sktime compatible cross-validation object.
         alpha: Optional[float]

--- a/pycaret/utils/time_series/forecasting/pipeline.py
+++ b/pycaret/utils/time_series/forecasting/pipeline.py
@@ -4,32 +4,14 @@ from typing import Optional, Tuple
 import pandas as pd
 
 from sktime.forecasting.base import BaseForecaster
-from sktime.forecasting.compose import ForecastingPipeline
-from sktime.forecasting.compose import TransformedTargetForecaster
+from sktime.forecasting.compose import ForecastingPipeline, TransformedTargetForecaster
+from sktime.transformations.compose import TransformerPipeline
 from sktime.transformations.series.impute import Imputer
 
 
-class PyCaretForecastingPipeline(ForecastingPipeline):
-    """Workaround to sktime ForecastingPipeline not having a transform method."""
-
-    def transform(self, y, X=None):
-        # If X is not given, just passthrough the data without transformation
-        if self._X is not None:
-            # transform X
-            for _, _, transformer in self._iter_transformers():
-                X = transformer.transform(X)
-
-        name, forecaster = self.steps_[-1]
-        # If forecaster is not a TransformedTargetForecaster, just passthrough
-        if isinstance(forecaster, TransformedTargetForecaster):
-            y = forecaster.transform(Z=y, X=X)
-
-        return y, X
-
-
 def _add_model_to_pipeline(
-    pipeline: PyCaretForecastingPipeline, model: BaseForecaster
-) -> PyCaretForecastingPipeline:
+    pipeline: ForecastingPipeline, model: BaseForecaster
+) -> ForecastingPipeline:
     """Removes the dummy model from the preprocessing pipeline and adds the
     passed model to it instead.
 
@@ -37,7 +19,7 @@ def _add_model_to_pipeline(
 
     Parameters
     ----------
-    pipeline : PyCaretForecastingPipeline
+    pipeline : ForecastingPipeline
         A ForecastingPipeline to be used as the base to replace the final model.
     model : BaseForecaster
         sktime compatible model (without the pipeline). i.e. last step of
@@ -45,7 +27,7 @@ def _add_model_to_pipeline(
 
     Returns
     -------
-    PyCaretForecastingPipeline
+    ForecastingPipeline
         The forecasting pipeline with the dummy model replaced with the correct one.
     """
     pipeline_with_model = deepcopy(pipeline)
@@ -86,34 +68,66 @@ def _add_model_to_pipeline(
     return pipeline_with_model
 
 
-def _are_pipeline_tansformations_empty(pipeline: PyCaretForecastingPipeline) -> bool:
+def _transformations_present_X(pipeline: ForecastingPipeline) -> bool:
+    """Returns whether transformations are present for the exogenous variables
+
+    Parameters
+    ----------
+    pipeline : ForecastingPipeline
+        PyCaret's internal Pipeline
+
+    Returns
+    -------
+    bool
+        True if there are exogenous transformations, False otherwise
+    """
+    return isinstance(pipeline.steps[0][1], TransformerPipeline)
+
+
+def _transformations_present_y(pipeline: ForecastingPipeline) -> bool:
+    """Returns whether transformations are present for the target variables
+
+    Parameters
+    ----------
+    pipeline : ForecastingPipeline
+        PyCaret's internal Pipeline
+
+    Returns
+    -------
+    bool
+        True if there are target transformations, False otherwise
+    """
+    return isinstance(pipeline.steps[-1][1].steps[0][1], TransformerPipeline)
+
+
+def _are_pipeline_tansformations_empty(pipeline: ForecastingPipeline) -> bool:
     """Returns whether the pipeline has transformations for either the target
     or exogenous variables or whether there are no transformatons for either.
 
     Reminder: The pipeline structure is as follows:
-        PyCaretForecastingPipeline
-            - exogenous_steps
-            - TransformedTargetForecaster
-                - target_steps
-                - model
+    ForecastingPipeline
+        - TransformerPipeline(exogenous_steps) [Optional]
+        - TransformedTargetForecaster
+            - TransformerPipeline(target_steps) [Optional]
+            - model
 
     Parameters
     ----------
-    pipeline : PyCaretForecastingPipeline
-        PyCaret Pipeline
+    pipeline : ForecastingPipeline
+        PyCaret's internal Pipeline
 
     Returns
     -------
     bool
         True if there are no transformations, False otherwise
     """
-    num_steps_transform_X = len(pipeline.steps) - 1
-    num_steps_transform_y = len(pipeline.steps[-1][1].steps) - 1
-    return num_steps_transform_X == 0 and num_steps_transform_y == 0
+    transform_X_present = _transformations_present_X(pipeline)
+    transform_y_present = _transformations_present_y(pipeline)
+    return (transform_X_present is False) and (transform_y_present is False)
 
 
 def _get_imputed_data(
-    pipeline: PyCaretForecastingPipeline, y: pd.Series, X: Optional[pd.DataFrame] = None
+    pipeline: ForecastingPipeline, y: pd.Series, X: Optional[pd.DataFrame] = None
 ) -> Tuple[pd.Series, Optional[pd.DataFrame]]:
     """Passes y and X through the pipeline and returns the imputed data.
 
@@ -127,7 +141,7 @@ def _get_imputed_data(
 
     Parameters
     ----------
-    pipeline : PyCaretForecastingPipeline
+    pipeline : ForecastingPipeline
         The pipeline used to get the imputed values
     y : pd.Series
         target data to be used for imputation
@@ -135,11 +149,11 @@ def _get_imputed_data(
         Exogenous variable data to be used for imputation, by default None
 
     Reminder: The pipeline structure is as follows:
-        PyCaretForecastingPipeline
-            - exogenous_steps
-            - TransformedTargetForecaster
-                - target_steps
-                - model
+    ForecastingPipeline
+        - TransformerPipeline(exogenous_steps) [Optional]
+        - TransformedTargetForecaster
+            - TransformerPipeline(target_steps) [Optional]
+            - model
 
     Returns
     -------
@@ -154,22 +168,27 @@ def _get_imputed_data(
     else:
         # Exogenous variables present
         X_imputed = X.copy()
-        for _, transformer_X in pipeline.steps_:
-            if isinstance(transformer_X, Imputer):
-                X_imputed = transformer_X.fit_transform(X, y)
-                continue
+
+        if _transformations_present_X(pipeline):
+            transformer_pipeline_X = pipeline.steps_[0][1]
+            for _, transformer_X in transformer_pipeline_X.steps_:
+                if isinstance(transformer_X, Imputer):
+                    X_imputed = transformer_X.fit_transform(X, y)
+                    continue
 
     y_imputed = y.copy()
-    for _, transformer_y in pipeline.steps_[-1][1].steps_:
-        if isinstance(transformer_y, Imputer):
-            y_imputed = transformer_y.fit_transform(y)
-            continue
+    if _transformations_present_y(pipeline):
+        transformer_pipeline_y = pipeline.steps_[-1][1].steps_[0][1]
+        for _, transformer_y in transformer_pipeline_y.steps_:
+            if isinstance(transformer_y, Imputer):
+                y_imputed = transformer_y.fit_transform(y)
+                continue
 
     return y_imputed, X_imputed
 
 
 def _get_pipeline_estimator_label(
-    pipeline: PyCaretForecastingPipeline,
+    pipeline: ForecastingPipeline,
 ) -> str:
     """Returns the name of the Transformed Target Forecaster in the pipeline along
     with the name of the final model step in the pipeline.
@@ -181,7 +200,7 @@ def _get_pipeline_estimator_label(
 
     Parameters
     ----------
-    pipeline : PyCaretForecastingPipeline
+    pipeline : ForecastingPipeline
         The pipeline used for modeling
 
     Returns
@@ -194,3 +213,45 @@ def _get_pipeline_estimator_label(
     name_ttf, transformed_target_forecaster = pipeline.steps_[-1]
     name_model, _ = transformed_target_forecaster.steps_[-1]
     return name_ttf + "__" + name_model
+
+
+def _pipeline_transform(
+    pipeline: ForecastingPipeline, y: pd.Series, X: Optional[pd.DataFrame] = None
+) -> Tuple[pd.Series, Optional[pd.DataFrame]]:
+    """Transforms y and X based on the transformations present in the pipeline.
+
+    Reminder: The pipeline structure is as follows:
+    ForecastingPipeline
+        - TransformerPipeline(exogenous_steps) [Optional]
+        - TransformedTargetForecaster
+            - TransformerPipeline(target_steps) [Optional]
+            - model
+
+    Parameters
+    ----------
+    pipeline : ForecastingPipeline
+        The pipeline used for modeling
+    y : pd.Series
+        Original target values
+    X : pd.DataFrame, optional
+        Original exogenous values, by default None
+
+    Returns
+    -------
+    Tuple[pd.Series, Optional[pd.DataFrame]]
+        The transformed values for y and X. If no transformations are present in
+        the pipeline, then the values are returned as is ("unity" transformation).
+    """
+    # Get X Transformations ----
+    if X is not None:
+        _, potential_tx = pipeline.steps_[0]
+        if isinstance(potential_tx, TransformerPipeline):
+            X = potential_tx.transform(X)
+
+    # Get y Transformations ----
+    _, forecaster = pipeline.steps_[-1]
+    _, potential_tx = forecaster.steps_[0]
+    if isinstance(potential_tx, TransformerPipeline):
+        y = potential_tx.transform(y)
+
+    return y, X


### PR DESCRIPTION
## Related Issue or bug

Closes #2449 

#### Describe the changes you've made

Previously, (`sktime` 0.10.x), the sktime `ForecastingPipeline` did not have a transform method, so we had to add this as a `PyCaretForecastingPipeline` and maintain inside PyCaret.

But with `sktime` 0.11.0, they do have transformation capability. This PR updates the pycaret time series pipeline accordingly to use sktime constructs only without having to maintain a parallel `PyCaretForecastingPipeline` in pycaret. This makes use of the `TransformerPipeline` available in `sktime` 0.11.x.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

A couple of new unit tests were added + existing unit tests should pass.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

