### PR TITLE
Custom feature engineering in time series

### DIFF
--- a/pycaret/containers/models/time_series.py
+++ b/pycaret/containers/models/time_series.py
@@ -1316,6 +1316,7 @@ class CdsDtContainer(TimeSeriesContainer):
     def __init__(self, experiment) -> None:
         self.logger = get_logger()
         self.seed = experiment.seed
+        self.fe_target = experiment.fe_target
         np.random.seed(self.seed)
 
         # Import the right regressor
@@ -1422,6 +1423,7 @@ class CdsDtContainer(TimeSeriesContainer):
             "regressor": self.regressor,
             "sp": self.sp,
             "window_length": self.sp,
+            "fe_target": self.fe_target,
         }
         return args
 
@@ -2568,7 +2570,7 @@ class BaseCdsDtForecaster(BaseForecaster):
         deseasonal_model: str = "additive",
         degree: int = 1,
         window_length: int = 10,
-        target_feature_transformer: Optional[list] = None,
+        fe_target: Optional[list] = None,
     ):
         """Base Class for time series using scikit models which includes
         Conditional Deseasonalizing and Detrending
@@ -2585,8 +2587,8 @@ class BaseCdsDtForecaster(BaseForecaster):
             degree of detrender, by default 1
         window_length : int, optional
             Window Length used for the Reduced Forecaster, by default 10.
-            If target_feature_transformer is provided, window_length is ignored.
-        target_feature_transformer : Optional[list], optional
+            If fe_target is provided, window_length is ignored.
+        fe_target : Optional[list], optional
             Custom transformations used to extract features from the target (useful
             for extracting lagged features), by default None which takes the lags
             based on a window_length parameter. If provided, window_length is ignored.
@@ -2597,7 +2599,7 @@ class BaseCdsDtForecaster(BaseForecaster):
         self.degree = degree
         self.window_length = window_length
 
-        if target_feature_transformer is None:
+        if fe_target is None:
             # All target lags as features.
             # NOTE: Previously, this forecaster class used the `window_length` argument
             # in make_reduction. Now we have moved to using the `transformers` argument.
@@ -2608,9 +2610,9 @@ class BaseCdsDtForecaster(BaseForecaster):
             kwargs = {
                 "lag_feature": {"lag": list(np.arange(self.window_length, 0, -1))}
             }
-            self.target_feature_transformer = [WindowSummarizer(**kwargs, n_jobs=1)]
+            self.fe_target = [WindowSummarizer(**kwargs, n_jobs=1)]
         else:
-            self.target_feature_transformer = target_feature_transformer
+            self.fe_target = fe_target
 
         super(BaseCdsDtForecaster, self).__init__()
 
@@ -2630,7 +2632,7 @@ class BaseCdsDtForecaster(BaseForecaster):
                     make_reduction(
                         estimator=self.regressor,
                         scitype="tabular-regressor",
-                        transformers=self.target_feature_transformer,
+                        transformers=self.fe_target,
                         window_length=None,
                         strategy="recursive",
                         pooling="global",

--- a/pycaret/internal/preprocess/time_series/forecasting/preprocessor.py
+++ b/pycaret/internal/preprocess/time_series/forecasting/preprocessor.py
@@ -255,8 +255,12 @@ class TSForecastingPreprocessor:
             only added if this is set to TSExogenousPresent.YES.
         """
         # Transform exogenous variables ----
-        # Only add exogenous pipeline steps if exogenous variables are present.
-        if exogenous_present == TSExogenousPresent.YES and fe_exogenous is not None:
+        # Only add exogenous pipeline steps if exogenous variables are present,
+        # but this is an exception. We may not have exogenous variables, but
+        # these could be created using fe_exogenous, so we do not explicitly check
+        # for the presence of exogenous variables to add this to the pipeline.
+        # if exogenous_present == TSExogenousPresent.YES and fe_exogenous is not None:
+        if fe_exogenous is not None:
             self._add_feat_eng_steps(
                 fe_exogenous=fe_exogenous,
                 target=False,

--- a/pycaret/internal/preprocess/time_series/forecasting/preprocessor.py
+++ b/pycaret/internal/preprocess/time_series/forecasting/preprocessor.py
@@ -23,7 +23,7 @@ class TSForecastingPreprocessor:
         self,
         numeric_imputation_target: Optional[Union[str, int, float]],
         numeric_imputation_exogenous: Optional[Union[str, int, float]],
-        exogenous_present: bool,
+        exogenous_present: TSExogenousPresent,
     ):
         # Impute target ----
         if numeric_imputation_target is not None:
