### PR TITLE
Fix for time series forecast horizon with gaps and exogenous variables

### DIFF
--- a/pycaret/internal/pycaret_experiment/pycaret_experiment.py
+++ b/pycaret/internal/pycaret_experiment/pycaret_experiment.py
@@ -462,12 +462,16 @@ class _PyCaretExperiment:
         if self._ml_usecase != MLUsecase.TIME_SERIES:
             return self.dataset.loc[self.idx[1], :]
         else:
-            # Return the X_test indices not y_test indices since X_test indices
-            # are the expanded indices for handling FH with gaps.
+            # Return the y_test indices not X_test indices.
+            # X_test indices are expanded indices for handling FH with gaps.
+            # But if we return X_test indices, then we will get expanded test
+            # indices even for univariate time series without exogenous variables
+            # which would be confusing. Hence, we return y_test indices here and if
+            # we want to get X_test indices, then we use self.X_test directly.
             # Refer:
             # https://github.com/alan-turing-institute/sktime/issues/2598#issuecomment-1203308542
             # https://github.com/alan-turing-institute/sktime/blob/4164639e1c521b112711c045d0f7e63013c1e4eb/sktime/forecasting/model_evaluation/_functions.py#L196
-            return self.dataset.loc[self.idx[2], :]
+            return self.dataset.loc[self.idx[1], :]
 
     @property
     def X(self):
@@ -610,12 +614,16 @@ class _PyCaretExperiment:
                 ],
                 axis=1,
             )
-            # Return the X_test indices not y_test indices since X_test indices
-            # are the expanded indices for handling FH with gaps.
+            # Return the y_test indices not X_test indices.
+            # X_test indices are expanded indices for handling FH with gaps.
+            # But if we return X_test indices, then we will get expanded test
+            # indices even for univariate time series without exogenous variables
+            # which would be confusing. Hence, we return y_test indices here and if
+            # we want to get X_test indices, then we use self.X_test directly.
             # Refer:
             # https://github.com/alan-turing-institute/sktime/issues/2598#issuecomment-1203308542
             # https://github.com/alan-turing-institute/sktime/blob/4164639e1c521b112711c045d0f7e63013c1e4eb/sktime/forecasting/model_evaluation/_functions.py#L196
-            return all_data.loc[self.idx[2]]
+            return all_data.loc[self.idx[1]]
 
     @property
     def X_transformed(self):

