### PR TITLE
added index handling

### DIFF
--- a/pycaret/anomaly/functional.py
+++ b/pycaret/anomaly/functional.py
@@ -6,8 +6,8 @@ from joblib.memory import Memory
 
 from pycaret.anomaly.oop import AnomalyExperiment
 from pycaret.internal.utils import check_if_global_is_not_none
-from pycaret.utils.constants import SEQUENCE_LIKE, DATAFRAME_LIKE
 from pycaret.loggers.base_logger import BaseLogger
+from pycaret.utils.constants import DATAFRAME_LIKE, SEQUENCE_LIKE
 
 _EXPERIMENT_CLASS = AnomalyExperiment
 _CURRENT_EXPERIMENT: Optional[AnomalyExperiment] = None

--- a/pycaret/anomaly/functional.py
+++ b/pycaret/anomaly/functional.py
@@ -5,7 +5,8 @@ import pandas as pd
 from joblib.memory import Memory
 
 from pycaret.anomaly.oop import AnomalyExperiment
-from pycaret.internal.utils import DATAFRAME_LIKE, check_if_global_is_not_none
+from pycaret.internal.utils import check_if_global_is_not_none
+from pycaret.utils.constants import SEQUENCE_LIKE, DATAFRAME_LIKE
 from pycaret.loggers.base_logger import BaseLogger
 
 _EXPERIMENT_CLASS = AnomalyExperiment
