### PR TITLE
Add `create_date_columns`, replace column names in `predict_model`

### DIFF
--- a/examples/PyCaret 2 Anomaly Detection.ipynb
+++ b/examples/PyCaret 2 Anomaly Detection.ipynb
@@ -7712,7 +7712,7 @@
         "coloraxis": {
          "colorbar": {
           "title": {
-           "text": "Label"
+           "text": "prediction_label"
           }
          },
          "colorscale": [
@@ -14721,7 +14721,7 @@
         "coloraxis": {
          "colorbar": {
           "title": {
-           "text": "Label"
+           "text": "prediction_label"
           }
          },
          "colorscale": [

--- a/pycaret/anomaly/functional.py
+++ b/pycaret/anomaly/functional.py
@@ -28,6 +28,7 @@ def setup(
     ignore_features: Optional[List[str]] = None,
     keep_features: Optional[List[str]] = None,
     preprocess: bool = True,
+    create_date_columns: List[str] = ["day", "month", "year"],
     imputation_type: Optional[str] = "simple",
     numeric_imputation: str = "mean",
     categorical_imputation: str = "constant",
@@ -141,6 +142,14 @@ def setup(
         and custom transformations passed in ``custom_pipeline`` param. Data must be
         ready for modeling (no missing values, no dates, categorical data encoding),
         when preprocess is set to False.
+
+
+    create_date_columns: list of str, default=["day", "month", "year"]
+        Columns to create from the date features. Note that created features
+        with zero variance (e.g. the feature hour in a column that only contains
+        dates) are ignored. Allowed values are datetime attributes from
+        `pandas.Series.dt`. The datetime format of the feature is inferred
+        automatically from the first non NaN value.
 
 
     imputation_type: str or None, default = 'simple'
@@ -421,6 +430,7 @@ def setup(
         ignore_features=ignore_features,
         keep_features=keep_features,
         preprocess=preprocess,
+        create_date_columns=create_date_columns,
         imputation_type=imputation_type,
         numeric_imputation=numeric_imputation,
         categorical_imputation=categorical_imputation,

--- a/pycaret/classification/functional.py
+++ b/pycaret/classification/functional.py
@@ -37,6 +37,7 @@ def setup(
     ignore_features: Optional[List[str]] = None,
     keep_features: Optional[List[str]] = None,
     preprocess: bool = True,
+    create_date_columns: List[str] = ["day", "month", "year"],
     imputation_type: Optional[str] = "simple",
     numeric_imputation: Union[int, float, str] = "mean",
     categorical_imputation: str = "constant",
@@ -75,7 +76,7 @@ def setup(
     custom_pipeline: Optional[Any] = None,
     custom_pipeline_position: int = -1,
     data_split_shuffle: bool = True,
-    data_split_stratify: Union[bool, List[str]] = True,
+    data_split_stratify: Union[bool, List[str]] = False,
     fold_strategy: Union[str, Any] = "stratifiedkfold",
     fold: int = 10,
     fold_shuffle: bool = False,
@@ -191,6 +192,14 @@ def setup(
         and custom transformations passed in ``custom_pipeline`` param. Data must be
         ready for modeling (no missing values, no dates, categorical data encoding),
         when preprocess is set to False.
+
+
+    create_date_columns: list of str, default=["day", "month", "year"]
+        Columns to create from the date features. Note that created features
+        with zero variance (e.g. the feature hour in a column that only contains
+        dates) are ignored. Allowed values are datetime attributes from
+        `pandas.Series.dt`. The datetime format of the feature is inferred
+        automatically from the first non NaN value.
 
 
     imputation_type: str or None, default = 'simple'
@@ -592,6 +601,7 @@ def setup(
         ignore_features=ignore_features,
         keep_features=keep_features,
         preprocess=preprocess,
+        create_date_columns=create_date_columns,
         imputation_type=imputation_type,
         numeric_imputation=numeric_imputation,
         categorical_imputation=categorical_imputation,

--- a/pycaret/classification/functional.py
+++ b/pycaret/classification/functional.py
@@ -76,7 +76,7 @@ def setup(
     custom_pipeline: Optional[Any] = None,
     custom_pipeline_position: int = -1,
     data_split_shuffle: bool = True,
-    data_split_stratify: Union[bool, List[str]] = False,
+    data_split_stratify: Union[bool, List[str]] = True,
     fold_strategy: Union[str, Any] = "stratifiedkfold",
     fold: int = 10,
     fold_shuffle: bool = False,
@@ -447,7 +447,7 @@ def setup(
         When set to False, prevents shuffling of rows during 'train_test_split'.
 
 
-    data_split_stratify: bool or list, default = False
+    data_split_stratify: bool or list, default = True
         Controls stratification during 'train_test_split'. When set to True, will
         stratify by target column. To stratify on any other columns, pass a list of
         column names. Ignored when ``data_split_shuffle`` is False.

--- a/pycaret/classification/oop.py
+++ b/pycaret/classification/oop.py
@@ -133,6 +133,7 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
         ignore_features: Optional[List[str]] = None,
         keep_features: Optional[List[str]] = None,
         preprocess: bool = True,
+        create_date_columns: List[str] = ["day", "month", "year"],
         imputation_type: Optional[str] = "simple",
         numeric_imputation: str = "mean",
         categorical_imputation: str = "constant",
@@ -171,7 +172,7 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
         custom_pipeline: Optional[Any] = None,
         custom_pipeline_position: int = -1,
         data_split_shuffle: bool = True,
-        data_split_stratify: Union[bool, List[str]] = True,
+        data_split_stratify: Union[bool, List[str]] = False,
         fold_strategy: Union[str, Any] = "stratifiedkfold",
         fold: int = 10,
         fold_shuffle: bool = False,
@@ -290,6 +291,14 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
             and custom transformations passed in ``custom_pipeline`` param. Data must be
             ready for modeling (no missing values, no dates, categorical data encoding),
             when preprocess is set to False.
+
+
+        create_date_columns: list of str, default=["day", "month", "year"]
+            Columns to create from the date features. Note that created features
+            with zero variance (e.g. the feature hour in a column that only contains
+            dates) are ignored. Allowed values are datetime attributes from
+            `pandas.Series.dt`. The datetime format of the feature is inferred
+            automatically from the first non NaN value.
 
 
         imputation_type: str or None, default = 'simple'
@@ -783,7 +792,7 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
 
             # Convert date feature to numerical values
             if self._fxs["Date"]:
-                self._date_feature_engineering()
+                self._date_feature_engineering(create_date_columns)
 
             # Impute missing values
             if imputation_type == "simple":

--- a/pycaret/classification/oop.py
+++ b/pycaret/classification/oop.py
@@ -172,7 +172,7 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
         custom_pipeline: Optional[Any] = None,
         custom_pipeline_position: int = -1,
         data_split_shuffle: bool = True,
-        data_split_stratify: Union[bool, List[str]] = False,
+        data_split_stratify: Union[bool, List[str]] = True,
         fold_strategy: Union[str, Any] = "stratifiedkfold",
         fold: int = 10,
         fold_shuffle: bool = False,
@@ -546,7 +546,7 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
             When set to False, prevents shuffling of rows during 'train_test_split'.
 
 
-        data_split_stratify: bool or list, default = False
+        data_split_stratify: bool or list, default = True
             Controls stratification during 'train_test_split'. When set to True, will
             stratify by target column. To stratify on any other columns, pass a list of
             column names. Ignored when ``data_split_shuffle`` is False.

--- a/pycaret/clustering/functional.py
+++ b/pycaret/clustering/functional.py
@@ -28,6 +28,7 @@ def setup(
     ignore_features: Optional[List[str]] = None,
     keep_features: Optional[List[str]] = None,
     preprocess: bool = True,
+    create_date_columns: List[str] = ["day", "month", "year"],
     imputation_type: Optional[str] = "simple",
     numeric_imputation: str = "mean",
     categorical_imputation: str = "constant",
@@ -140,6 +141,14 @@ def setup(
         and custom transformations passed in ``custom_pipeline`` param. Data must be
         ready for modeling (no missing values, no dates, categorical data encoding),
         when preprocess is set to False.
+
+
+    create_date_columns: list of str, default=["day", "month", "year"]
+        Columns to create from the date features. Note that created features
+        with zero variance (e.g. the feature hour in a column that only contains
+        dates) are ignored. Allowed values are datetime attributes from
+        `pandas.Series.dt`. The datetime format of the feature is inferred
+        automatically from the first non NaN value.
 
 
     imputation_type: str or None, default = 'simple'
@@ -411,6 +420,7 @@ def setup(
         ignore_features=ignore_features,
         keep_features=keep_features,
         preprocess=preprocess,
+        create_date_columns=create_date_columns,
         imputation_type=imputation_type,
         numeric_imputation=numeric_imputation,
         categorical_imputation=categorical_imputation,

--- a/pycaret/internal/preprocess/preprocessor.py
+++ b/pycaret/internal/preprocess/preprocessor.py
@@ -153,6 +153,10 @@ class Preprocessor:
         self.logger.info("Set up train/test split.")
 
         if test_data is None:
+            print(data_split_stratify)
+            print(
+                "sii", get_columns_to_stratify_by(self.X, self.y, data_split_stratify)
+            )
             # self.data is already prepared here
             train, test = train_test_split(
                 self.data,
@@ -324,12 +328,13 @@ class Preprocessor:
             )
         )
 
-    def _date_feature_engineering(self):
+    def _date_feature_engineering(self, create_date_columns):
         """Convert date features to numerical values."""
         self.logger.info("Set up date feature engineering.")
         # TODO: Could be improved allowing the user to choose which features to add
         date_estimator = TransformerWrapper(
-            transformer=ExtractDateTimeFeatures(), include=self._fxs["Date"]
+            transformer=ExtractDateTimeFeatures(create_date_columns),
+            include=self._fxs["Date"],
         )
         self.pipeline.steps.append(
             ("date_feature_extractor", date_estimator),

--- a/pycaret/internal/preprocess/preprocessor.py
+++ b/pycaret/internal/preprocess/preprocessor.py
@@ -153,10 +153,6 @@ class Preprocessor:
         self.logger.info("Set up train/test split.")
 
         if test_data is None:
-            print(data_split_stratify)
-            print(
-                "sii", get_columns_to_stratify_by(self.X, self.y, data_split_stratify)
-            )
             # self.data is already prepared here
             train, test = train_test_split(
                 self.data,

--- a/pycaret/internal/preprocess/transformers.py
+++ b/pycaret/internal/preprocess/transformers.py
@@ -280,8 +280,8 @@ class ExtractDateTimeFeatures(BaseEstimator, TransformerMixin):
             for fx in self.features:
                 values = getattr(X[col].dt, fx)
 
-                # Only create feature if values contains less than 30% NaTs
-                if values.isna().sum() <= 0.3 * len(values):
+                # Only create feature if values contains less than 10% NaTs
+                if values.isna().sum() <= 0.1 * len(values):
                     X.insert(X.columns.get_loc(col) + 1, f"{col}_{fx}", values)
 
             X = X.drop(col, axis=1)  # Drop the original datetime column

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -5222,7 +5222,7 @@ class _SupervisedExperiment(_TabularExperiment):
         if self._ml_usecase == MLUsecase.CLASSIFICATION:
             metric_dict["Selection Rate"] = selection_rate
 
-        y_pred = self.predict_model(estimator)["Label"]
+        y_pred = self.predict_model(estimator)["prediction_label"]
         y_true = self.y_test
 
         try:

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -60,6 +60,7 @@ from pycaret.internal.utils import (
 )
 from pycaret.internal.validation import is_fitted, is_sklearn_cv_generator
 from pycaret.utils._dependencies import _check_soft_dependencies
+from pycaret.utils.constants import LABEL_COLUMN, SCORE_COLUMN
 
 LOGGER = get_logger()
 
@@ -4836,8 +4837,8 @@ class _SupervisedExperiment(_TabularExperiment):
         Returns
         -------
         Predictions
-            Predictions (prediction_label and prediction_score) columns are
-            attached to the original dataset and returned as pandas dataframe.
+            Predictions (label and score) columns are attached to the original
+            dataset and returned as pandas dataframe.
 
         score_grid
             A table containing the scoring metrics on hold-out / test set.
@@ -5029,16 +5030,16 @@ class _SupervisedExperiment(_TabularExperiment):
             df_score = df_score.round(round)
             display.display(df_score.style.format(precision=round))
 
-        label = pd.DataFrame(pred, columns=["prediction_label"], index=X_test_.index)
+        label = pd.DataFrame(pred, columns=[LABEL_COLUMN], index=X_test_.index)
         if ml_usecase == MLUsecase.CLASSIFICATION:
             try:
-                label["prediction_label"] = label["prediction_label"].astype(int)
+                label[LABEL_COLUMN] = label[LABEL_COLUMN].astype(int)
             except:
                 pass
 
         if not encoded_labels:
-            label["prediction_label"] = replace_labels_in_column(
-                pipeline, label["prediction_label"]
+            label[LABEL_COLUMN] = replace_labels_in_column(
+                pipeline, label[LABEL_COLUMN]
             )
             if y_test_ is not None:
                 y_test_ = replace_labels_in_column(pipeline, y_test_)
@@ -5060,9 +5061,9 @@ class _SupervisedExperiment(_TabularExperiment):
                         score_columns = replace_labels_in_column(
                             pipeline, score_columns
                         )
-                    score.columns = [f"prediction_score_{l}" for l in score_columns]
+                    score.columns = [f"{SCORE_COLUMN}_{l}" for l in score_columns]
                 else:
-                    score.columns = ["prediction_score"]
+                    score.columns = [SCORE_COLUMN]
                 score = score.round(round)
                 old_index = X_test_.index
                 X_test_ = pd.concat((X_test_, score), axis=1)
@@ -5222,7 +5223,7 @@ class _SupervisedExperiment(_TabularExperiment):
         if self._ml_usecase == MLUsecase.CLASSIFICATION:
             metric_dict["Selection Rate"] = selection_rate
 
-        y_pred = self.predict_model(estimator)["prediction_label"]
+        y_pred = self.predict_model(estimator)[LABEL_COLUMN]
         y_true = self.y_test
 
         try:

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -4836,8 +4836,8 @@ class _SupervisedExperiment(_TabularExperiment):
         Returns
         -------
         Predictions
-            Predictions (Label and Score) column attached to the original dataset
-            and returned as pandas dataframe.
+            Predictions (prediction_label and prediction_score) columns are
+            attached to the original dataset and returned as pandas dataframe.
 
         score_grid
             A table containing the scoring metrics on hold-out / test set.
@@ -5029,15 +5029,17 @@ class _SupervisedExperiment(_TabularExperiment):
             df_score = df_score.round(round)
             display.display(df_score.style.format(precision=round))
 
-        label = pd.DataFrame(pred, columns=["Label"], index=X_test_.index)
+        label = pd.DataFrame(pred, columns=["prediction_label"], index=X_test_.index)
         if ml_usecase == MLUsecase.CLASSIFICATION:
             try:
-                label["Label"] = label["Label"].astype(int)
+                label["prediction_label"] = label["prediction_label"].astype(int)
             except:
                 pass
 
         if not encoded_labels:
-            label["Label"] = replace_labels_in_column(pipeline, label["Label"])
+            label["prediction_label"] = replace_labels_in_column(
+                pipeline, label["prediction_label"]
+            )
             if y_test_ is not None:
                 y_test_ = replace_labels_in_column(pipeline, y_test_)
         old_index = X_test_.index
@@ -5058,9 +5060,9 @@ class _SupervisedExperiment(_TabularExperiment):
                         score_columns = replace_labels_in_column(
                             pipeline, score_columns
                         )
-                    score.columns = [f"Score_{label}" for label in score_columns]
+                    score.columns = [f"prediction_score_{l}" for l in score_columns]
                 else:
-                    score.columns = ["Score"]
+                    score.columns = ["prediction_score"]
                 score = score.round(round)
                 old_index = X_test_.index
                 X_test_ = pd.concat((X_test_, score), axis=1)

--- a/pycaret/internal/pycaret_experiment/tabular_experiment.py
+++ b/pycaret/internal/pycaret_experiment/tabular_experiment.py
@@ -2644,7 +2644,7 @@ pydanticoutputmodel=create_model("{API_NAME}_output", **{outputDataframeschema})
 def predict(datainput:pydanticinputmodel):
     data = pd.DataFrame([datainput.dict()])
     predictions = predict_model(model, data=data)
-    return {D1}"{tarname}": predictions["Label"][0]{D2}
+    return {D1}"{tarname}": predictions["prediction_label"][0]{D2}
 if __name__ == "__main__":
     uvicorn.run(app, host="{HOST}", port={PORT})""".format(
             MODULE_NAME=MODULE,

--- a/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
@@ -94,6 +94,7 @@ class _UnsupervisedExperiment(_TabularExperiment, Preprocessor):
         ignore_features: Optional[List[str]] = None,
         keep_features: Optional[List[str]] = None,
         preprocess: bool = True,
+        create_date_columns: List[str] = ["day", "month", "year"],
         imputation_type: Optional[str] = "simple",
         numeric_imputation: str = "mean",
         categorical_imputation: str = "constant",
@@ -209,6 +210,14 @@ class _UnsupervisedExperiment(_TabularExperiment, Preprocessor):
             and custom transformations passed in ``custom_pipeline`` param. Data must be
             ready for modeling (no missing values, no dates, categorical data encoding),
             when preprocess is set to False.
+
+
+        create_date_columns: list of str, default=["day", "month", "year"]
+            Columns to create from the date features. Note that created features
+            with zero variance (e.g. the feature hour in a column that only contains
+            dates) are ignored. Allowed values are datetime attributes from
+            `pandas.Series.dt`. The datetime format of the feature is inferred
+            automatically from the first non NaN value.
 
 
         imputation_type: str or None, default = 'simple'
@@ -542,7 +551,7 @@ class _UnsupervisedExperiment(_TabularExperiment, Preprocessor):
 
             # Convert date feature to numerical values
             if self._fxs["Date"]:
-                self._date_feature_engineering()
+                self._date_feature_engineering(create_date_columns)
 
             # Impute missing values
             if imputation_type == "simple":

--- a/pycaret/regression/functional.py
+++ b/pycaret/regression/functional.py
@@ -38,6 +38,7 @@ def setup(
     ignore_features: Optional[List[str]] = None,
     keep_features: Optional[List[str]] = None,
     preprocess: bool = True,
+    create_date_columns: List[str] = ["day", "month", "year"],
     imputation_type: Optional[str] = "simple",
     numeric_imputation: Union[int, float, str] = "mean",
     categorical_imputation: str = "constant",
@@ -191,6 +192,14 @@ def setup(
         and custom transformations passed in ``custom_pipeline`` param. Data must be
         ready for modeling (no missing values, no dates, categorical data encoding),
         when preprocess is set to False.
+
+
+    create_date_columns: list of str, default=["day", "month", "year"]
+        Columns to create from the date features. Note that created features
+        with zero variance (e.g. the feature hour in a column that only contains
+        dates) are ignored. Allowed values are datetime attributes from
+        `pandas.Series.dt`. The datetime format of the feature is inferred
+        automatically from the first non NaN value.
 
 
     imputation_type: str or None, default = 'simple'
@@ -590,6 +599,7 @@ def setup(
         ignore_features=ignore_features,
         keep_features=keep_features,
         preprocess=preprocess,
+        create_date_columns=create_date_columns,
         imputation_type=imputation_type,
         numeric_imputation=numeric_imputation,
         categorical_imputation=categorical_imputation,

--- a/pycaret/regression/oop.py
+++ b/pycaret/regression/oop.py
@@ -98,6 +98,7 @@ class RegressionExperiment(_SupervisedExperiment, Preprocessor):
         ignore_features: Optional[List[str]] = None,
         keep_features: Optional[List[str]] = None,
         preprocess: bool = True,
+        create_date_columns: List[str] = ["day", "month", "year"],
         imputation_type: Optional[str] = "simple",
         numeric_imputation: str = "mean",
         categorical_imputation: str = "constant",
@@ -255,6 +256,14 @@ class RegressionExperiment(_SupervisedExperiment, Preprocessor):
             and custom transformations passed in ``custom_pipeline`` param. Data must be
             ready for modeling (no missing values, no dates, categorical data encoding),
             when preprocess is set to False.
+
+
+        create_date_columns: list of str, default=["day", "month", "year"]
+            Columns to create from the date features. Note that created features
+            with zero variance (e.g. the feature hour in a column that only contains
+            dates) are ignored. Allowed values are datetime attributes from
+            `pandas.Series.dt`. The datetime format of the feature is inferred
+            automatically from the first non NaN value.
 
 
         imputation_type: str or None, default = 'simple'
@@ -753,7 +762,7 @@ class RegressionExperiment(_SupervisedExperiment, Preprocessor):
 
             # Convert date feature to numerical values
             if self._fxs["Date"]:
-                self._date_feature_engineering()
+                self._date_feature_engineering(create_date_columns)
 
             # Impute missing values
             if imputation_type == "simple":

--- a/pycaret/tests/test_preprocess.py
+++ b/pycaret/tests/test_preprocess.py
@@ -101,6 +101,20 @@ def test_date_features():
     assert all([f"date_{attr}" in X for attr in ("day", "month", "year")])
 
 
+def test_custom_date_features():
+    """Assert that features are extracted from date features."""
+    data = pycaret.datasets.get_data("juice")
+    data["date"] = pd.date_range(start="1/1/2018", periods=len(data))
+    pc = pycaret.classification.setup(
+        data,
+        target=-2,
+        date_features=["date"],
+        create_date_columns=["quarter"],
+    )
+    X, _ = pc.pipeline.transform(pc.X, pc.y)
+    assert "date_quarter" in X and "day" not in X
+
+
 @pytest.mark.parametrize(
     "imputation_method", [0, "drop", "mean", "median", "mode", "knn"]
 )

--- a/pycaret/tests/test_utils.py
+++ b/pycaret/tests/test_utils.py
@@ -43,7 +43,7 @@ def test_utils():
         final_model, data=test.drop("Purchase", axis=1), encoded_labels=True
     )
     actual = clf1.pipeline.transform(y=test["Purchase"])
-    prediction = result["Label"]
+    prediction = result["prediction_label"]
 
     # provisional support
     actual = actual.dropna(axis=0, how="any")
@@ -51,7 +51,7 @@ def test_utils():
     actual = actual["Purchase"].astype(np.int64)
     prediction = prediction.dropna(axis=0, how="any")
     prediction = prediction.reset_index()
-    prediction = prediction["Label"].astype(np.int64)
+    prediction = prediction["prediction_label"].astype(np.int64)
 
     # check metric(classification)
     accuracy = pycaret.utils.check_metric(actual, prediction, "Accuracy")
@@ -101,7 +101,7 @@ def test_utils():
         final_model, data=test.drop("medv", axis=1)
     )
     actual = test["medv"]
-    prediction = result["Label"]
+    prediction = result["prediction_label"]
 
     # provisional support
     actual = actual.dropna(axis=0, how="any")

--- a/pycaret/tests/test_utils.py
+++ b/pycaret/tests/test_utils.py
@@ -14,6 +14,7 @@ import pycaret.classification
 import pycaret.datasets
 import pycaret.regression
 import pycaret.utils
+from pycaret.utils.constants import LABEL_COLUMN
 
 
 def test_utils():
@@ -43,7 +44,7 @@ def test_utils():
         final_model, data=test.drop("Purchase", axis=1), encoded_labels=True
     )
     actual = clf1.pipeline.transform(y=test["Purchase"])
-    prediction = result["prediction_label"]
+    prediction = result[LABEL_COLUMN]
 
     # provisional support
     actual = actual.dropna(axis=0, how="any")
@@ -51,7 +52,7 @@ def test_utils():
     actual = actual["Purchase"].astype(np.int64)
     prediction = prediction.dropna(axis=0, how="any")
     prediction = prediction.reset_index()
-    prediction = prediction["prediction_label"].astype(np.int64)
+    prediction = prediction[LABEL_COLUMN].astype(np.int64)
 
     # check metric(classification)
     accuracy = pycaret.utils.check_metric(actual, prediction, "Accuracy")
@@ -101,7 +102,7 @@ def test_utils():
         final_model, data=test.drop("medv", axis=1)
     )
     actual = test["medv"]
-    prediction = result["prediction_label"]
+    prediction = result[LABEL_COLUMN]
 
     # provisional support
     actual = actual.dropna(axis=0, how="any")

--- a/pycaret/utils/constants.py
+++ b/pycaret/utils/constants.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+"""
+Pycaret
+Author: Mavs
+Description: Module containing all constants of pycaret.
+
+"""
+
+
+# Column name that contains the predicted label in predict_model's output
+LABEL_COLUMN = "prediction_label"
+
+# Column name that contains the predicted label in predict_model's output
+SCORE_COLUMN = "prediction_score"

--- a/resources/Time Series 101 — For beginners.md
+++ b/resources/Time Series 101 — For beginners.md
@@ -138,7 +138,7 @@ MAE on the test set is 12% higher than the cross-validated MAE. Not so good, but
     predictions['Date'] = pd.date_range(start='1949-01-01', end = '1960-12-01', freq = 'MS')
 
     **# line plot**
-    fig = px.line(predictions, x='Date', y=["Passengers", "Label"], template = 'plotly_dark')
+    fig = px.line(predictions, x='Date', y=["Passengers", "prediction_label"], template = 'plotly_dark')
 
     **# add a vertical rectange for test-set separation**
     fig.add_vrect(x0="1960-01-01", x1="1960-12-01", fillcolor="grey", opacity=0.25, line_width=0)fig.show()
@@ -176,7 +176,7 @@ Now, let’s use the future_df to score and generate predictions.
     concat_df_i = pd.date_range(start='1949-01-01', end = '1965-01-01', freq = 'MS')
     concat_df.set_index(concat_df_i, inplace=True)fig = 
 
-    px.line(concat_df, x=concat_df.index, y=["Passengers", "Label"], template = 'plotly_dark')
+    px.line(concat_df, x=concat_df.index, y=["Passengers", "prediction_label"], template = 'plotly_dark')
     fig.show()
 
 ![Actual (1949–1960) and Predicted (1961–1964) US airline passengers](https://cdn-images-1.medium.com/max/2614/0*x8TJJUO--Unxheeg.png)


### PR DESCRIPTION
Closes #2790 and #2784

#### Describe the changes you've made

* It's now possible to choose which datetime columns to extract from `date_features` using parameter `create_date_columns` in setup.
 * In `predict_model`, the Label and Score column names have been replaced with `prediction_label` and `prediction_score`.

## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
