### PR TITLE
Enforce X86 platform spec for scikit-learn-intelex package

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -14,7 +14,7 @@ catboost>=0.23.2
 kmodes>=0.11.1
 mlxtend>=0.19.0
 statsforecast>=0.5.5
-scikit-learn-intelex>=2021.6.3 platform_machine == 'x86_64' or platform_machine == 'AMD64'
+scikit-learn-intelex>=2021.6.3; platform_machine == 'x86_64' or platform_machine == 'AMD64'
 
 # Tuners
 tune-sklearn>=0.2.1; python_version < '3.10' or platform_system != 'Windows'

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -14,7 +14,7 @@ catboost>=0.23.2
 kmodes>=0.11.1
 mlxtend>=0.19.0
 statsforecast>=0.5.5
-scikit-learn-intelex>=2021.6.3
+scikit-learn-intelex>=2021.6.3 platform_machine == 'x86_64' or platform_machine == 'AMD64'
 
 # Tuners
 tune-sklearn>=0.2.1; python_version < '3.10' or platform_system != 'Windows'


### PR DESCRIPTION
# Related Issue or bug

Fix for dependency problem - https://github.com/pycaret/pycaret/issues/1971#issuecomment-1331449447 described in this issue 
Closes https://github.com/pycaret/pycaret/issues/1971

# Describe the changes you've made

Adding platform spec for scikit-learn-intelex package as it's available only for x86 platform 

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
would be tested as part of product build/packaging

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

scikit-learn-intelex package would be requested only for x86 platform 

# Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

# Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
