### PR TITLE
Added additional library to resolve importing error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,8 @@ lightgbm>=3.0.0
 numba~=0.55.0
 requests>=2.27.1  # Required by pycaret.datasets
 psutil>=5.9.0
+markupsafe>=2.0.1
+
 
 # Plotting
 matplotlib>=3.3.0


### PR DESCRIPTION
Added additional library to resolve the error `ImportError: Missing optional dependency 'Jinja2'. DataFrame.style requires jinja2. Use pip or conda to install Jinja2` while executing `from pycaret.classification import *` 

![Error](https://user-images.githubusercontent.com/47806749/177248214-c1af3601-a38c-45f0-b648-d855f31d9135.JPG)

