### PR TITLE
cat imputation default to mode

### DIFF
--- a/pycaret/anomaly/functional.py
+++ b/pycaret/anomaly/functional.py
@@ -33,7 +33,7 @@ def setup(
     create_date_columns: List[str] = ["day", "month", "year"],
     imputation_type: Optional[str] = "simple",
     numeric_imputation: str = "mean",
-    categorical_imputation: str = "constant",
+    categorical_imputation: str = "mode",
     text_features_method: str = "tf-idf",
     max_encoding_ohe: int = -1,
     encoding_method: Optional[Any] = None,

--- a/pycaret/classification/functional.py
+++ b/pycaret/classification/functional.py
@@ -38,7 +38,7 @@ def setup(
     create_date_columns: List[str] = ["day", "month", "year"],
     imputation_type: Optional[str] = "simple",
     numeric_imputation: Union[int, float, str] = "mean",
-    categorical_imputation: str = "constant",
+    categorical_imputation: str = "mode",
     iterative_imputation_iters: int = 5,
     numeric_iterative_imputer: Union[str, Any] = "lightgbm",
     categorical_iterative_imputer: Union[str, Any] = "lightgbm",

--- a/pycaret/classification/oop.py
+++ b/pycaret/classification/oop.py
@@ -131,7 +131,7 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
         create_date_columns: List[str] = ["day", "month", "year"],
         imputation_type: Optional[str] = "simple",
         numeric_imputation: str = "mean",
-        categorical_imputation: str = "constant",
+        categorical_imputation: str = "mode",
         iterative_imputation_iters: int = 5,
         numeric_iterative_imputer: Union[str, Any] = "lightgbm",
         categorical_iterative_imputer: Union[str, Any] = "lightgbm",

--- a/pycaret/clustering/functional.py
+++ b/pycaret/clustering/functional.py
@@ -33,7 +33,7 @@ def setup(
     create_date_columns: List[str] = ["day", "month", "year"],
     imputation_type: Optional[str] = "simple",
     numeric_imputation: str = "mean",
-    categorical_imputation: str = "constant",
+    categorical_imputation: str = "mode",
     text_features_method: str = "tf-idf",
     max_encoding_ohe: int = -1,
     encoding_method: Optional[Any] = None,

--- a/pycaret/internal/preprocess/preprocessor.py
+++ b/pycaret/internal/preprocess/preprocessor.py
@@ -403,7 +403,6 @@ class Preprocessor:
     def _date_feature_engineering(self, create_date_columns):
         """Convert date features to numerical values."""
         self.logger.info("Set up date feature engineering.")
-        # TODO: Could be improved allowing the user to choose which features to add
         date_estimator = TransformerWrapper(
             transformer=ExtractDateTimeFeatures(create_date_columns),
             include=self._fxs["Date"],

--- a/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
@@ -99,7 +99,7 @@ class _UnsupervisedExperiment(_TabularExperiment, Preprocessor):
         create_date_columns: List[str] = ["day", "month", "year"],
         imputation_type: Optional[str] = "simple",
         numeric_imputation: str = "mean",
-        categorical_imputation: str = "constant",
+        categorical_imputation: str = "mode",
         text_features_method: str = "tf-idf",
         max_encoding_ohe: int = -1,
         encoding_method: Optional[Any] = None,

--- a/pycaret/regression/functional.py
+++ b/pycaret/regression/functional.py
@@ -38,7 +38,7 @@ def setup(
     create_date_columns: List[str] = ["day", "month", "year"],
     imputation_type: Optional[str] = "simple",
     numeric_imputation: Union[int, float, str] = "mean",
-    categorical_imputation: str = "constant",
+    categorical_imputation: str = "mode",
     iterative_imputation_iters: int = 5,
     numeric_iterative_imputer: Union[str, Any] = "lightgbm",
     categorical_iterative_imputer: Union[str, Any] = "lightgbm",

--- a/pycaret/regression/oop.py
+++ b/pycaret/regression/oop.py
@@ -94,7 +94,7 @@ class RegressionExperiment(_SupervisedExperiment, Preprocessor):
         create_date_columns: List[str] = ["day", "month", "year"],
         imputation_type: Optional[str] = "simple",
         numeric_imputation: str = "mean",
-        categorical_imputation: str = "constant",
+        categorical_imputation: str = "mode",
         iterative_imputation_iters: int = 5,
         numeric_iterative_imputer: Union[str, Any] = "lightgbm",
         categorical_iterative_imputer: Union[str, Any] = "lightgbm",


### PR DESCRIPTION
# Related Issue or bug

Closes #3033

# Describe the changes you've made

When someone specifies a non-numerical feature as categorical `setup` fails. Changing the default value for categorical imputation to `mode` (`most_frequent`) solves this issue and makes more sense.

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
