### PR TITLE
fix error catb

### DIFF
--- a/pycaret/internal/persistence.py
+++ b/pycaret/internal/persistence.py
@@ -317,7 +317,7 @@ def save_model(
             )
         else:
             model_ = deepcopy(prep_pipe_)
-            model_.steps.append(["trained_model", model])
+            model_.steps.append(("trained_model", model))
 
     import joblib
 

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -4911,10 +4911,7 @@ class _SupervisedExperiment(_TabularExperiment):
                 raise ValueError(
                     "If estimator is a Pipeline, it must implement `feature_names_in_`."
                 )
-            # Using deepcopy fails for catboost. Using shallow copy is
-            # fine since underlying estimators are only used for transform
             pipeline = copy(estimator)
-
             # Temporarily remove final estimator so it's not used for transform
             final_step = pipeline.steps[-1]
             estimator = final_step[-1]

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -4911,7 +4911,11 @@ class _SupervisedExperiment(_TabularExperiment):
                 raise ValueError(
                     "If estimator is a Pipeline, it must implement `feature_names_in_`."
                 )
+            # We use copy instead of deepcopy because of https://github.com/pycaret/pycaret/issues/2769
+            # Catboost behaves strange when deep copied. Using copy is fine
+            # since the underlying estimators are only used for transform
             pipeline = copy(estimator)
+
             # Temporarily remove final estimator so it's not used for transform
             final_step = pipeline.steps[-1]
             estimator = final_step[-1]

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -5,7 +5,7 @@ import time
 import traceback
 import warnings
 from collections import Iterable
-from copy import deepcopy
+from copy import copy
 from functools import partial
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 from unittest.mock import patch
@@ -4911,7 +4911,10 @@ class _SupervisedExperiment(_TabularExperiment):
                 raise ValueError(
                     "If estimator is a Pipeline, it must implement `feature_names_in_`."
                 )
-            pipeline = deepcopy(estimator)
+            # Using deepcopy fails for catboost. Using shallow copy is
+            # fine since underlying estimators are only used for transform
+            pipeline = copy(estimator)
+
             # Temporarily remove final estimator so it's not used for transform
             final_step = pipeline.steps[-1]
             estimator = final_step[-1]


### PR DESCRIPTION
## Related Issue or bug

Closes #2769

#### Describe the changes you've made

Running `deepcopy(pipeline)` on a pipleine containing a catboost model returns the catboost estimator instead of the pipeline self. Very weird. I changed deepcopy for copy, which is fine since the underlying estimators are only used for transform

## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update