### PR TITLE
Fix for time series pipeline order and renamed argument

### DIFF
--- a/pycaret/time_series/forecasting/functional.py
+++ b/pycaret/time_series/forecasting/functional.py
@@ -34,7 +34,7 @@ def setup(
     numeric_imputation_exogenous: Optional[Union[int, float, str]] = None,
     transform_target: Optional[str] = None,
     transform_exogenous: Optional[str] = None,
-    fe_target: Optional[list] = None,
+    fe_target_rr: Optional[list] = None,
     fe_exogenous: Optional[list] = None,
     scale_target: Optional[str] = None,
     scale_exogenous: Optional[str] = None,
@@ -150,7 +150,7 @@ def setup(
             "zscore", "minmax", "maxabs", "robust"
 
 
-    fe_target: Optional[list], default = None
+    fe_target_rr: Optional[list], default = None
         The transformers to be applied to the target variable in order to
         extract useful features. By default, None which means that the
         provided target variable are used "as is".
@@ -170,7 +170,7 @@ def setup(
         >>> data = get_data("airline")
 
         >>> kwargs = {"lag_feature": {"lag": [36, 24, 13, 12, 11, 9, 6, 3, 2, 1]}}
-        >>> fe_target = [WindowSummarizer(n_jobs=1, truncate="bfill", **kwargs)]
+        >>> fe_target_rr = [WindowSummarizer(n_jobs=1, truncate="bfill", **kwargs)]
 
         >>> # Baseline
         >>> exp = TSForecastingExperiment()
@@ -180,7 +180,7 @@ def setup(
         >>> # With Feature Engineering
         >>> exp = TSForecastingExperiment()
         >>> exp.setup(
-        >>>     data=data, fh=12, fold=3, fe_target=fe_target, session_id=42
+        >>>     data=data, fh=12, fold=3, fe_target_rr=fe_target_rr, session_id=42
         >>> )
         >>> model2 = exp.create_model("lr_cds_dt")
 
@@ -485,7 +485,7 @@ def setup(
         transform_exogenous=transform_exogenous,
         scale_target=scale_target,
         scale_exogenous=scale_exogenous,
-        fe_target=fe_target,
+        fe_target_rr=fe_target_rr,
         fe_exogenous=fe_exogenous,
         fold_strategy=fold_strategy,
         fold=fold,

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -199,8 +199,8 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
                     ["Transformation (Target)", self.transform_target],
                     ["Scaling (Target)", self.scale_target],
                     [
-                        "Custom Feature Engineering (Target)",
-                        True if self.fe_target else False,
+                        "Feature Engineering (Target) - Reduced Regression",
+                        True if self.fe_target_rr else False,
                     ],
                 ]
             )
@@ -223,7 +223,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
                 display_container.extend(
                     [
                         [
-                            "Custom Feature Engineering (Exogenous)",
+                            "Feature Engineering (Exogenous)",
                             True if self.fe_exogenous else False,
                         ]
                     ]
@@ -1031,6 +1031,12 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
                 exogenous_present=self.exogenous_present,
             )
 
+            # Feature Engineering ----
+            self._feature_engineering(
+                fe_exogenous=self.fe_exogenous,
+                exogenous_present=self.exogenous_present,
+            )
+
             # Transformations (preferably based on residual analysis) ----
             self._transformation(
                 transform_target=self.transform_target,
@@ -1042,12 +1048,6 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             self._scaling(
                 scale_target=self.scale_target,
                 scale_exogenous=self.scale_exogenous,
-                exogenous_present=self.exogenous_present,
-            )
-
-            # Feature Engineering ----
-            self._feature_engineering(
-                fe_exogenous=self.fe_exogenous,
                 exogenous_present=self.exogenous_present,
             )
 
@@ -1279,7 +1279,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         transform_exogenous: Optional[str] = None,
         scale_target: Optional[str] = None,
         scale_exogenous: Optional[str] = None,
-        fe_target: Optional[list] = None,
+        fe_target_rr: Optional[list] = None,
         fe_exogenous: Optional[list] = None,
         fold_strategy: Union[str, Any] = "expanding",
         fold: int = 3,
@@ -1397,7 +1397,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
                 "zscore", "minmax", "maxabs", "robust"
 
 
-        fe_target: Optional[list], default = None
+        fe_target_rr: Optional[list], default = None
             The transformers to be applied to the target variable in order to
             extract useful features. By default, None which means that the
             provided target variable are used "as is".
@@ -1417,7 +1417,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             >>> data = get_data("airline")
 
             >>> kwargs = {"lag_feature": {"lag": [36, 24, 13, 12, 11, 9, 6, 3, 2, 1]}}
-            >>> fe_target = [WindowSummarizer(n_jobs=1, truncate="bfill", **kwargs)]
+            >>> fe_target_rr = [WindowSummarizer(n_jobs=1, truncate="bfill", **kwargs)]
 
             >>> # Baseline
             >>> exp = TSForecastingExperiment()
@@ -1427,7 +1427,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             >>> # With Feature Engineering
             >>> exp = TSForecastingExperiment()
             >>> exp.setup(
-            >>>     data=data, fh=12, fold=3, fe_target=fe_target, session_id=42
+            >>>     data=data, fh=12, fold=3, fe_target_rr=fe_target_rr, session_id=42
             >>> )
             >>> model2 = exp.create_model("lr_cds_dt")
 
@@ -1754,7 +1754,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         self.transform_exogenous = transform_exogenous
         self.scale_target = scale_target
         self.scale_exogenous = scale_exogenous
-        self.fe_target = fe_target
+        self.fe_target_rr = fe_target_rr
         self.fe_exogenous = fe_exogenous
 
         self.fold_strategy = fold_strategy

--- a/tests/test_time_series_feat_eng.py
+++ b/tests/test_time_series_feat_eng.py
@@ -39,7 +39,7 @@ def test_fe_target(load_pos_and_neg_data):
     data = load_pos_and_neg_data
 
     kwargs = {"lag_feature": {"lag": [36, 24, 13, 12, 11, 9, 6, 3, 2, 1]}}
-    fe_target = [WindowSummarizer(n_jobs=1, truncate="bfill", **kwargs)]
+    fe_target_rr = [WindowSummarizer(n_jobs=1, truncate="bfill", **kwargs)]
 
     # Baseline
     exp = TSForecastingExperiment()
@@ -49,7 +49,7 @@ def test_fe_target(load_pos_and_neg_data):
 
     # With Feature Engineering
     exp = TSForecastingExperiment()
-    exp.setup(data=data, fh=12, fold=3, fe_target=fe_target, session_id=42)
+    exp.setup(data=data, fh=12, fold=3, fe_target_rr=fe_target_rr, session_id=42)
     exp.create_model("lr_cds_dt")
     metrics2 = exp.pull()
 
@@ -131,7 +131,7 @@ def test_fe_exog_data_no_exo(load_pos_and_neg_data):
     """
     data = load_pos_and_neg_data
     kwargs = {"lag_feature": {"lag": [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]}}
-    fe_target = [WindowSummarizer(n_jobs=1, truncate="bfill", **kwargs)]
+    fe_target_rr = [WindowSummarizer(n_jobs=1, truncate="bfill", **kwargs)]
 
     # Baseline
     exp = TSForecastingExperiment()
@@ -141,15 +141,15 @@ def test_fe_exog_data_no_exo(load_pos_and_neg_data):
 
     # With Feature Engineering (1) - replicate the default
     exp = TSForecastingExperiment()
-    exp.setup(data=data, fh=12, fe_target=fe_target, session_id=42)
+    exp.setup(data=data, fh=12, fe_target_rr=fe_target_rr, session_id=42)
     _ = exp.create_model("lr_cds_dt")
     metrics2 = exp.pull()
     assert_frame_equal(metrics1, metrics2)
 
     # With Feature Engineering (2) - Date Time features created in y
-    fe_target2 = fe_target + [DateTimeFeatures(ts_freq="M")]
+    fe_target2 = fe_target_rr + [DateTimeFeatures(ts_freq="M")]
     exp = TSForecastingExperiment()
-    exp.setup(data=data, fh=12, fe_target=fe_target2, session_id=42)
+    exp.setup(data=data, fh=12, fe_target_rr=fe_target2, session_id=42)
     _ = exp.create_model("lr_cds_dt")
     metrics3 = exp.pull()
     assert_frame_not_equal(metrics1, metrics3)
@@ -158,7 +158,11 @@ def test_fe_exog_data_no_exo(load_pos_and_neg_data):
     fe_exogenous = [DateTimeFeatures(ts_freq="M")]
     exp = TSForecastingExperiment()
     exp.setup(
-        data=data, fh=12, fe_target=fe_target, fe_exogenous=fe_exogenous, session_id=42
+        data=data,
+        fh=12,
+        fe_target_rr=fe_target_rr,
+        fe_exogenous=fe_exogenous,
+        session_id=42,
     )
     _ = exp.create_model("lr_cds_dt")
     metrics4 = exp.pull()


### PR DESCRIPTION
# Related Issue or bug

Closes #3118

# Describe the changes you've made

- Fixes order of time series pipeline per #3118
- Renames the argument used to create features for target in reduced regression models from `fe_target` to `fe_target_rr` (more explicit). This will allow us to add `fe_target` argument later if we want these features to apply to all types of models.


# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests to pass on GH

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