@@ -105,7 +105,7 @@ class TSForecastingPreprocessor:
         self,
         transform_target: Optional[Union[str, int, float]],
         transform_exogenous: Optional[Union[str, int, float]],
-        exogenous_present: bool,
+        exogenous_present: TSExogenousPresent,
     ):
         # Impute target ----
         if transform_target is not None:
@@ -157,12 +157,12 @@ class TSForecastingPreprocessor:
 
             if transform not in transform_dict:
                 raise ValueError(
-                    f"{type_} transformaton method '{transform}' not allowed."
+                    f"{type_} transformation method '{transform}' not allowed."
                 )
 
         else:
             raise ValueError(
-                f"{type_} transformaton method '{type(transform)}' is not of allowed type."
+                f"{type_} transformation method '{type(transform)}' is not of allowed type."
             )
 
         if target:
@@ -176,7 +176,7 @@ class TSForecastingPreprocessor:
         self,
         scale_target: Optional[Union[str, int, float]],
         scale_exogenous: Optional[Union[str, int, float]],
-        exogenous_present: bool,
+        exogenous_present: TSExogenousPresent,
     ):
         # Scale target ----
         if scale_target:
@@ -227,13 +227,73 @@ class TSForecastingPreprocessor:
 
         else:
             raise ValueError(
-                f"{type_} transformaton method '{type(scale)}' is not of allowed type."
+                f"{type_} transformation method '{type(scale)}' is not of allowed type."
             )
 
         if target:
             self.transformer_steps_target.extend([("scaler", scaler)])
         else:
             self.transformer_steps_exogenous.extend([("scaler", scaler)])
+
+    def _feature_engineering(
+        self,
+        fe_exogenous: Optional[list],
+        exogenous_present: TSExogenousPresent,
+    ):
+        """Add feature engineering steps to the pipeline.
+        NOTE: Only Applied to Reduced regression models (see note in Setup).
+        But in these models, target feature engineering is done internal to the
+        model. Hence target feature engineering is not done here.
+
+        Parameters
+        ----------
+        fe_exogenous : Optional[list]
+            Feature Engineering Transformer to apply to exogenous variables.
+        exogenous_present : TSExogenousPresent
+            TSExogenousPresent.YES if exogenous variables are present in the data,
+            TSExogenousPresent.NO otherwise. Exogenous feature transformers are
+            only added if this is set to TSExogenousPresent.YES.
+        """
+        # Transform exogenous variables ----
+        # Only add exogenous pipeline steps if exogenous variables are present.
+        if exogenous_present == TSExogenousPresent.YES and fe_exogenous is not None:
+            self._add_feat_eng_steps(
+                fe_exogenous=fe_exogenous,
+                target=False,
+            )
+
+    def _add_feat_eng_steps(self, fe_exogenous: list, target: bool = True):
+        """Add feature engineering steps for the data.
+
+        Parameters
+        ----------
+        fe_exogenous : list
+            Feature engineering transformations to be applied to exogenous variables.
+        target : bool, optional
+            If True, feature engineering steps are added to the target variable steps
+            (This is not implemented yet - see note in _feature_engineering)
+            If False, feature engineering steps are added to the exogenous variable steps,
+            by default True
+
+        Raises
+        ------
+        ValueError
+            `fe_exogenous` is not of the correct type.
+        """
+        type_ = "Target" if target else "Exogenous"
+        self.logger.info(f"Set up feature engineering for {type_} variable(s).")
+
+        if not isinstance(fe_exogenous, list):
+            raise ValueError(
+                f"{type_} Feature Engineering input must be of a List or sktime transformers."
+                f"You provided {fe_exogenous}"
+            )
+
+        if target:
+            # This is not implemented yet - see note in _feature_engineering
+            pass
+        else:
+            self.transformer_steps_exogenous.extend(fe_exogenous)
 
     # def _feature_selection(
     #     self,