@@ -20,6 +21,7 @@ _CURRENT_EXPERIMENT_DECORATOR_DICT = {
 
 def setup(
     data: DATAFRAME_LIKE,
+    index: Union[bool, int, str, SEQUENCE_LIKE] = False,
     ordinal_features: Optional[Dict[str, list]] = None,
     numeric_features: Optional[List[str]] = None,
     categorical_features: Optional[List[str]] = None,
@@ -93,6 +95,14 @@ def setup(
         number of samples and n_features is the number of features. If data
         is not a pandas dataframe, it's converted to one using default column
         names.
+
+
+    index: bool, int, str or sequence, default=False
+        - If False: Reset to RangeIndex.
+        - If True: Use the current index.
+        - If int: Index of the column to use as index.
+        - If str: Name of the column to use as index.
+        - If sequence: Index column with shape=(n_samples,).
 
 
     ordinal_features: dict, default = None
@@ -423,6 +433,7 @@ def setup(
     set_current_experiment(exp)
     return exp.setup(
         data=data,
+        index=index,
         ordinal_features=ordinal_features,
         numeric_features=numeric_features,
         categorical_features=categorical_features,

--- a/pycaret/anomaly/functional.py
+++ b/pycaret/anomaly/functional.py
@@ -97,12 +97,13 @@ def setup(
         names.
 
 
-    index: bool, int, str or sequence, default=False
-        - If False: Reset to RangeIndex.
-        - If True: Use the current index.
-        - If int: Index of the column to use as index.
-        - If str: Name of the column to use as index.
-        - If sequence: Index column with shape=(n_samples,).
+    index: bool, int, str or sequence, default = False
+        Handle indices in the `data` dataframe.
+            - If False: Reset to RangeIndex.
+            - If True: Keep the provided index.
+            - If int: Position of the column to use as index.
+            - If str: Name of the column to use as index.
+            - If sequence: Array with shape=(n_samples,) to use as index.
 
 
     ordinal_features: dict, default = None
@@ -154,7 +155,7 @@ def setup(
         when preprocess is set to False.
 
 
-    create_date_columns: list of str, default=["day", "month", "year"]
+    create_date_columns: list of str, default = ["day", "month", "year"]
         Columns to create from the date features. Note that created features
         with zero variance (e.g. the feature hour in a column that only contains
         dates) are ignored. Allowed values are datetime attributes from

--- a/pycaret/classification/functional.py
+++ b/pycaret/classification/functional.py
@@ -7,10 +7,9 @@ from joblib.memory import Memory
 from pycaret.classification.oop import ClassificationExperiment
 from pycaret.internal.parallel.parallel_backend import ParallelBackend
 from pycaret.internal.utils import (
-    DATAFRAME_LIKE,
-    TARGET_LIKE,
     check_if_global_is_not_none,
 )
+from pycaret.utils.constants import SEQUENCE_LIKE, DATAFRAME_LIKE, TARGET_LIKE
 from pycaret.loggers.base_logger import BaseLogger
 
 _EXPERIMENT_CLASS = ClassificationExperiment
@@ -27,6 +26,7 @@ def setup(
     data: Optional[DATAFRAME_LIKE] = None,
     data_func: Optional[Callable[[], DATAFRAME_LIKE]] = None,
     target: TARGET_LIKE = -1,
+    index: Union[bool, int, str, SEQUENCE_LIKE] = False,
     train_size: float = 0.7,
     test_data: Optional[DATAFRAME_LIKE] = None,
     ordinal_features: Optional[Dict[str, list]] = None,
@@ -61,7 +61,7 @@ def setup(
     outliers_method: str = "iforest",
     outliers_threshold: float = 0.05,
     fix_imbalance: bool = False,
-    fix_imbalance_method: Optional[Any] = None,
+    fix_imbalance_method: Union[str, Any] = "SMOTE",
     transformation: bool = False,
     transformation_method: str = "yeo-johnson",
     normalize: bool = False,
@@ -134,6 +134,14 @@ def setup(
         multiclass.
 
 
+    index: bool, int, str or sequence, default=False
+        - If False: Reset to RangeIndex.
+        - If True: Use the current index.
+        - If int: Index of the column to use as index.
+        - If str: Name of the column to use as index.
+        - If sequence: Index column with shape=(n_samples,).
+
+
     train_size: float, default = 0.7
         Proportion of the dataset to be used for training and validation. Should be
         between 0.0 and 1.0.
@@ -141,8 +149,7 @@ def setup(
 
     test_data: dataframe-like or None, default = None
         If not None, test_data is used as a hold-out set and `train_size` parameter
-        is ignored. The columns of data and test_data must match. If it's a pandas
-        dataframe, the indices must match as well.
+        is ignored. The columns of data and test_data must match.
 
 
     ordinal_features: dict, default = None
@@ -349,10 +356,10 @@ def setup(
         Technique) is applied by default to create synthetic datapoints for minority class.
 
 
-    fix_imbalance_method: imblearn estimator, default = None
-        When ``fix_imbalance`` is True, `imblearn` compatible estimator with a
-        `fit_resample` method can be passed. If None, `imblearn.over_sampling.SMOTE`
-        is used.
+    fix_imbalance_method: str or imblearn estimator, default = "SMOTE"
+        Estimator with which to perform class balancing. Choose from the name
+        of an `imblearn` estimator, or a custom instance of such. Ignored when
+        `fix_imbalance=False`.
 
 
     transformation: bool, default = False
@@ -591,6 +598,7 @@ def setup(
         data=data,
         data_func=data_func,
         target=target,
+        index=index,
         train_size=train_size,
         test_data=test_data,
         ordinal_features=ordinal_features,

--- a/pycaret/classification/functional.py
+++ b/pycaret/classification/functional.py
@@ -6,11 +6,9 @@ from joblib.memory import Memory
 
 from pycaret.classification.oop import ClassificationExperiment
 from pycaret.internal.parallel.parallel_backend import ParallelBackend
-from pycaret.internal.utils import (
-    check_if_global_is_not_none,
-)
-from pycaret.utils.constants import SEQUENCE_LIKE, DATAFRAME_LIKE, TARGET_LIKE
+from pycaret.internal.utils import check_if_global_is_not_none
 from pycaret.loggers.base_logger import BaseLogger
+from pycaret.utils.constants import DATAFRAME_LIKE, SEQUENCE_LIKE, TARGET_LIKE
 
 _EXPERIMENT_CLASS = ClassificationExperiment
 _CURRENT_EXPERIMENT: Optional[ClassificationExperiment] = None

--- a/pycaret/classification/functional.py
+++ b/pycaret/classification/functional.py
@@ -132,12 +132,13 @@ def setup(
         multiclass.
 
 
-    index: bool, int, str or sequence, default=False
-        - If False: Reset to RangeIndex.
-        - If True: Use the current index.
-        - If int: Index of the column to use as index.
-        - If str: Name of the column to use as index.
-        - If sequence: Index column with shape=(n_samples,).
+    index: bool, int, str or sequence, default = False
+        Handle indices in the `data` dataframe.
+            - If False: Reset to RangeIndex.
+            - If True: Keep the provided index.
+            - If int: Position of the column to use as index.
+            - If str: Name of the column to use as index.
+            - If sequence: Array with shape=(n_samples,) to use as index.
 
 
     train_size: float, default = 0.7
@@ -199,7 +200,7 @@ def setup(
         when preprocess is set to False.
 
 
-    create_date_columns: list of str, default=["day", "month", "year"]
+    create_date_columns: list of str, default = ["day", "month", "year"]
         Columns to create from the date features. Note that created features
         with zero variance (e.g. the feature hour in a column that only contains
         dates) are ignored. Allowed values are datetime attributes from

--- a/pycaret/classification/oop.py
+++ b/pycaret/classification/oop.py
@@ -230,12 +230,13 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
             multiclass.
 
 
-        index: bool, int, str or sequence, default=False
-            - If False: Reset to RangeIndex.
-            - If True: Use the current index.
-            - If int: Index of the column to use as index.
-            - If str: Name of the column to use as index.
-            - If sequence: Index column with shape=(n_samples,).
+        index: bool, int, str or sequence, default = False
+            Handle indices in the `data` dataframe.
+                - If False: Reset to RangeIndex.
+                - If True: Keep the provided index.
+                - If int: Position of the column to use as index.
+                - If str: Name of the column to use as index.
+                - If sequence: Array with shape=(n_samples,) to use as index.
 
 
         train_size: float, default = 0.7
@@ -297,7 +298,7 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
             when preprocess is set to False.
 
 
-        create_date_columns: list of str, default=["day", "month", "year"]
+        create_date_columns: list of str, default = ["day", "month", "year"]
             Columns to create from the date features. Note that created features
             with zero variance (e.g. the feature hour in a column that only contains
             dates) are ignored. Allowed values are datetime attributes from

--- a/pycaret/classification/oop.py
+++ b/pycaret/classification/oop.py
@@ -34,11 +34,10 @@ from pycaret.internal.pycaret_experiment.supervised_experiment import (
 )
 from pycaret.internal.pycaret_experiment.utils import MLUsecase, highlight_setup
 from pycaret.internal.utils import (
-    DATAFRAME_LIKE,
-    TARGET_LIKE,
     get_classification_task,
     get_label_encoder,
 )
+from pycaret.utils.constants import SEQUENCE_LIKE, DATAFRAME_LIKE, TARGET_LIKE
 from pycaret.internal.validation import is_sklearn_cv_generator
 from pycaret.loggers.base_logger import BaseLogger
 
@@ -123,6 +122,7 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
         data: Optional[DATAFRAME_LIKE] = None,
         data_func: Optional[Callable[[], DATAFRAME_LIKE]] = None,
         target: TARGET_LIKE = -1,
+        index: Union[bool, int, str, SEQUENCE_LIKE] = False,
         train_size: float = 0.7,
         test_data: Optional[DATAFRAME_LIKE] = None,
         ordinal_features: Optional[Dict[str, list]] = None,
@@ -157,7 +157,7 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
         outliers_method: str = "iforest",
         outliers_threshold: float = 0.05,
         fix_imbalance: bool = False,
-        fix_imbalance_method: Optional[Any] = None,
+        fix_imbalance_method: Union[str, Any] = "SMOTE",
         transformation: bool = False,
         transformation_method: str = "yeo-johnson",
         normalize: bool = False,
@@ -233,6 +233,14 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
             multiclass.
 
 
+        index: bool, int, str or sequence, default=False
+            - If False: Reset to RangeIndex.
+            - If True: Use the current index.
+            - If int: Index of the column to use as index.
+            - If str: Name of the column to use as index.
+            - If sequence: Index column with shape=(n_samples,).
+
+
         train_size: float, default = 0.7
             Proportion of the dataset to be used for training and validation. Should be
             between 0.0 and 1.0.
@@ -240,8 +248,7 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
 
         test_data: dataframe-like or None, default = None
             If not None, test_data is used as a hold-out set and `train_size` parameter
-            is ignored. The columns of data and test_data must match. If it's a pandas
-            dataframe, the indices must match as well.
+            is ignored. The columns of data and test_data must match.
 
 
         ordinal_features: dict, default = None
@@ -448,10 +455,10 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
             Technique) is applied by default to create synthetic datapoints for minority class.
 
 
-        fix_imbalance_method: imblearn estimator, default = None
-            When ``fix_imbalance`` is True, `imblearn` compatible estimator with a
-            `fit_resample` method can be passed. If None, `imblearn.over_sampling.SMOTE`
-            is used.
+        fix_imbalance_method: str or imblearn estimator, default = "SMOTE"
+            Estimator with which to perform class balancing. Choose from the name
+            of an `imblearn` estimator, or a custom instance of such. Ignored when
+            `fix_imbalance=False`.
 
 
         transformation: bool, default = False
@@ -744,6 +751,7 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
 
         self.data = self._prepare_dataset(data, target)
         self.target_param = self.data.columns[-1]
+        self.index = index
 
         self._prepare_train_test(
             train_size=train_size,

--- a/pycaret/classification/oop.py
+++ b/pycaret/classification/oop.py
@@ -33,13 +33,10 @@ from pycaret.internal.pycaret_experiment.supervised_experiment import (
     _SupervisedExperiment,
 )
 from pycaret.internal.pycaret_experiment.utils import MLUsecase, highlight_setup
-from pycaret.internal.utils import (
-    get_classification_task,
-    get_label_encoder,
-)
-from pycaret.utils.constants import SEQUENCE_LIKE, DATAFRAME_LIKE, TARGET_LIKE
+from pycaret.internal.utils import get_classification_task, get_label_encoder
 from pycaret.internal.validation import is_sklearn_cv_generator
 from pycaret.loggers.base_logger import BaseLogger
+from pycaret.utils.constants import DATAFRAME_LIKE, SEQUENCE_LIKE, TARGET_LIKE
 
 LOGGER = get_logger()
 

--- a/pycaret/clustering/functional.py
+++ b/pycaret/clustering/functional.py
@@ -96,12 +96,13 @@ def setup(
         names.
 
 
-    index: bool, int, str or sequence, default=False
-        - If False: Reset to RangeIndex.
-        - If True: Use the current index.
-        - If int: Index of the column to use as index.
-        - If str: Name of the column to use as index.
-        - If sequence: Index column with shape=(n_samples,).
+    index: bool, int, str or sequence, default = False
+        Handle indices in the `data` dataframe.
+            - If False: Reset to RangeIndex.
+            - If True: Keep the provided index.
+            - If int: Position of the column to use as index.
+            - If str: Name of the column to use as index.
+            - If sequence: Array with shape=(n_samples,) to use as index.
 
 
     ordinal_features: dict, default = None
@@ -153,7 +154,7 @@ def setup(
         when preprocess is set to False.
 
 
-    create_date_columns: list of str, default=["day", "month", "year"]
+    create_date_columns: list of str, default = ["day", "month", "year"]
         Columns to create from the date features. Note that created features
         with zero variance (e.g. the feature hour in a column that only contains
         dates) are ignored. Allowed values are datetime attributes from

--- a/pycaret/clustering/functional.py
+++ b/pycaret/clustering/functional.py
@@ -5,7 +5,8 @@ import pandas as pd
 from joblib.memory import Memory
 
 from pycaret.clustering.oop import ClusteringExperiment
-from pycaret.internal.utils import DATAFRAME_LIKE, check_if_global_is_not_none
+from pycaret.internal.utils import check_if_global_is_not_none
+from pycaret.utils.constants import SEQUENCE_LIKE, DATAFRAME_LIKE
 from pycaret.loggers.base_logger import BaseLogger
 
 _EXPERIMENT_CLASS = ClusteringExperiment
@@ -20,6 +21,7 @@ _CURRENT_EXPERIMENT_DECORATOR_DICT = {
 
 def setup(
     data: DATAFRAME_LIKE,
+    index: Union[bool, int, str, SEQUENCE_LIKE] = False,
     ordinal_features: Optional[Dict[str, list]] = None,
     numeric_features: Optional[List[str]] = None,
     categorical_features: Optional[List[str]] = None,
@@ -92,6 +94,14 @@ def setup(
         number of samples and n_features is the number of features. If data
         is not a pandas dataframe, it's converted to one using default column
         names.
+
+
+    index: bool, int, str or sequence, default=False
+        - If False: Reset to RangeIndex.
+        - If True: Use the current index.
+        - If int: Index of the column to use as index.
+        - If str: Name of the column to use as index.
+        - If sequence: Index column with shape=(n_samples,).
 
 
     ordinal_features: dict, default = None
@@ -413,6 +423,7 @@ def setup(
     set_current_experiment(exp)
     return exp.setup(
         data=data,
+        index=index,
         ordinal_features=ordinal_features,
         numeric_features=numeric_features,
         categorical_features=categorical_features,

--- a/pycaret/clustering/functional.py
+++ b/pycaret/clustering/functional.py
@@ -6,8 +6,8 @@ from joblib.memory import Memory
 
 from pycaret.clustering.oop import ClusteringExperiment
 from pycaret.internal.utils import check_if_global_is_not_none
-from pycaret.utils.constants import SEQUENCE_LIKE, DATAFRAME_LIKE
 from pycaret.loggers.base_logger import BaseLogger
+from pycaret.utils.constants import DATAFRAME_LIKE, SEQUENCE_LIKE
 
 _EXPERIMENT_CLASS = ClusteringExperiment
 _CURRENT_EXPERIMENT: Optional[ClusteringExperiment] = None

--- a/pycaret/internal/preprocess/preprocessor.py
+++ b/pycaret/internal/preprocess/preprocessor.py
@@ -171,7 +171,7 @@ class Preprocessor:
 
         target = df.columns[-1]
 
-        if self.index is True:  # True gets caught by isinstance(int)
+        if getattr(self, "index", True) is True:  # True gets caught by isinstance(int)
             return df
         elif self.index is False:
             df = df.reset_index(drop=True)

--- a/pycaret/internal/preprocess/preprocessor.py
+++ b/pycaret/internal/preprocess/preprocessor.py
@@ -26,6 +26,18 @@ from sklearn.model_selection import (
     TimeSeriesSplit,
     train_test_split,
 )
+from pycaret.utils.constants import SEQUENCE
+from imblearn.combine import SMOTEENN, SMOTETomek
+from imblearn.over_sampling import (
+    ADASYN, SMOTE, SMOTEN, SMOTENC, SVMSMOTE, BorderlineSMOTE, KMeansSMOTE,
+    RandomOverSampler,
+)
+from imblearn.under_sampling import (
+    AllKNN, CondensedNearestNeighbour, EditedNearestNeighbours,
+    InstanceHardnessThreshold, NearMiss, NeighbourhoodCleaningRule,
+    OneSidedSelection, RandomUnderSampler, RepeatedEditedNearestNeighbours,
+    TomekLinks,
+)
 from sklearn.preprocessing import (
     KBinsDiscretizer,
     LabelEncoder,
@@ -142,6 +154,41 @@ class Preprocessor:
             X.merge(y.to_frame(), left_index=True, right_index=True)
         )
 
+    def _set_index(self, df):
+        """Assign an index to the dataframe."""
+        self.logger.info("Set up index.")
+
+        target = df.columns[-1]
+
+        if self.index is True:  # True gets caught by isinstance(int)
+            return df
+        elif self.index is False:
+            df = df.reset_index(drop=True)
+        elif isinstance(self.index, int):
+            if -df.shape[1] <= self.index <= df.shape[1]:
+                df = df.set_index(df.columns[self.index], drop=True)
+            else:
+                raise ValueError(
+                    f"Invalid value for the index parameter. Value {self.index} "
+                    f"is out of range for a dataset with {df.shape[1]} columns."
+                )
+        elif isinstance(self.index, str):
+            if self.index in df:
+                df = df.set_index(self.index, drop=True)
+            else:
+                raise ValueError(
+                    "Invalid value for the index parameter. "
+                    f"Column {self.index} not found in the dataset."
+                )
+
+        if df.index.name == target:
+            raise ValueError(
+                "Invalid value for the index parameter. The index column "
+                f"can not be the same as the target column, got {target}."
+            )
+
+        return df
+
     def _prepare_train_test(
         self,
         train_size,
@@ -153,6 +200,15 @@ class Preprocessor:
         self.logger.info("Set up train/test split.")
 
         if test_data is None:
+            if isinstance(self.index, SEQUENCE):
+                if len(self.index) != len(self.data):
+                    raise ValueError(
+                        "Invalid value for the index parameter. Length of "
+                        f"index ({len(self.index)}) doesn't match that of "
+                        f"the dataset ({len(self.data)})."
+                    )
+                self.data.index = self.index
+
             # self.data is already prepared here
             train, test = train_test_split(
                 self.data,
@@ -163,12 +219,23 @@ class Preprocessor:
                 random_state=self.seed,
                 shuffle=data_split_shuffle,
             )
-            self.data = pd.concat([train, test]).reset_index(drop=True)
+            self.data = self._set_index(pd.concat([train, test]))
             self.idx = [self.data.index[: len(train)], self.data.index[-len(test) :]]
 
         else:  # test_data is provided
             test_data = self._prepare_dataset(test_data, self.target_param)
-            self.data = pd.concat([self.data, test_data]).reset_index(drop=True)
+
+            if isinstance(self.index, SEQUENCE):
+                if len(self.index) != len(self.data) + len(test_data):
+                    raise ValueError(
+                        "Invalid value for the index parameter. Length of "
+                        f"index ({len(self.index)}) doesn't match that of "
+                        f"the data sets ({len(self.data) + len(test_data)})."
+                    )
+                self.data.index = self.index[:len(self.data)]
+                test_data.index = self.index[-len(test_data):]
+
+            self.data = self._set_index(pd.concat([self.data, test_data]))
             self.idx = [
                 self.data.index[: -len(test_data)],
                 self.data.index[-len(test_data) :],
@@ -716,10 +783,40 @@ class Preprocessor:
         """Balance the classes in the target column."""
         self.logger.info("Set up imbalanced handling.")
 
-        if fix_imbalance_method is None:
-            balance_estimator = FixImbalancer(SMOTE())
+        strategies = dict(
+            # clustercentroids=ClusterCentroids,  # Has no sample_indices_
+            condensednearestneighbour=CondensedNearestNeighbour,
+            editednearestneighborus=EditedNearestNeighbours,
+            repeatededitednearestneighbours=RepeatedEditedNearestNeighbours,
+            allknn=AllKNN,
+            instancehardnessthreshold=InstanceHardnessThreshold,
+            nearmiss=NearMiss,
+            neighbourhoodcleaningrule=NeighbourhoodCleaningRule,
+            onesidedselection=OneSidedSelection,
+            randomundersampler=RandomUnderSampler,
+            tomeklinks=TomekLinks,
+            randomoversampler=RandomOverSampler,
+            smote=SMOTE,
+            smotenc=SMOTENC,
+            smoten=SMOTEN,
+            adasyn=ADASYN,
+            borderlinesmote=BorderlineSMOTE,
+            kmeanssmote=KMeansSMOTE,
+            svmsmote=SVMSMOTE,
+            smoteenn=SMOTEENN,
+            smotetomek=SMOTETomek,
+        )
+
+        if isinstance(fix_imbalance_method, str):
+            fix_imbalance_method = fix_imbalance_method.lower()
+            if fix_imbalance_method not in strategies:
+                raise ValueError(
+                    "Invalid value for the strategy parameter, got "
+                    f"{fix_imbalance_method}. Choose from: {', '.join(strategies)}."
+                )
+            balance_estimator = FixImbalancer(strategies[fix_imbalance_method]())
         elif not hasattr(fix_imbalance_method, "fit_resample"):
-            raise ValueError(
+            raise TypeError(
                 "Invalid value for the fix_imbalance_method parameter. "
                 "The provided value must be a imblearn estimator, got "
                 f"{fix_imbalance_method.__class__.__name_}."
@@ -727,8 +824,7 @@ class Preprocessor:
         else:
             balance_estimator = FixImbalancer(fix_imbalance_method)
 
-        balance_estimator = TransformerWrapper(balance_estimator)
-        self.pipeline.steps.append(("balance", balance_estimator))
+        self.pipeline.steps.append(("balance", TransformerWrapper(balance_estimator)))
 
     def _transformation(self, transformation_method):
         """Power transform the data to be more Gaussian-like."""

--- a/pycaret/internal/preprocess/preprocessor.py
+++ b/pycaret/internal/preprocess/preprocessor.py
@@ -8,7 +8,29 @@ import pandas as pd
 from category_encoders.leave_one_out import LeaveOneOutEncoder
 from category_encoders.one_hot import OneHotEncoder
 from category_encoders.ordinal import OrdinalEncoder
-from imblearn.over_sampling import SMOTE
+from imblearn.combine import SMOTEENN, SMOTETomek
+from imblearn.over_sampling import (
+    ADASYN,
+    SMOTE,
+    SMOTEN,
+    SMOTENC,
+    SVMSMOTE,
+    BorderlineSMOTE,
+    KMeansSMOTE,
+    RandomOverSampler,
+)
+from imblearn.under_sampling import (
+    AllKNN,
+    CondensedNearestNeighbour,
+    EditedNearestNeighbours,
+    InstanceHardnessThreshold,
+    NearMiss,
+    NeighbourhoodCleaningRule,
+    OneSidedSelection,
+    RandomUnderSampler,
+    RepeatedEditedNearestNeighbours,
+    TomekLinks,
+)
 from sklearn.decomposition import PCA, IncrementalPCA, KernelPCA
 from sklearn.feature_selection import (
     SelectFromModel,
@@ -25,18 +47,6 @@ from sklearn.model_selection import (
     StratifiedKFold,
     TimeSeriesSplit,
     train_test_split,
-)
-from pycaret.utils.constants import SEQUENCE
-from imblearn.combine import SMOTEENN, SMOTETomek
-from imblearn.over_sampling import (
-    ADASYN, SMOTE, SMOTEN, SMOTENC, SVMSMOTE, BorderlineSMOTE, KMeansSMOTE,
-    RandomOverSampler,
-)
-from imblearn.under_sampling import (
-    AllKNN, CondensedNearestNeighbour, EditedNearestNeighbours,
-    InstanceHardnessThreshold, NearMiss, NeighbourhoodCleaningRule,
-    OneSidedSelection, RandomUnderSampler, RepeatedEditedNearestNeighbours,
-    TomekLinks,
 )
 from sklearn.preprocessing import (
     KBinsDiscretizer,
@@ -79,6 +89,7 @@ from pycaret.internal.utils import (
     to_df,
     to_series,
 )
+from pycaret.utils.constants import SEQUENCE
 
 
 class Preprocessor:
@@ -232,8 +243,8 @@ class Preprocessor:
                         f"index ({len(self.index)}) doesn't match that of "
                         f"the data sets ({len(self.data) + len(test_data)})."
                     )
-                self.data.index = self.index[:len(self.data)]
-                test_data.index = self.index[-len(test_data):]
+                self.data.index = self.index[: len(self.data)]
+                test_data.index = self.index[-len(test_data) :]
 
             self.data = self._set_index(pd.concat([self.data, test_data]))
             self.idx = [

--- a/pycaret/internal/preprocess/transformers.py
+++ b/pycaret/internal/preprocess/transformers.py
@@ -33,12 +33,12 @@ class TransformerWrapper(BaseEstimator, TransformerMixin):
         Transformer to wrap. Should implement a `fit` and/or `transform`
         method.
 
-    include: list or None
+    include: list or None, default=None
         Columns to apply on the transformer. If specified, only these
         columns are used and the rest ignored. If None, all columns
         are used.
 
-    exclude: list or None
+    exclude: list or None, default=None
         Columns to NOT apply on the transformer. If None, no columns
         are excluded.
 
@@ -486,6 +486,11 @@ class RemoveOutliers(BaseEstimator, TransformerMixin):
 class FixImbalancer(BaseEstimator, TransformerMixin):
     """Wrapper for a balancer with a fit_resample method.
 
+    When oversampling, the newly created samples have an increasing
+    integer index for numerical indices, and an index of the form
+    [estimator]_N for non-numerical indices, where N stands for the
+    N-th sample in the data set.
+
     Balancing classes should only be used on the training set,
     therefore this estimator is skipped by the pipeline when
     making new predictions (only used to fit).
@@ -500,7 +505,63 @@ class FixImbalancer(BaseEstimator, TransformerMixin):
         return self
 
     def transform(self, X, y):
-        return self.estimator.fit_resample(X, y)
+        if "over_sampling" in self.estimator.__module__:
+            index = X.index  # Save indices for later reassignment
+            X, y = self.estimator.fit_resample(X, y)
+
+            # Create indices for the new samples
+            if index.dtype.kind in "ifu":
+                new_index = range(max(index) + 1, max(index) + len(X) - len(index) + 1)
+            else:
+                new_index = [
+                    f"{self.estimator.__class__.__name__.lower()}_{i}"
+                    for i in range(1, len(X) - len(index) + 1)
+                ]
+
+            # Assign the old + new indices
+            X.index = list(index) + list(new_index)
+            y.index = list(index) + list(new_index)
+
+        elif "under_sampling" in self.estimator.__module__:
+            self.estimator.fit_resample(X, y)
+
+            # Select chosen rows (imblearn doesn't return them in order)
+            samples = sorted(self.estimator.sample_indices_)
+            X, y = X.iloc[samples, :], y.iloc[samples]
+
+        elif "combine" in self.estimator.__module__:
+            index = X.index
+            X_new, y_new = self.estimator.fit_resample(X, y)
+
+            # Select rows that were kept by the undersampler
+            if self.estimator.__class__.__name__ == "SMOTEENN":
+                samples = sorted(self.estimator.enn_.sample_indices_)
+            elif self.estimator.__class__.__name__ == "SMOTETomek":
+                samples = sorted(self.estimator.tomek_.sample_indices_)
+
+            # Select the remaining samples from the old dataframe
+            old_samples = [s for s in samples if s < len(X)]
+            X, y = X.iloc[old_samples, :], y.iloc[old_samples]
+
+            # Create indices for the new samples
+            if index.dtype.kind in "ifu":
+                new_index = range(max(index) + 1, max(index) + len(X_new) - len(X) + 1)
+            else:
+                new_index = [
+                    f"{self.estimator.__class__.__name__.lower()}_{i}"
+                    for i in range(1, len(X_new) - len(X) + 1)
+                ]
+
+            # Select the new samples and assign the new indices
+            X_new = X_new.iloc[-len(X_new) + len(old_samples):, :]
+            X_new.index = new_index
+            y_new = y_new.iloc[-len(y_new) + len(old_samples):]
+            y_new.index = new_index
+
+            # Add the new samples to the old dataframe
+            X, y = X.append(X_new), y.append(y_new)
+
+        return X, y
 
 
 class TargetTransformer(BaseEstimator):

--- a/pycaret/internal/preprocess/transformers.py
+++ b/pycaret/internal/preprocess/transformers.py
@@ -553,9 +553,9 @@ class FixImbalancer(BaseEstimator, TransformerMixin):
                 ]
 
             # Select the new samples and assign the new indices
-            X_new = X_new.iloc[-len(X_new) + len(old_samples):, :]
+            X_new = X_new.iloc[-len(X_new) + len(old_samples) :, :]
             X_new.index = new_index
-            y_new = y_new.iloc[-len(y_new) + len(old_samples):]
+            y_new = y_new.iloc[-len(y_new) + len(old_samples) :]
             y_new.index = new_index
 
             # Add the new samples to the old dataframe

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -1404,9 +1404,6 @@ class _SupervisedExperiment(_TabularExperiment):
         if self._ml_usecase != MLUsecase.TIME_SERIES:
             data_X = self.X_train if X_train_data is None else X_train_data.copy()
             data_y = self.y_train if y_train_data is None else y_train_data.copy()
-
-            data_X.reset_index(drop=True, inplace=True)
-            data_y.reset_index(drop=True, inplace=True)
         else:
             if X_train_data is not None:
                 data_X = X_train_data.copy()
@@ -2226,10 +2223,6 @@ class _SupervisedExperiment(_TabularExperiment):
         # Storing X_train and y_train in data_X and data_y parameter
         data_X = self.X_train
         data_y = self.y_train
-
-        # reset index
-        data_X.reset_index(drop=True, inplace=True)
-        data_y.reset_index(drop=True, inplace=True)
 
         display.move_progress()
 
@@ -4938,11 +4931,11 @@ class _SupervisedExperiment(_TabularExperiment):
             X_test_, y_test_ = self.X_test_transformed, self.y_test_transformed
         else:
             if y_name in data.columns:
-                data = self._prepare_dataset(data, y_name)
+                data = self._set_index(self._prepare_dataset(data, y_name))
                 target = data[y_name]
                 data = data.drop(y_name, axis=1)
             else:
-                data = self._prepare_dataset(data)
+                data = self._set_index(self._prepare_dataset(data))
                 target = None
             data = data[X_columns]  # Ignore all columns but the originals
             if preprocess:

--- a/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
@@ -25,9 +25,9 @@ from pycaret.internal.preprocess.preprocessor import Preprocessor
 from pycaret.internal.pycaret_experiment.tabular_experiment import _TabularExperiment
 from pycaret.internal.pycaret_experiment.utils import MLUsecase, highlight_setup
 from pycaret.internal.utils import infer_ml_usecase, to_df
-from pycaret.utils.constants import SEQUENCE_LIKE, DATAFRAME_LIKE
 from pycaret.internal.validation import is_sklearn_pipeline
 from pycaret.loggers.base_logger import BaseLogger
+from pycaret.utils.constants import DATAFRAME_LIKE, SEQUENCE_LIKE
 
 LOGGER = get_logger()
 

--- a/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
@@ -165,12 +165,13 @@ class _UnsupervisedExperiment(_TabularExperiment, Preprocessor):
             names.
 
 
-        index: bool, int, str or sequence, default=False
-            - If False: Reset to RangeIndex.
-            - If True: Use the current index.
-            - If int: Index of the column to use as index.
-            - If str: Name of the column to use as index.
-            - If sequence: Index column with shape=(n_samples,).
+        index: bool, int, str or sequence, default = False
+            Handle indices in the `data` dataframe.
+                - If False: Reset to RangeIndex.
+                - If True: Keep the provided index.
+                - If int: Position of the column to use as index.
+                - If str: Name of the column to use as index.
+                - If sequence: Array with shape=(n_samples,) to use as index.
 
 
         ordinal_features: dict, default = None
@@ -222,7 +223,7 @@ class _UnsupervisedExperiment(_TabularExperiment, Preprocessor):
             when preprocess is set to False.
 
 
-        create_date_columns: list of str, default=["day", "month", "year"]
+        create_date_columns: list of str, default = ["day", "month", "year"]
             Columns to create from the date features. Note that created features
             with zero variance (e.g. the feature hour in a column that only contains
             dates) are ignored. Allowed values are datetime attributes from

--- a/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
@@ -24,7 +24,8 @@ from pycaret.internal.pipeline import estimator_pipeline, get_pipeline_fit_kwarg
 from pycaret.internal.preprocess.preprocessor import Preprocessor
 from pycaret.internal.pycaret_experiment.tabular_experiment import _TabularExperiment
 from pycaret.internal.pycaret_experiment.utils import MLUsecase, highlight_setup
-from pycaret.internal.utils import DATAFRAME_LIKE, infer_ml_usecase, to_df
+from pycaret.internal.utils import infer_ml_usecase, to_df
+from pycaret.utils.constants import SEQUENCE_LIKE, DATAFRAME_LIKE
 from pycaret.internal.validation import is_sklearn_pipeline
 from pycaret.loggers.base_logger import BaseLogger
 
@@ -86,6 +87,7 @@ class _UnsupervisedExperiment(_TabularExperiment, Preprocessor):
     def setup(
         self,
         data: DATAFRAME_LIKE,
+        index: Union[bool, int, str, SEQUENCE_LIKE] = False,
         ordinal_features: Optional[Dict[str, list]] = None,
         numeric_features: Optional[List[str]] = None,
         categorical_features: Optional[List[str]] = None,
@@ -161,6 +163,14 @@ class _UnsupervisedExperiment(_TabularExperiment, Preprocessor):
             number of samples and n_features is the number of features. If data
             is not a pandas dataframe, it's converted to one using default column
             names.
+
+
+        index: bool, int, str or sequence, default=False
+            - If False: Reset to RangeIndex.
+            - If True: Use the current index.
+            - If int: Index of the column to use as index.
+            - If str: Name of the column to use as index.
+            - If sequence: Index column with shape=(n_samples,).
 
 
         ordinal_features: dict, default = None
@@ -524,7 +534,8 @@ class _UnsupervisedExperiment(_TabularExperiment, Preprocessor):
 
         # Set up data ============================================== >>
 
-        self.data = self._prepare_dataset(data)
+        self.index = index
+        self.data = self._set_index(self._prepare_dataset(data))
 
         # Train and Test indices
         self.idx = [self.data.index, None]

--- a/pycaret/internal/utils.py
+++ b/pycaret/internal/utils.py
@@ -18,9 +18,6 @@ from pycaret.internal.validation import (
 )
 from pycaret.utils._dependencies import _check_soft_dependencies
 
-DATAFRAME_LIKE = Union[dict, list, tuple, np.ndarray, sparse.spmatrix, pd.DataFrame]
-TARGET_LIKE = Union[int, str, list, tuple, np.ndarray, pd.Series]
-
 
 def get_classification_task(y):
     """Return if the target column is binary or multiclass."""

--- a/pycaret/regression/functional.py
+++ b/pycaret/regression/functional.py
@@ -7,10 +7,9 @@ from joblib.memory import Memory
 
 from pycaret.internal.parallel.parallel_backend import ParallelBackend
 from pycaret.internal.utils import (
-    DATAFRAME_LIKE,
-    TARGET_LIKE,
     check_if_global_is_not_none,
 )
+from pycaret.utils.constants import SEQUENCE_LIKE, DATAFRAME_LIKE, TARGET_LIKE
 from pycaret.loggers.base_logger import BaseLogger
 from pycaret.regression.oop import RegressionExperiment
 
@@ -28,6 +27,7 @@ def setup(
     data: Optional[DATAFRAME_LIKE] = None,
     data_func: Optional[Callable[[], DATAFRAME_LIKE]] = None,
     target: TARGET_LIKE = -1,
+    index: Union[bool, int, str, SEQUENCE_LIKE] = False,
     train_size: float = 0.7,
     test_data: Optional[DATAFRAME_LIKE] = None,
     ordinal_features: Optional[Dict[str, list]] = None,
@@ -134,6 +134,14 @@ def setup(
         multiclass.
 
 
+    index: bool, int, str or sequence, default=False
+        - If False: Reset to RangeIndex.
+        - If True: Use the current index.
+        - If int: Index of the column to use as index.
+        - If str: Name of the column to use as index.
+        - If sequence: Index column with shape=(n_samples,).
+
+
     train_size: float, default = 0.7
         Proportion of the dataset to be used for training and validation. Should be
         between 0.0 and 1.0.
@@ -141,8 +149,7 @@ def setup(
 
     test_data: dataframe-like or None, default = None
         If not None, test_data is used as a hold-out set and `train_size` parameter
-        is ignored. The columns of data and test_data must match. If it's a pandas
-        dataframe, the indices must match as well.
+        is ignored. The columns of data and test_data must match.
 
 
     ordinal_features: dict, default = None
@@ -589,6 +596,7 @@ def setup(
         data=data,
         data_func=data_func,
         target=target,
+        index=index,
         train_size=train_size,
         test_data=test_data,
         ordinal_features=ordinal_features,

--- a/pycaret/regression/functional.py
+++ b/pycaret/regression/functional.py
@@ -6,12 +6,10 @@ import pandas as pd
 from joblib.memory import Memory
 
 from pycaret.internal.parallel.parallel_backend import ParallelBackend
-from pycaret.internal.utils import (
-    check_if_global_is_not_none,
-)
-from pycaret.utils.constants import SEQUENCE_LIKE, DATAFRAME_LIKE, TARGET_LIKE
+from pycaret.internal.utils import check_if_global_is_not_none
 from pycaret.loggers.base_logger import BaseLogger
 from pycaret.regression.oop import RegressionExperiment
+from pycaret.utils.constants import DATAFRAME_LIKE, SEQUENCE_LIKE, TARGET_LIKE
 
 _EXPERIMENT_CLASS = RegressionExperiment
 _CURRENT_EXPERIMENT: Optional[RegressionExperiment] = None

--- a/pycaret/regression/functional.py
+++ b/pycaret/regression/functional.py
@@ -132,12 +132,13 @@ def setup(
         multiclass.
 
 
-    index: bool, int, str or sequence, default=False
-        - If False: Reset to RangeIndex.
-        - If True: Use the current index.
-        - If int: Index of the column to use as index.
-        - If str: Name of the column to use as index.
-        - If sequence: Index column with shape=(n_samples,).
+    index: bool, int, str or sequence, default = False
+        Handle indices in the `data` dataframe.
+            - If False: Reset to RangeIndex.
+            - If True: Keep the provided index.
+            - If int: Position of the column to use as index.
+            - If str: Name of the column to use as index.
+            - If sequence: Array with shape=(n_samples,) to use as index.
 
 
     train_size: float, default = 0.7
@@ -199,7 +200,7 @@ def setup(
         when preprocess is set to False.
 
 
-    create_date_columns: list of str, default=["day", "month", "year"]
+    create_date_columns: list of str, default = ["day", "month", "year"]
         Columns to create from the date features. Note that created features
         with zero variance (e.g. the feature hour in a column that only contains
         dates) are ignored. Allowed values are datetime attributes from

--- a/pycaret/regression/oop.py
+++ b/pycaret/regression/oop.py
@@ -27,8 +27,8 @@ from pycaret.internal.pycaret_experiment.supervised_experiment import (
     _SupervisedExperiment,
 )
 from pycaret.internal.pycaret_experiment.utils import MLUsecase, highlight_setup
-from pycaret.utils.constants import SEQUENCE_LIKE, DATAFRAME_LIKE, TARGET_LIKE
 from pycaret.loggers.base_logger import BaseLogger
+from pycaret.utils.constants import DATAFRAME_LIKE, SEQUENCE_LIKE, TARGET_LIKE
 
 LOGGER = get_logger()
 

--- a/pycaret/regression/oop.py
+++ b/pycaret/regression/oop.py
@@ -199,12 +199,13 @@ class RegressionExperiment(_SupervisedExperiment, Preprocessor):
             multiclass.
 
 
-        index: bool, int, str or sequence, default=False
-            - If False: Reset to RangeIndex.
-            - If True: Use the current index.
-            - If int: Index of the column to use as index.
-            - If str: Name of the column to use as index.
-            - If sequence: Index column with shape=(n_samples,).
+        index: bool, int, str or sequence, default = False
+            Handle indices in the `data` dataframe.
+                - If False: Reset to RangeIndex.
+                - If True: Keep the provided index.
+                - If int: Position of the column to use as index.
+                - If str: Name of the column to use as index.
+                - If sequence: Array with shape=(n_samples,) to use as index.
 
 
         train_size: float, default = 0.7
@@ -266,7 +267,7 @@ class RegressionExperiment(_SupervisedExperiment, Preprocessor):
             when preprocess is set to False.
 
 
-        create_date_columns: list of str, default=["day", "month", "year"]
+        create_date_columns: list of str, default = ["day", "month", "year"]
             Columns to create from the date features. Note that created features
             with zero variance (e.g. the feature hour in a column that only contains
             dates) are ignored. Allowed values are datetime attributes from

--- a/pycaret/regression/oop.py
+++ b/pycaret/regression/oop.py
@@ -27,7 +27,7 @@ from pycaret.internal.pycaret_experiment.supervised_experiment import (
     _SupervisedExperiment,
 )
 from pycaret.internal.pycaret_experiment.utils import MLUsecase, highlight_setup
-from pycaret.internal.utils import DATAFRAME_LIKE, TARGET_LIKE
+from pycaret.utils.constants import SEQUENCE_LIKE, DATAFRAME_LIKE, TARGET_LIKE
 from pycaret.loggers.base_logger import BaseLogger
 
 LOGGER = get_logger()
@@ -88,6 +88,7 @@ class RegressionExperiment(_SupervisedExperiment, Preprocessor):
         data: Optional[DATAFRAME_LIKE] = None,
         data_func: Optional[Callable[[], DATAFRAME_LIKE]] = None,
         target: TARGET_LIKE = -1,
+        index: Union[bool, int, str, SEQUENCE_LIKE] = False,
         train_size: float = 0.7,
         test_data: Optional[DATAFRAME_LIKE] = None,
         ordinal_features: Optional[Dict[str, list]] = None,
@@ -198,6 +199,14 @@ class RegressionExperiment(_SupervisedExperiment, Preprocessor):
             multiclass.
 
 
+        index: bool, int, str or sequence, default=False
+            - If False: Reset to RangeIndex.
+            - If True: Use the current index.
+            - If int: Index of the column to use as index.
+            - If str: Name of the column to use as index.
+            - If sequence: Index column with shape=(n_samples,).
+
+
         train_size: float, default = 0.7
             Proportion of the dataset to be used for training and validation. Should be
             between 0.0 and 1.0.
@@ -205,8 +214,7 @@ class RegressionExperiment(_SupervisedExperiment, Preprocessor):
 
         test_data: dataframe-like or None, default = None
             If not None, test_data is used as a hold-out set and `train_size` parameter
-            is ignored. The columns of data and test_data must match. If it's a pandas
-            dataframe, the indices must match as well.
+            is ignored. The columns of data and test_data must match.
 
 
         ordinal_features: dict, default = None
@@ -713,6 +721,7 @@ class RegressionExperiment(_SupervisedExperiment, Preprocessor):
 
         self.data = self._prepare_dataset(data, target)
         self.target_param = self.data.columns[-1]
+        self.index = index
 
         self._prepare_train_test(
             train_size=train_size,

--- a/pycaret/utils/constants.py
+++ b/pycaret/utils/constants.py
@@ -13,7 +13,6 @@ import numpy as np
 import pandas as pd
 from scipy import sparse
 
-
 # Group of variable types for isinstance
 SEQUENCE = (list, tuple, np.ndarray, pd.Series)
 

--- a/pycaret/utils/constants.py
+++ b/pycaret/utils/constants.py
@@ -7,6 +7,20 @@ Description: Module containing all constants of pycaret.
 
 """
 
+from typing import Union
+
+import numpy as np
+import pandas as pd
+from scipy import sparse
+
+
+# Group of variable types for isinstance
+SEQUENCE = (list, tuple, np.ndarray, pd.Series)
+
+# Variable types for type hinting
+SEQUENCE_LIKE = Union[SEQUENCE]
+DATAFRAME_LIKE = Union[dict, list, tuple, np.ndarray, sparse.spmatrix, pd.DataFrame]
+TARGET_LIKE = Union[int, str, list, tuple, np.ndarray, pd.Series]
 
 # Column name that contains the predicted label in predict_model's output
 LABEL_COLUMN = "prediction_label"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 ipython>=5.5.0
 ipywidgets>=7.6.5  # required by pycaret.internal.display
 tqdm>=4.62.0  # required by pycaret.internal.display
-numpy~=1.21  # Can't >=1.22 because of sktime/numba
+numpy~=1.22  # Can't >=1.23 because of sktime/numba
 pandas>=1.3.0, <1.5.0  # Can't >=1.5 because of sktime
 jinja2>=1.2  # Required by pycaret.internal.utils --> pandas.io.formats.style
 scipy<1.9.0  # Can't >=1.9.0 due to sktime

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 ipython>=5.5.0
 ipywidgets>=7.6.5  # required by pycaret.internal.display
 tqdm>=4.62.0  # required by pycaret.internal.display
-numpy~=1.22  # Can't >=1.23 because of sktime/numba
+numpy>=1.21, <1.23  # Can't >=1.23 because of sktime/numba
 pandas>=1.3.0, <1.5.0  # Can't >=1.5 because of sktime
 jinja2>=1.2  # Required by pycaret.internal.utils --> pandas.io.formats.style
 scipy<1.9.0  # Can't >=1.9.0 due to sktime


### PR DESCRIPTION
## Related Issue or bug

Closes #2815

#### Describe the changes you've made

Support custom indices for the dataset. The user can now specify the `index` parameter in `setup` to specify the indices for his dataset. If specified, the indices are not reset.

Additionally, the `fix_imbalance_method` parameter now also accepts any of the imblearn estimators as string.

## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update