### PR TITLE
Time Series test fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ plotly-resampler>=0.7.2.2
 
 # Time-series
 statsmodels>=0.12.1
-sktime~=0.13.2
+sktime==0.13.2  # https://github.com/sktime/sktime/issues/3547
 tbats>=1.1.0
 pmdarima>=1.8.0,!=1.8.1,<2.0.0 # Matches sktime


### PR DESCRIPTION
# Related Issue or bug

Info about Issue or bug

A forecasting pipeline that contains an imputer and a forecaster that does not accept missing values fails to work in the latest release of sktime (0.13.4). This used to work fine in 0.13.2 release.

# Describe the changes you've made

Pinned sktime to 0.13.2 until bug with 0.13.4 is fixed. See: https://github.com/sktime/sktime/issues/3547

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests to pass on GitHub

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