--- a/pycaret/internal/pycaret_experiment/pycaret_experiment.py
+++ b/pycaret/internal/pycaret_experiment/pycaret_experiment.py
@@ -482,9 +482,12 @@ class _PyCaretExperiment:
                 return self.dataset  # For unsupervised: dataset == X
         else:
             X = self.dataset.drop(self.target_param, axis=1)
-            if X.empty:
+            if X.empty and self.fe_exogenous is None:
                 return None
             else:
+                # If X is not empty or empty but self.fe_exogenous is provided
+                # Return X instead of None, since the index can be used to
+                # generate features using self.fe_exogenous
                 return X
 
     @property
@@ -505,9 +508,12 @@ class _PyCaretExperiment:
         if self._ml_usecase != MLUsecase.TIME_SERIES:
             return X_train
         else:
-            if X_train.empty:
+            if X_train.empty and self.fe_exogenous is None:
                 return None
             else:
+                # If X_train is not empty or empty but self.fe_exogenous is provided
+                # Return X_train instead of None, since the index can be used to
+                # generate features using self.fe_exogenous
                 return X_train
 
     @property
@@ -527,9 +533,12 @@ class _PyCaretExperiment:
         if self._ml_usecase != MLUsecase.TIME_SERIES:
             return X_test
         else:
-            if X_test.empty:
+            if X_test.empty and self.fe_exogenous is None:
                 return None
             else:
+                # If X_test is not empty or empty but self.fe_exogenous is provided
+                # Return X_test instead of None, since the index can be used to
+                # generate features using self.fe_exogenous
                 return X_test
 
     @property