--- a/pycaret/tests/test_time_series_setup.py
+++ b/pycaret/tests/test_time_series_setup.py
@@ -299,8 +299,8 @@ def test_setup_seasonal_period_alphanumeric(
     assert exp.seasonal_period == expected_seasonal_value
 
 
-def test_train_test_split(load_pos_and_neg_data):
-    """Tests the enforcement of prediction interval"""
+def test_train_test_split_uni_no_exo(load_pos_and_neg_data):
+    """Tests the train-test splits for univariate time series without exogenous variables"""
     data = load_pos_and_neg_data
 
     ####################################
@@ -311,22 +311,78 @@ def test_train_test_split(load_pos_and_neg_data):
     exp = TSForecastingExperiment()
     fh = 12
     exp.setup(data=data, fh=fh, session_id=42)
-    y_test = exp.get_config("y_test")
-    assert len(y_test) == fh
+    assert np.all(exp.dataset.index == data.index)
+    assert np.all(exp.train.index == data.iloc[: (len(data) - fh)].index)
+    assert np.all(exp.test.index == data.iloc[-fh:].index)
+    assert exp.X is None
+    assert np.all(exp.y.index == data.index)
+    assert exp.X_train is None
+    assert exp.X_test is None
+    assert np.all(exp.y_train.index == data.iloc[: (len(data) - fh)].index)
+    assert np.all(exp.y_test.index == data.iloc[-fh:].index)
+    assert np.all(exp.dataset_transformed.index == data.index)
+    assert np.all(exp.train_transformed.index == data.iloc[: (len(data) - fh)].index)
+    assert np.all(exp.test_transformed.index == data.iloc[-fh:].index)
+    assert exp.X_transformed is None
+    assert np.all(exp.y_transformed.index == data.index)
+    assert exp.X_train_transformed is None
+    assert exp.X_test_transformed is None
+    assert np.all(exp.y_train_transformed.index == data.iloc[: (len(data) - fh)].index)
+    assert np.all(exp.y_test_transformed.index == data.iloc[-fh:].index)
 
     #### Numpy fh ----
     exp = TSForecastingExperiment()
     fh = np.arange(1, 10)  # 9 values
     exp.setup(data=data, fh=fh, session_id=42)
-    y_test = exp.get_config("y_test")
-    assert len(y_test) == len(fh)
+    assert np.all(exp.dataset.index == data.index)
+    assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert np.all(exp.test.index == data.iloc[-len(fh) :].index)
+    assert exp.X is None
+    assert np.all(exp.y.index == data.index)
+    assert exp.X_train is None
+    assert exp.X_test is None
+    assert np.all(exp.y_train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert np.all(exp.y_test.index == data.iloc[-len(fh) :].index)
+    assert np.all(exp.dataset_transformed.index == data.index)
+    assert np.all(
+        exp.train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert np.all(exp.test_transformed.index == data.iloc[-len(fh) :].index)
+    assert exp.X_transformed is None
+    assert np.all(exp.y_transformed.index == data.index)
+    assert exp.X_train_transformed is None
+    assert exp.X_test_transformed is None
+    assert np.all(
+        exp.y_train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert np.all(exp.y_test_transformed.index == data.iloc[-len(fh) :].index)
 
     #### List fh ----
     exp = TSForecastingExperiment()
     fh = [1, 2, 3, 4, 5, 6]
     exp.setup(data=data, fh=fh, session_id=42)
-    y_test = exp.get_config("y_test")
-    assert len(y_test) == len(fh)
+    assert np.all(exp.dataset.index == data.index)
+    assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert np.all(exp.test.index == data.iloc[-len(fh) :].index)
+    assert exp.X is None
+    assert np.all(exp.y.index == data.index)
+    assert exp.X_train is None
+    assert exp.X_test is None
+    assert np.all(exp.y_train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert np.all(exp.y_test.index == data.iloc[-len(fh) :].index)
+    assert np.all(exp.dataset_transformed.index == data.index)
+    assert np.all(
+        exp.train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert np.all(exp.test_transformed.index == data.iloc[-len(fh) :].index)
+    assert exp.X_transformed is None
+    assert np.all(exp.y_transformed.index == data.index)
+    assert exp.X_train_transformed is None
+    assert exp.X_test_transformed is None
+    assert np.all(
+        exp.y_train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert np.all(exp.y_test_transformed.index == data.iloc[-len(fh) :].index)
 
     #################################
     #### Continuous fh with Gaps ####
@@ -336,15 +392,55 @@ def test_train_test_split(load_pos_and_neg_data):
     exp = TSForecastingExperiment()
     fh = np.arange(7, 13)  # 6 values
     exp.setup(data=data, fh=fh, session_id=42)
-    y_test = exp.get_config("y_test")
-    assert len(y_test) == len(fh)
+    assert np.all(exp.dataset.index == data.index)
+    assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert len(exp.test) == len(fh)
+    assert exp.X is None
+    assert np.all(exp.y.index == data.index)
+    assert exp.X_train is None
+    assert exp.X_test is None
+    assert np.all(exp.y_train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert len(exp.y_test) == len(fh)
+    assert np.all(exp.dataset_transformed.index == data.index)
+    assert np.all(
+        exp.train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert len(exp.test_transformed) == len(fh)
+    assert exp.X_transformed is None
+    assert np.all(exp.y_transformed.index == data.index)
+    assert exp.X_train_transformed is None
+    assert exp.X_test_transformed is None
+    assert np.all(
+        exp.y_train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert len(exp.y_test_transformed) == len(fh)
 
     #### List fh ----
     exp = TSForecastingExperiment()
     fh = [4, 5, 6]
     exp.setup(data=data, fh=fh, session_id=42)
-    y_test = exp.get_config("y_test")
-    assert len(y_test) == len(fh)
+    assert np.all(exp.dataset.index == data.index)
+    assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert len(exp.test) == len(fh)
+    assert exp.X is None
+    assert np.all(exp.y.index == data.index)
+    assert exp.X_train is None
+    assert exp.X_test is None
+    assert np.all(exp.y_train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert len(exp.y_test) == len(fh)
+    assert np.all(exp.dataset_transformed.index == data.index)
+    assert np.all(
+        exp.train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert len(exp.test_transformed) == len(fh)
+    assert exp.X_transformed is None
+    assert np.all(exp.y_transformed.index == data.index)
+    assert exp.X_train_transformed is None
+    assert exp.X_test_transformed is None
+    assert np.all(
+        exp.y_train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert len(exp.y_test_transformed) == len(fh)
 
     ####################################
     #### Discontinuous fh with Gaps ####
@@ -354,15 +450,263 @@ def test_train_test_split(load_pos_and_neg_data):
     exp = TSForecastingExperiment()
     fh = np.array([4, 5, 6, 10, 11, 12])  # 6 values
     exp.setup(data=data, fh=fh, session_id=42)
-    y_test = exp.get_config("y_test")
-    assert len(y_test) == len(fh)
+    assert np.all(exp.dataset.index == data.index)
+    assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert len(exp.test) == len(fh)
+    assert exp.X is None
+    assert np.all(exp.y.index == data.index)
+    assert exp.X_train is None
+    assert exp.X_test is None
+    assert np.all(exp.y_train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert len(exp.y_test) == len(fh)
+    assert np.all(exp.dataset_transformed.index == data.index)
+    assert np.all(
+        exp.train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert len(exp.test_transformed) == len(fh)
+    assert exp.X_transformed is None
+    assert np.all(exp.y_transformed.index == data.index)
+    assert exp.X_train_transformed is None
+    assert exp.X_test_transformed is None
+    assert np.all(
+        exp.y_train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert len(exp.y_test_transformed) == len(fh)
 
     #### List fh ----
     exp = TSForecastingExperiment()
     fh = [4, 5, 6, 10, 11, 12]
     exp.setup(data=data, fh=fh, session_id=42)
-    y_test = exp.get_config("y_test")
-    assert len(y_test) == len(fh)
+    assert np.all(exp.dataset.index == data.index)
+    assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert len(exp.test) == len(fh)
+    assert exp.X is None
+    assert np.all(exp.y.index == data.index)
+    assert exp.X_train is None
+    assert exp.X_test is None
+    assert np.all(exp.y_train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert len(exp.y_test) == len(fh)
+    assert np.all(exp.dataset_transformed.index == data.index)
+    assert np.all(
+        exp.train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert len(exp.test_transformed) == len(fh)
+    assert exp.X_transformed is None
+    assert np.all(exp.y_transformed.index == data.index)
+    assert exp.X_train_transformed is None
+    assert exp.X_test_transformed is None
+    assert np.all(
+        exp.y_train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert len(exp.y_test_transformed) == len(fh)
+
+
+def test_train_test_split_uni_exo(load_uni_exo_data_target):
+    """Tests the train-test splits for univariate time series with exogenous variables"""
+    data, target = load_uni_exo_data_target
+
+    ####################################
+    #### Continuous fh without Gaps ####
+    ####################################
+
+    #### Integer fh ----
+    exp = TSForecastingExperiment()
+    fh = 12
+    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    assert np.all(exp.dataset.index == data.index)
+    assert np.all(exp.train.index == data.iloc[: (len(data) - fh)].index)
+    assert np.all(exp.test.index == data.iloc[-fh:].index)
+    assert np.all(exp.X.index == data.index)
+    assert np.all(exp.y.index == data.index)
+    assert np.all(exp.X_train.index == data.iloc[: (len(data) - fh)].index)
+    assert np.all(exp.X_test.index == data.iloc[-fh:].index)
+    assert np.all(exp.y_train.index == data.iloc[: (len(data) - fh)].index)
+    assert np.all(exp.y_test.index == data.iloc[-fh:].index)
+    assert np.all(exp.dataset_transformed.index == data.index)
+    assert np.all(exp.train_transformed.index == data.iloc[: (len(data) - fh)].index)
+    assert np.all(exp.test_transformed.index == data.iloc[-fh:].index)
+    assert np.all(exp.X_transformed.index == data.index)
+    assert np.all(exp.y_transformed.index == data.index)
+    assert np.all(exp.X_train_transformed.index == data.iloc[: (len(data) - fh)].index)
+    assert np.all(exp.X_test_transformed.index == data.iloc[-fh:].index)
+    assert np.all(exp.y_train_transformed.index == data.iloc[: (len(data) - fh)].index)
+    assert np.all(exp.y_test_transformed.index == data.iloc[-fh:].index)
+
+    #### Numpy fh ----
+    exp = TSForecastingExperiment()
+    fh = np.arange(1, 10)  # 9 values
+    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    assert np.all(exp.dataset.index == data.index)
+    assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert np.all(exp.test.index == data.iloc[-len(fh) :].index)
+    assert np.all(exp.X.index == data.index)
+    assert np.all(exp.y.index == data.index)
+    assert np.all(exp.X_train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert np.all(exp.X_test.index == data.iloc[-len(fh) :].index)
+    assert np.all(exp.y_train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert np.all(exp.y_test.index == data.iloc[-len(fh) :].index)
+    assert np.all(exp.dataset_transformed.index == data.index)
+    assert np.all(
+        exp.train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert np.all(exp.test_transformed.index == data.iloc[-len(fh) :].index)
+    assert np.all(exp.X_transformed.index == data.index)
+    assert np.all(exp.y_transformed.index == data.index)
+    assert np.all(
+        exp.X_train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert np.all(exp.X_test_transformed.index == data.iloc[-len(fh) :].index)
+    assert np.all(
+        exp.y_train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert np.all(exp.y_test_transformed.index == data.iloc[-len(fh) :].index)
+
+    #### List fh ----
+    exp = TSForecastingExperiment()
+    fh = [1, 2, 3, 4, 5, 6]
+    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    assert np.all(exp.dataset.index == data.index)
+    assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert np.all(exp.test.index == data.iloc[-len(fh) :].index)
+    assert np.all(exp.X.index == data.index)
+    assert np.all(exp.y.index == data.index)
+    assert np.all(exp.X_train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert np.all(exp.X_test.index == data.iloc[-len(fh) :].index)
+    assert np.all(exp.y_train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert np.all(exp.y_test.index == data.iloc[-len(fh) :].index)
+    assert np.all(exp.dataset_transformed.index == data.index)
+    assert np.all(
+        exp.train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert np.all(exp.test_transformed.index == data.iloc[-len(fh) :].index)
+    assert np.all(exp.X_transformed.index == data.index)
+    assert np.all(exp.y_transformed.index == data.index)
+    assert np.all(
+        exp.X_train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert np.all(exp.X_test_transformed.index == data.iloc[-len(fh) :].index)
+    assert np.all(
+        exp.y_train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert np.all(exp.y_test_transformed.index == data.iloc[-len(fh) :].index)
+
+    #################################
+    #### Continuous fh with Gaps ####
+    #################################
+
+    #### Numpy fh ----
+    exp = TSForecastingExperiment()
+    fh = np.arange(7, 13)  # 6 values
+    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    assert np.all(exp.dataset.index == data.index)
+    assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
+    # `test`` call still refers to y_test indices and not X_test indices
+    assert len(exp.test) == len(fh)
+    assert np.all(exp.X.index == data.index)
+    assert np.all(exp.y.index == data.index)
+    assert np.all(exp.X_train.index == data.iloc[: (len(data) - max(fh))].index)
+    # Exogenous variables will not have any gaps (only target has gaps)
+    assert np.all(exp.X_test.index == data.iloc[-max(fh) :].index)
+    assert np.all(exp.y_train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert len(exp.y_test) == len(fh)
+    assert np.all(exp.dataset_transformed.index == data.index)
+    assert np.all(
+        exp.train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert len(exp.test_transformed) == len(fh)
+    assert np.all(exp.X_transformed.index == data.index)
+    assert np.all(exp.y_transformed.index == data.index)
+
+    #### List fh ----
+    exp = TSForecastingExperiment()
+    fh = [4, 5, 6]
+    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    assert np.all(exp.dataset.index == data.index)
+    assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
+    # `test`` call still refers to y_test indices and not X_test indices
+    assert len(exp.test) == len(fh)
+    assert np.all(exp.X.index == data.index)
+    assert np.all(exp.y.index == data.index)
+    assert np.all(exp.X_train.index == data.iloc[: (len(data) - max(fh))].index)
+    # Exogenous variables will not have any gaps (only target has gaps)
+    assert np.all(exp.X_test.index == data.iloc[-max(fh) :].index)
+    assert np.all(exp.y_train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert len(exp.y_test) == len(fh)
+    assert np.all(exp.dataset_transformed.index == data.index)
+    assert np.all(
+        exp.train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert len(exp.test_transformed) == len(fh)
+    assert np.all(exp.X_transformed.index == data.index)
+    assert np.all(exp.y_transformed.index == data.index)
+
+    ####################################
+    #### Discontinuous fh with Gaps ####
+    ####################################
+
+    #### Numpy fh ----
+    exp = TSForecastingExperiment()
+    fh = np.array([4, 5, 6, 10, 11, 12])  # 6 values
+    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    assert np.all(exp.dataset.index == data.index)
+    assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
+    # `test`` call still refers to y_test indices and not X_test indices
+    assert len(exp.test) == len(fh)
+    assert np.all(exp.X.index == data.index)
+    assert np.all(exp.y.index == data.index)
+    assert np.all(exp.X_train.index == data.iloc[: (len(data) - max(fh))].index)
+    # Exogenous variables will not have any gaps (only target has gaps)
+    assert np.all(exp.X_test.index == data.iloc[-max(fh) :].index)
+    assert np.all(exp.y_train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert len(exp.y_test) == len(fh)
+    assert np.all(exp.dataset_transformed.index == data.index)
+    assert np.all(
+        exp.train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert len(exp.test_transformed) == len(fh)
+    assert np.all(exp.X_transformed.index == data.index)
+    assert np.all(exp.y_transformed.index == data.index)
+    assert np.all(
+        exp.X_train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    # Exogenous variables will not have any gaps (only target has gaps)
+    assert np.all(exp.X_test_transformed.index == data.iloc[-max(fh) :].index)
+    assert np.all(
+        exp.y_train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert len(exp.y_test_transformed) == len(fh)
+
+    #### List fh ----
+    exp = TSForecastingExperiment()
+    fh = [4, 5, 6, 10, 11, 12]
+    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    assert np.all(exp.dataset.index == data.index)
+    assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
+    # `test`` call still refers to y_test indices and not X_test indices
+    assert len(exp.test) == len(fh)
+    assert np.all(exp.X.index == data.index)
+    assert np.all(exp.y.index == data.index)
+    assert np.all(exp.X_train.index == data.iloc[: (len(data) - max(fh))].index)
+    # Exogenous variables will not have any gaps (only target has gaps)
+    assert np.all(exp.X_test.index == data.iloc[-max(fh) :].index)
+    assert np.all(exp.y_train.index == data.iloc[: (len(data) - max(fh))].index)
+    assert len(exp.y_test) == len(fh)
+    assert np.all(exp.dataset_transformed.index == data.index)
+    assert np.all(
+        exp.train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert len(exp.test_transformed) == len(fh)
+    assert np.all(exp.X_transformed.index == data.index)
+    assert np.all(exp.y_transformed.index == data.index)
+    assert np.all(
+        exp.X_train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    # Exogenous variables will not have any gaps (only target has gaps)
+    assert np.all(exp.X_test_transformed.index == data.iloc[-max(fh) :].index)
+    assert np.all(
+        exp.y_train_transformed.index == data.iloc[: (len(data) - max(fh))].index
+    )
+    assert len(exp.y_test_transformed) == len(fh)
 
 
 def test_missing_indices():

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -875,7 +875,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         # internally based on these indices and self.data
         # Different from non-time series, we save X_test index here as well to
         # handle FH with gaps. In such cases, y_test will have gaps, but full
-        # X_test is needed for some forecasters. 
+        # X_test is needed for some forecasters.
         # Refer:
         # https://github.com/alan-turing-institute/sktime/issues/2598#issuecomment-1203308542
         # https://github.com/alan-turing-institute/sktime/blob/4164639e1c521b112711c045d0f7e63013c1e4eb/sktime/forecasting/model_evaluation/_functions.py#L196

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -871,9 +871,15 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         )
 
         # idx contains train, test indices.
-        # Setting of self.y_train, self.y_test, self.X_train and self.X_test
-        # will be handled internally based on these indices and self.data
-        self.idx = [y_train.index, y_test.index]
+        # Setting of self.y_train, self.y_test, self.X_train will be handled
+        # internally based on these indices and self.data
+        # Different from non-time series, we save X_test index here as well to
+        # handle FH with gaps. In such cases, y_test will have gaps, but full
+        # X_test is needed for some forecasters. 
+        # Refer:
+        # https://github.com/alan-turing-institute/sktime/issues/2598#issuecomment-1203308542
+        # https://github.com/alan-turing-institute/sktime/blob/4164639e1c521b112711c045d0f7e63013c1e4eb/sktime/forecasting/model_evaluation/_functions.py#L196
+        self.idx = [y_train.index, y_test.index, X_test.index]
 
         return self
 

--- a/pycaret/utils/time_series/forecasting/model_selection.py
+++ b/pycaret/utils/time_series/forecasting/model_selection.py
@@ -128,10 +128,19 @@ def _fit_and_score(
 
     y_imputed, _ = _get_imputed_data(pipeline=pipeline, y=y, X=X)
 
+    # We need to expand test indices to a full range, since some forecasters
+    # require the full range of exogenous values. This comes into picture when
+    # FH has gaps (e.g. [2, 3]). In that case, some forecasters still need the
+    # exogenous variable values at FH = 1
+    # Refer:
+    # https://github.com/alan-turing-institute/sktime/issues/2598#issuecomment-1203308542
+    # https://github.com/alan-turing-institute/sktime/blob/4164639e1c521b112711c045d0f7e63013c1e4eb/sktime/forecasting/model_evaluation/_functions.py#L196
+    test_expanded = np.arange(train[-1], test[-1]) + 1
+
     # y_train, X_train, X_test can have missing values since pipeline will impute them
     y_train = y[train]
     X_train = None if X is None else X.iloc[train]
-    X_test = None if X is None else X.iloc[test]
+    X_test = None if X is None else X.iloc[test_expanded]
 
     # y_test is "y_true" and used for metrics, hence it can not have missing values
     # Hence using y_imputed


### PR DESCRIPTION
## Related Issue or bug

Closes #2480

#### Describe the changes you've made

Made changes to the handling of test indices for exogenous variables (expand test indices for exogenous variables to include all points without gaps). y_test indices remain the same (with gaps).

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- New tests added for FH with gaps and to test the attributes like X_test, y_test, etc. 
- Existing tests pass on GitHub

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

A clear and concise description of it.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

