### PR TITLE
fix import and train test split bugs

### DIFF
--- a/pycaret/anomaly/functional.py
+++ b/pycaret/anomaly/functional.py
@@ -41,7 +41,7 @@ def setup(
     rare_value: str = "rare",
     polynomial_features: bool = False,
     polynomial_degree: int = 2,
-    low_variance_threshold: Optional[float] = 0,
+    low_variance_threshold: Optional[float] = None,
     group_features: Optional[list] = None,
     group_names: Optional[Union[str, list]] = None,
     remove_multicollinearity: bool = False,

--- a/pycaret/classification/functional.py
+++ b/pycaret/classification/functional.py
@@ -49,7 +49,7 @@ def setup(
     rare_value: str = "rare",
     polynomial_features: bool = False,
     polynomial_degree: int = 2,
-    low_variance_threshold: Optional[float] = 0,
+    low_variance_threshold: Optional[float] = None,
     group_features: Optional[list] = None,
     group_names: Optional[Union[str, list]] = None,
     remove_multicollinearity: bool = False,

--- a/pycaret/classification/oop.py
+++ b/pycaret/classification/oop.py
@@ -142,7 +142,7 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
         rare_value: str = "rare",
         polynomial_features: bool = False,
         polynomial_degree: int = 2,
-        low_variance_threshold: Optional[float] = 0,
+        low_variance_threshold: Optional[float] = None,
         group_features: Optional[list] = None,
         group_names: Optional[Union[str, list]] = None,
         remove_multicollinearity: bool = False,

--- a/pycaret/clustering/functional.py
+++ b/pycaret/clustering/functional.py
@@ -41,7 +41,7 @@ def setup(
     rare_value: str = "rare",
     polynomial_features: bool = False,
     polynomial_degree: int = 2,
-    low_variance_threshold: Optional[float] = 0,
+    low_variance_threshold: Optional[float] = None,
     remove_multicollinearity: bool = False,
     multicollinearity_threshold: float = 0.9,
     bin_numeric_features: Optional[List[str]] = None,

--- a/pycaret/internal/preprocess/preprocessor.py
+++ b/pycaret/internal/preprocess/preprocessor.py
@@ -221,7 +221,7 @@ class Preprocessor:
             # self.data is already prepared here
             train, test = train_test_split(
                 self.data,
-                test_size=1 - train_size,
+                train_size=train_size,
                 stratify=get_columns_to_stratify_by(
                     self.X, self.y, data_split_stratify
                 ),

--- a/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
@@ -107,7 +107,7 @@ class _UnsupervisedExperiment(_TabularExperiment, Preprocessor):
         rare_value: str = "rare",
         polynomial_features: bool = False,
         polynomial_degree: int = 2,
-        low_variance_threshold: Optional[float] = 0,
+        low_variance_threshold: Optional[float] = None,
         group_features: Optional[list] = None,
         group_names: Optional[Union[str, list]] = None,
         remove_multicollinearity: bool = False,

--- a/pycaret/nlp/__init__.py
+++ b/pycaret/nlp/__init__.py
@@ -1888,6 +1888,9 @@ def plot_model(
         )
     )
 
+    # ignore warnings
+    import warnings
+
     warnings.filterwarnings("ignore")
 
     # setting default of topic_num

--- a/pycaret/regression/functional.py
+++ b/pycaret/regression/functional.py
@@ -49,7 +49,7 @@ def setup(
     rare_value: str = "rare",
     polynomial_features: bool = False,
     polynomial_degree: int = 2,
-    low_variance_threshold: Optional[float] = 0,
+    low_variance_threshold: Optional[float] = None,
     group_features: Optional[list] = None,
     group_names: Optional[Union[str, list]] = None,
     remove_multicollinearity: bool = False,

--- a/pycaret/regression/oop.py
+++ b/pycaret/regression/oop.py
@@ -105,7 +105,7 @@ class RegressionExperiment(_SupervisedExperiment, Preprocessor):
         rare_value: str = "rare",
         polynomial_features: bool = False,
         polynomial_degree: int = 2,
-        low_variance_threshold: Optional[float] = 0,
+        low_variance_threshold: Optional[float] = None,
         group_features: Optional[list] = None,
         group_names: Optional[Union[str, list]] = None,
         remove_multicollinearity: bool = False,

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -241,7 +241,7 @@ def test_encoding_grouping_rare_categories():
     data = pycaret.datasets.get_data("juice")
     pc = pycaret.classification.setup(data, rare_to_value=0.5)
     X, _ = pc.pipeline.transform(pc.X, pc.y)
-    assert "rare" in pc.pipeline.steps[-2][1].transformer.mapping[0]["mapping"]
+    assert "rare" in pc.pipeline.steps[-1][1].transformer.mapping[0]["mapping"]
 
 
 def test_encoding_categorical_features():


### PR DESCRIPTION
# Related Issue or bug

Closes #3040
Closes #3048


# Describe the changes you've made

* Preprocessing doesn't default to apply low_variance_threshold. We should refrain from forcing preprocessing steps as default unless strictly necessary for the models to be able to run (such as imputation)
* Fixed a bug where train and test splits weren't of the correct size
* Fixed an import issue

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