--- a/pycaret/time_series/forecasting/functional.py
+++ b/pycaret/time_series/forecasting/functional.py
@@ -1205,7 +1205,7 @@ def plot_model(
             NOTE:
             (1) If no imputation is specified, then plotting the "imputed"
                 data type will produce the same results as the "original" data type.
-            (2) If no transforations are specified, then plotting the "transformed"
+            (2) If no transformations are specified, then plotting the "transformed"
                 data type will produce the same results as the "imputed" data type.
 
             Allowed values are (if not specified, defaults to the first one in the list):
@@ -1250,6 +1250,27 @@ def plot_model(
         The setting to be used for the plot. Overrides any global setting
         passed during setup. Pass these as key-value pairs. For available
         keys, refer to the `setup` documentation.
+
+        Time-series plots support more display_formats, as a result the fig-kwargs
+        can also contain the `resampler_kwargs` key and its corresponding dict.
+        These are additional keyword arguments that are fed to the display function.
+        This is mainly used for configuring `plotly-resampler` visualizations
+        (i.e., `display_format` "plotly-dash" or "plotly-widget") which down sampler
+        will be used; how many data points are shown in the front-end.
+
+        When the plotly-resampler figure is rendered via Dash (by setting the
+        `display_format` to "plotly-dash"), one can also use the
+        "show_dash" key within this dictionary to configure the show_dash args.
+
+        example::
+
+            fig_kwargs = {
+                "width": None,
+                "resampler_kwargs":  {
+                    "default_n_shown_samples": 1000,
+                    "show_dash": {"mode": "inline", "port": 9012}
+                }
+            }
 
 
     save: string or bool, default = False

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -3795,7 +3795,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
                 NOTE:
                 (1) If no imputation is specified, then plotting the "imputed"
                     data type will produce the same results as the "original" data type.
-                (2) If no transforations are specified, then plotting the "transformed"
+                (2) If no transformations are specified, then plotting the "transformed"
                     data type will produce the same results as the "imputed" data type.
 
                 Allowed values are (if not specified, defaults to the first one in the list):
@@ -3845,10 +3845,10 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             can also contain the `resampler_kwargs` key and its corresponding dict.
             These are additional keyword arguments that are fed to the display function.
             This is mainly used for configuring `plotly-resampler` visualizations
-            (i.e., `display_format` "plotly-dash" or "plotly-widget") which downsampler
-            will be used; how many datapoints are shown in the front-end.
+            (i.e., `display_format` "plotly-dash" or "plotly-widget") which down sampler
+            will be used; how many data points are shown in the front-end.
 
-            When the plotly-resampler figure is renderd via Dash (by setting the
+            When the plotly-resampler figure is rendered via Dash (by setting the
             `display_format` to "plotly-dash"), one can also use the
             "show_dash" key within this dictionary to configure the show_dash args.
 
@@ -4013,7 +4013,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         ------
         ValueError
             If model is finalized and was trained using exogenous variables and
-            user does not provide exogenous variabled for predictions.
+            user does not provide exogenous variables for predictions.
         """
         if self._setup_ran:
             estimator_y, _ = self._get_cleaned_estimator_y_X(estimator=estimator)

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -61,7 +61,6 @@ from pycaret.utils._dependencies import _check_soft_dependencies
 from pycaret.utils.datetime import coerce_datetime_to_period_index
 from pycaret.utils.generic import (
     MLUsecase,
-    _coerce_empty_dataframe_to_none,
     _resolve_dict_keys,
     highlight_setup,
 )

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -59,11 +59,7 @@ from pycaret.internal.validation import is_sklearn_cv_generator
 from pycaret.loggers.base_logger import BaseLogger
 from pycaret.utils._dependencies import _check_soft_dependencies
 from pycaret.utils.datetime import coerce_datetime_to_period_index
-from pycaret.utils.generic import (
-    MLUsecase,
-    _resolve_dict_keys,
-    highlight_setup,
-)
+from pycaret.utils.generic import MLUsecase, _resolve_dict_keys, highlight_setup
 from pycaret.utils.time_series import (
     TSApproachTypes,
     TSExogenousPresent,

--- a/pycaret/utils/time_series/forecasting/__init__.py
+++ b/pycaret/utils/time_series/forecasting/__init__.py
@@ -113,7 +113,7 @@ def get_predictions_with_intervals(
         y_pred = forecaster.predict_quantiles(fh=fh, X=X, alpha=alpha)
         if y_pred.shape[1] != 1:
             raise ValueError(
-                "Something wrong happended during point prediction; received values "
+                "Something wrong happened during point prediction; received values "
                 "This should not have happened. Please report on GitHub."
             )
         y_pred = pd.DataFrame({"y_pred": y_pred.iloc[:, 0]})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def load_uni_exo_data_target_missing():
 def load_models_uni_exo():
     """Load models that support univariate date with exogenous variables."""
     # TODO: Later, get this dynamically from sktime
-    models = ["arima", "auto_arima"]
+    models = ["arima", "lr_cds_dt"]
     return models
 
 
@@ -91,7 +91,7 @@ def load_models_uni_mix_exo_noexo():
     """Load a sample mix of models that support univariate date with
     exogenous variables and those that do not."""
     # TODO: Later, get this dynamically from sktime
-    models = ["naive", "ets", "arima"]
+    models = ["naive", "ets", "arima", "lr_cds_dt"]
     return models
 
 

--- a/tests/test_time_series_feat_eng.py
+++ b/tests/test_time_series_feat_eng.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 from pandas.testing import assert_frame_equal
+from sktime.transformations.series.date import DateTimeFeatures
 from sktime.transformations.series.summarize import WindowSummarizer
 from time_series_test_utils import assert_frame_not_equal
 
@@ -122,3 +123,46 @@ def test_fe_exogenous(load_uni_exo_data_target, model, expected_equal):
         assert_frame_equal(metrics1, metrics2)
     else:
         assert_frame_not_equal(metrics1, metrics2)
+
+
+def test_fe_exog_data_no_exo(load_pos_and_neg_data):
+    """Test custom feature engineering for target and exogenous when data does
+    not have any exogenous variables. e.g. extracting DateTimeFeatures from Index.
+    """
+    data = load_pos_and_neg_data
+    kwargs = {"lag_feature": {"lag": [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]}}
+    fe_target = [WindowSummarizer(n_jobs=1, truncate="bfill", **kwargs)]
+
+    # Baseline
+    exp = TSForecastingExperiment()
+    exp.setup(data=data, fh=12, session_id=42)
+    _ = exp.create_model("lr_cds_dt")
+    metrics1 = exp.pull()
+
+    # With Feature Engineering (1) - replicate the default
+    exp = TSForecastingExperiment()
+    exp.setup(data=data, fh=12, fe_target=fe_target, session_id=42)
+    _ = exp.create_model("lr_cds_dt")
+    metrics2 = exp.pull()
+    assert_frame_equal(metrics1, metrics2)
+
+    # With Feature Engineering (2) - Date Time features created in y
+    fe_target2 = fe_target + [DateTimeFeatures(ts_freq="M")]
+    exp = TSForecastingExperiment()
+    exp.setup(data=data, fh=12, fe_target=fe_target2, session_id=42)
+    _ = exp.create_model("lr_cds_dt")
+    metrics3 = exp.pull()
+    assert_frame_not_equal(metrics1, metrics3)
+
+    # With Feature Engineering (3) - Date Time features created in X
+    fe_exogenous = [DateTimeFeatures(ts_freq="M")]
+    exp = TSForecastingExperiment()
+    exp.setup(
+        data=data, fh=12, fe_target=fe_target, fe_exogenous=fe_exogenous, session_id=42
+    )
+    _ = exp.create_model("lr_cds_dt")
+    metrics4 = exp.pull()
+    assert_frame_not_equal(metrics1, metrics4)
+
+    # TODO: Not sure why these are different. Needs investigation.
+    # assert_frame_equal(metrics3, metrics4)

--- a/tests/test_time_series_feat_eng.py
+++ b/tests/test_time_series_feat_eng.py
@@ -1,0 +1,125 @@
+"""Module to test time_series functionality
+"""
+import numpy as np
+from pandas.testing import assert_frame_equal
+from sktime.transformations.series.summarize import WindowSummarizer
+
+import pytest
+
+from pycaret.time_series import TSForecastingExperiment
+from time_series_test_utils import assert_frame_not_equal
+
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
+
+
+##############################
+# Functions Start Here ####
+##############################
+
+# NOTE: Fixtures can not be used to parameterize tests
+# https://stackoverflow.com/questions/52764279/pytest-how-to-parametrize-a-test-with-a-list-that-is-returned-from-a-fixture
+# Hence, we have to create functions and create the parameterized list first
+# (must happen during collect phase) before passing it to mark.parameterize.
+
+
+############################
+# Functions End Here ####
+############################
+
+
+##########################
+# Tests Start Here ####
+##########################
+
+
+def test_fe_target(load_pos_and_neg_data):
+    """Test custom feature engineering for target (applicable to reduced
+    regression models only)
+    """
+    data = load_pos_and_neg_data
+
+    kwargs = {"lag_feature": {"lag": [36, 24, 13, 12, 11, 9, 6, 3, 2, 1]}}
+    fe_target = [WindowSummarizer(n_jobs=1, truncate="bfill", **kwargs)]
+
+    # Baseline
+    exp = TSForecastingExperiment()
+    exp.setup(data=data, fh=12, fold=3, session_id=42)
+    exp.create_model("lr_cds_dt")
+    metrics1 = exp.pull()
+
+    # With Feature Engineering
+    exp = TSForecastingExperiment()
+    exp.setup(data=data, fh=12, fold=3, fe_target=fe_target, session_id=42)
+    exp.create_model("lr_cds_dt")
+    metrics2 = exp.pull()
+
+    assert_frame_not_equal(metrics1, metrics2)
+
+
+@pytest.mark.parametrize(
+    "model, expected_equal", [("arima", False), ("lr_cds_dt", False), ("naive", True)]
+)
+def test_fe_exogenous(load_uni_exo_data_target, model, expected_equal):
+    """Test custom feature engineering for exogenous variables (applicable to all models)."""
+    data, target = load_uni_exo_data_target
+    fh = 12
+
+    # Example: function num_above_thresh to count how many observations lie above
+    # the threshold within a window of length 2, lagged by 0 periods.
+    def num_above_thresh(x):
+        """Count how many observations lie above threshold."""
+        return np.sum((x > 0.7)[::-1])
+
+    kwargs1 = {"lag_feature": {"lag": [0, 1], "mean": [[0, 4]]}}
+    kwargs2 = {
+        "lag_feature": {
+            "lag": [0, 1],
+            num_above_thresh: [[0, 2]],
+            "mean": [[0, 4]],
+            "std": [[0, 4]],
+        }
+    }
+    fe_exogenous = [
+        (
+            "a",
+            WindowSummarizer(
+                n_jobs=1, target_cols=["Income"], truncate="bfill", **kwargs1
+            ),
+        ),
+        (
+            "b",
+            WindowSummarizer(
+                n_jobs=1,
+                target_cols=["Unemployment", "Production"],
+                truncate="bfill",
+                **kwargs2,
+            ),
+        ),
+    ]
+
+    # Baseline
+    exp = TSForecastingExperiment()
+    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    features1 = exp.get_config("X_transformed").columns
+    _ = exp.create_model(model)
+    metrics1 = exp.pull()
+
+    # With Feature Engineering
+    exp = TSForecastingExperiment()
+    exp.setup(
+        data=data,
+        target=target,
+        fh=fh,
+        seasonal_period=4,
+        fe_exogenous=fe_exogenous,
+        session_id=42,
+    )
+    features2 = exp.get_config("X_transformed").columns
+    _ = exp.create_model(model)
+    metrics2 = exp.pull()
+
+    assert len(features1) != len(features2)
+    if expected_equal:
+        assert_frame_equal(metrics1, metrics2)
+    else:
+        assert_frame_not_equal(metrics1, metrics2)

--- a/tests/test_time_series_feat_eng.py
+++ b/tests/test_time_series_feat_eng.py
@@ -1,13 +1,12 @@
 """Module to test time_series functionality
 """
 import numpy as np
+import pytest
 from pandas.testing import assert_frame_equal
 from sktime.transformations.series.summarize import WindowSummarizer
-
-import pytest
+from time_series_test_utils import assert_frame_not_equal
 
 from pycaret.time_series import TSForecastingExperiment
-from time_series_test_utils import assert_frame_not_equal
 
 pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 

--- a/tests/time_series_test_utils.py
+++ b/tests/time_series_test_utils.py
@@ -3,6 +3,7 @@
 import random
 
 import numpy as np
+from pandas.testing import assert_frame_equal
 from sktime.forecasting.base import ForecastingHorizon
 
 from pycaret.containers.models import get_all_ts_model_containers
@@ -310,6 +311,18 @@ def _return_model_names_for_missing_data():
     """Returns models that do not support missing data"""
     model_names = ["ets", "theta", "lr_cds_dt"]
     return model_names
+
+
+def assert_frame_not_equal(*args, **kwargs):
+    """https://stackoverflow.com/a/38778401/8925915"""
+    try:
+        assert_frame_equal(*args, **kwargs)
+    except AssertionError:
+        # frames are not equal
+        pass
+    else:
+        # frames are equal
+        raise AssertionError("Frames are equal, but should not be.")
 
 
 def _return_data_big_small():


### PR DESCRIPTION
# Related Issue or bug

- Follow up to https://github.com/pycaret/pycaret/pull/3109
- (Closes #2324) Allows the user the ability to perform custom feature engineering for exogenous and target variables . Includes the ability to
    - add custom lags for the targets variable
    - add custom lags, windows, and summary functions for the exogenous variables. 
    - add separate feature engineering for different features  
    - extract Date Time Exogenous features even when data does not have exogenous variables.
- Also expands the scope of some exogenous tests to include a statistical and a reduced regression model.
- Minor spell checks
- Made docstring consistent between OOP and Functional for time series

# Describe the changes you've made

Described above. Tests (and docstring) show how to use this feature.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests have been added.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

