### PR TITLE
Auto Seasonal Period Detection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,7 +256,7 @@ jobs:
           pip list
       - name: Remove tests
         run: |
-          find tests -type f -not -name '__init__.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'benchmarks/*.py' -delete
+          find tests -type f -not -name '__init__.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'test_time_series_sp_detection.py' -delete
       - name: Run benchmarks
         run: pytest --durations=0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,6 @@ jobs:
       - name: Remove tests
         run: |
           find tests -type f -not -name '__init__.py' -not -name 'test_classification_plots.py' -not -name 'test_regression_plots.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'test_time_series_plots.py' -not -name 'test_time_series_utils_plots.py' -delete
-          rm tests/benchmarks/*.py
       - name: Test with pytest
         run: pytest --durations=0
 
@@ -184,7 +183,6 @@ jobs:
       - name: Remove tests
         run: |
           find tests -type f -not -name '__init__.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'test_time_series_tune_random.py' -delete
-          rm tests/benchmarks/*.py
       - name: Test with pytest
         run: pytest --durations=0
 
@@ -222,7 +220,6 @@ jobs:
       - name: Remove tests
         run: |
           find tests -type f -not -name '__init__.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'test_time_series_tune_grid.py' -delete
-          rm tests/benchmarks/*.py
       - name: Test with pytest
         run: pytest --durations=0
 
@@ -259,7 +256,7 @@ jobs:
           pip list
       - name: Remove tests
         run: |
-          find tests -type f -not -name '__init__.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -delete
+          find tests -type f -not -name '__init__.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'benchmarks/*.py' -delete
       - name: Run benchmarks
         run: pytest --durations=0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           path: pycaret tests
 
   # JOBS MUST START WITH test !!!!
-  test:
+  test_linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -74,6 +74,7 @@ jobs:
           rm tests/test_time_series_tune_random.py
           rm tests/test_time_series_plots.py
           rm tests/test_time_series_utils_plots.py
+          rm tests/benchmarks/*.py
       - name: Test with pytest
         run: pytest --durations=0
 
@@ -110,7 +111,156 @@ jobs:
       - name: Remove tests
         run: |
           remove-item tests/* -Include @('test_clustering.py', 'test_classification_tuning.py','test_classification_plots.py','test_regression_plots.py', 'test_regression_tuning.py', 'test_time_series_tune_grid.py', 'test_time_series_tune_random.py', 'test_create_api.py', 'test_create_docker.py', 'test_drift_report.py', 'test_eda.py', 'test_time_series_plots.py', 'test_time_series_utils_plots.py')
+          remove-item tests/benchmarks/*
       - name: Test with pytest
+        run: pytest --durations=0
+
+  test_plots:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        # SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
+        # pyLDAvis 3.3.1 having an "sklearn" dependency
+        run: |
+          export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
+          python -m pip install --upgrade pip
+          python -m pip install -U pytest codecov numpy
+          pip install -e ".[full, nlp]"
+          if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
+          python -m spacy download en_core_web_sm
+      - name: Python version and dependency list
+        run: |
+          echo "Python version expected: ${{ matrix.python-version }}"
+          python --version
+          which python
+          pip list
+      - name: Remove tests
+        run: |
+          find tests -type f -not -name '__init__.py' -not -name 'test_classification_plots.py' -not -name 'test_regression_plots.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'test_time_series_plots.py' -not -name 'test_time_series_utils_plots.py' -delete
+          rm tests/benchmarks/*.py
+      - name: Test with pytest
+        run: pytest --durations=0
+
+  test_ts_tune_random:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        # SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
+        # pyLDAvis 3.3.1 having an "sklearn" dependency
+        run: |
+          export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
+          python -m pip install -U pip
+          python -m pip install -U pytest codecov numpy
+
+          pip install -e ".[full, nlp]"
+          if [ -f requirements-prophet.txt ]; then pip install -r requirements-prophet.txt; fi
+          if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
+
+          python -m spacy download en_core_web_sm
+      - name: Python version and dependency list
+        run: |
+          echo "Python version expected: ${{ matrix.python-version }}"
+          python --version
+          which python
+          pip list
+      - name: Remove tests
+        run: |
+          find tests -type f -not -name '__init__.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'test_time_series_tune_random.py' -delete
+          rm tests/benchmarks/*.py
+      - name: Test with pytest
+        run: pytest --durations=0
+
+  test_ts_tune_grid:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        # SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
+        # pyLDAvis 3.3.1 having an "sklearn" dependency
+        run: |
+          export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
+          python -m pip install -U pip
+          python -m pip install -U pytest codecov numpy
+
+          pip install -e ".[full, nlp]"
+          if [ -f requirements-prophet.txt ]; then pip install -r requirements-prophet.txt; fi
+          if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
+
+          python -m spacy download en_core_web_sm
+      - name: Python version and dependency list
+        run: |
+          echo "Python version expected: ${{ matrix.python-version }}"
+          python --version
+          which python
+          pip list
+      - name: Remove tests
+        run: |
+          find tests -type f -not -name '__init__.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'test_time_series_tune_grid.py' -delete
+          rm tests/benchmarks/*.py
+      - name: Test with pytest
+        run: pytest --durations=0
+
+  test_benchmarks:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        # SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
+        # pyLDAvis 3.3.1 having an "sklearn" dependency
+        run: |
+          export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
+          python -m pip install -U pip
+          python -m pip install -U pytest codecov numpy
+
+          pip install -e ".[full, nlp]"
+          if [ -f requirements-prophet.txt ]; then pip install -r requirements-prophet.txt; fi
+          if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
+
+          python -m spacy download en_core_web_sm
+      - name: Python version and dependency list
+        run: |
+          echo "Python version expected: ${{ matrix.python-version }}"
+          python --version
+          which python
+          pip list
+      - name: Remove tests
+        run: |
+          find tests -type f -not -name '__init__.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -delete
+      - name: Run benchmarks
         run: pytest --durations=0
 
   # test_tuning:
@@ -182,108 +332,3 @@ jobs:
   #       remove-item tests/* -Exclude @('__init__.py','test_regression_tuning.py')
   #   - name: Test with pytest
   #     run: pytest --durations=0
-
-  test_plots:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install dependencies
-        # SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
-        # pyLDAvis 3.3.1 having an "sklearn" dependency
-        run: |
-          export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
-          python -m pip install --upgrade pip
-          python -m pip install -U pytest codecov numpy
-          pip install -e ".[full, nlp]"
-          if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
-          python -m spacy download en_core_web_sm
-      - name: Python version and dependency list
-        run: |
-          echo "Python version expected: ${{ matrix.python-version }}"
-          python --version
-          which python
-          pip list
-      - name: Remove tests
-        run: |
-          find tests -type f -not -name '__init__.py' -not -name 'test_classification_plots.py' -not -name 'test_regression_plots.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'test_time_series_plots.py' -not -name 'test_time_series_utils_plots.py' -delete
-      - name: Test with pytest
-        run: pytest --durations=0
-
-  test_ts_tune_random:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.8]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        # SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
-        # pyLDAvis 3.3.1 having an "sklearn" dependency
-        run: |
-          export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
-          python -m pip install -U pip
-          python -m pip install -U pytest codecov numpy
-
-          pip install -e ".[full, nlp]"
-          if [ -f requirements-prophet.txt ]; then pip install -r requirements-prophet.txt; fi
-          if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
-
-          python -m spacy download en_core_web_sm
-      - name: Python version and dependency list
-        run: |
-          echo "Python version expected: ${{ matrix.python-version }}"
-          python --version
-          which python
-          pip list
-      - name: Remove tests
-        run: |
-          find tests -type f -not -name '__init__.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'test_time_series_tune_random.py' -delete
-      - name: Test with pytest
-        run: pytest --durations=0
-
-  test_ts_tune_grid:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.8]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        # SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
-        # pyLDAvis 3.3.1 having an "sklearn" dependency
-        run: |
-          export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
-          python -m pip install -U pip
-          python -m pip install -U pytest codecov numpy
-
-          pip install -e ".[full, nlp]"
-          if [ -f requirements-prophet.txt ]; then pip install -r requirements-prophet.txt; fi
-          if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
-
-          python -m spacy download en_core_web_sm
-      - name: Python version and dependency list
-        run: |
-          echo "Python version expected: ${{ matrix.python-version }}"
-          python --version
-          which python
-          pip list
-      - name: Remove tests
-        run: |
-          find tests -type f -not -name '__init__.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'test_time_series_tune_grid.py' -delete
-      - name: Test with pytest
-        run: pytest --durations=0

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -23,6 +23,7 @@ from sktime.forecasting.model_selection import (
 )
 from sktime.transformations.compose import TransformerPipeline
 from sktime.transformations.series.impute import Imputer
+from sktime.utils.seasonality import autocorrelation_seasonality_test
 
 from pycaret.containers.metrics import get_all_ts_metric_containers
 from pycaret.containers.models import get_all_ts_model_containers
@@ -64,6 +65,7 @@ from pycaret.utils.time_series import (
     TSApproachTypes,
     TSExogenousPresent,
     TSModelTypes,
+    auto_detect_sp,
     get_sp_from_str,
 )
 from pycaret.utils.time_series.forecasting import (
@@ -181,6 +183,8 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             ["Fold Generator", type(self.fold_generator).__name__],
             ["Fold Number", self.fold_param],
             ["Enforce Prediction Interval", self.enforce_pi],
+            ["Seasonality Detection Algo", self.sp_detection],
+            ["Num Seasonalities to Use", self.multiple_sp_to_use],
             ["Seasonal Period(s) Tested", self.seasonal_period],
             ["Seasonality Present", self.seasonality_present],
             ["Seasonalities Detected", self.all_sp_values],
@@ -454,12 +458,15 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         seasonal_period: Optional[Union[List[Union[int, str]], int, str]] = None,
     ) -> "TSForecastingExperiment":
         """
-        Checks if the index is one of the allowed types (pd.PeriodIndex,
-        pd.DatetimeIndex). If it is not one of the allowed types, then seasonal
-        period must be provided. This check is also performed. Finally, index is
-        coerced into period index which is used in subsequent steps and the
-        appropriate class for data index is set so that it can be used to disable
-        certain models which do not support that type of index.
+        Checks the following
+        (1) Index has duplicate values.
+        (2) Data has missing index values.
+        (3) If sp_detection == "index" and the index is not one of the allowed type
+        (pd.PeriodIndex, pd.DatetimeIndex), then seasonal period must be provided.
+
+        Finally, index is coerced into period index which is used in subsequent
+        steps and the appropriate class for data index is set so that it can be
+        used to disable certain models which do not support that type of index.
 
         Parameters
         ----------
@@ -479,10 +486,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         Raises
         ------
         ValueError
-            Raised when
-            (1) Index has duplicate values.
-            (2) Data has missing index values.
-            (3) Index is not one of the allowed types and seasonal period is not provided
+            Raised when any of the checks fail
         """
 
         # Set Index if necessary ----
@@ -495,7 +499,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
                 unique_index_after = len(self.data[index]) == len(set(self.data[index]))
                 if unique_index_before and not unique_index_after:
                     raise ValueError(
-                        f"Coresion of Index column '{index}' to datetime led to duplicates!"
+                        f"Coercion of Index column '{index}' to datetime led to duplicates!"
                         " Consider setting the data index outside pycaret before passing to setup()."
                     )
                 self.data.set_index(index, inplace=True)
@@ -513,7 +517,8 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         # Check Index Type ----
         allowed_freq_index_types = (pd.PeriodIndex, pd.DatetimeIndex)
         if (
-            not isinstance(self.data.index, allowed_freq_index_types)
+            self.sp_detection == "index"
+            and not isinstance(self.data.index, allowed_freq_index_types)
             and seasonal_period is None
         ):
             # https://stackoverflow.com/questions/3590165/join-a-list-of-items-with-different-types-as-string-in-python
@@ -674,11 +679,12 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         """
         self.logger.info("Set up Seasonal Period.")
 
-        # sktime is an optional dependency
-        from sktime.utils.seasonality import autocorrelation_seasonality_test
-
+        # Set the seasonal periods if not provided ----
         if seasonal_period is None:
-            seasonal_period = self.data.index.freqstr
+            if self.sp_detection == "auto":
+                _, seasonal_period, _ = auto_detect_sp(y=self.y_transformed)
+            elif self.sp_detection == "index":
+                seasonal_period = self.data.index.freqstr
 
         if not isinstance(seasonal_period, list):
             seasonal_period = [seasonal_period]
@@ -703,6 +709,13 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             for sp, seasonality_present in sp_values_and_test_result
             if seasonality_present
         ] or [1]
+
+        if self.sp_detection == "auto":
+            # If the number of seasonalities detected is > the number of
+            # seasonalities allowed by user, then limit it.
+            if len(self.all_sp_values) > self.multiple_sp_to_use:
+                self.all_sp_values = self.all_sp_values[0 : self.multiple_sp_to_use]
+
         self.primary_sp_to_use = self.all_sp_values[0]
         self.seasonal_period = (
             seasonal_period[0] if len(seasonal_period) == 1 else seasonal_period
@@ -1285,6 +1298,8 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         fold: int = 3,
         fh: Optional[Union[List[int], int, np.ndarray, ForecastingHorizon]] = 1,
         seasonal_period: Optional[Union[List[Union[int, str]], int, str]] = None,
+        sp_detection: str = "auto",
+        multiple_sp_to_use: int = 1,
         point_alpha: Optional[float] = None,
         coverage: Union[float, List[float]] = 0.9,
         enforce_exogenous: bool = True,
@@ -1475,7 +1490,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             >>> data = get_data("uschange")
             >>> exp = TSForecastingExperiment()
             >>> exp.setup(
-            >>>     data=data, target="Consumption", fh=12, seasonal_period=4,
+            >>>     data=data, target="Consumption", fh=12,
             >>>     fe_exogenous=fe_exogenous, session_id=42
             >>> )
             >>> print(f"Feature Columns: {exp.get_config('X_transformed').columns}")
@@ -1518,26 +1533,45 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
 
 
         seasonal_period: list or int or str, default = None
-            Seasonal period in timeseries data. If not provided the frequency of the data
-            index is mapped to a seasonal period as follows:
+            Periods to check when performing seasonality checks. If not provided,
+            then seasonal periods are detected per the sp_detection setting.
 
-            * B, C = 5
-            * D = 7
-            * W = 52
-            * M, BM, CBM, MS, BMS, CBMS = 12
-            * SM, SMS = 24
-            * Q, BQ, QS, BQS = 4
-            * A, Y, BA, BY, AS, YS, BAS, BYS = 1
-            * H = 24
-            * T, min = 60
-            * S = 60
+            Users can provide `seasonal_period` by passing it as an integer or a
+            string corresponding to the keys below (e.g. 'W' for weekly data,
+            'M' for monthly data, etc.).
+                * B, C = 5
+                * D = 7
+                * W = 52
+                * M, BM, CBM, MS, BMS, CBMS = 12
+                * SM, SMS = 24
+                * Q, BQ, QS, BQS = 4
+                * A, Y, BA, BY, AS, YS, BAS, BYS = 1
+                * H = 24
+                * T, min = 60
+                * S = 60
 
-            Alternatively you can provide a custom `seasonal_period` by passing
-            it as an integer or a string corresponding to the keys above (e.g.
-            'W' for weekly data, 'M' for monthly data, etc.). You can also provide
-            a list of such values to use in models that accept multiple seasonal values
-            (currently TBATS). For models that don't accept multiple seasonal values, the
-            first value of the list will be used as the seasonal period.
+            Users can also provide a list of such values to use in models that
+            accept multiple seasonal values (currently TBATS). For models that
+            don't accept multiple seasonal values, the first value of the list
+            will be used as the seasonal period.
+
+
+        sp_detection: str = "auto"
+            If seasonal_period is None, then this parameter determines the algorithm
+            to use to detect the seasonal periods to use in the models.
+
+            Allowed values are ["auto" or "index"].
+
+            If "auto", then seasonal periods are detected using statistical tests.
+            If "index", then the frequency of the data index is mapped to a seasonal
+            period as shown in seasonal_period.
+
+
+        multiple_sp_to_use: int = 1
+            Applicable only when sp_detection is set to "auto". It determines how
+            many seasonal periods to use in the models. If a model only allows one
+            seasonal period and multiple_sp_to_use > 1, then the most dominant
+            (primary) seasonal that is detected is used.
 
 
         point_alpha: Optional[float], default = None
@@ -1759,6 +1793,14 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
 
         self.fold_strategy = fold_strategy
         self.fold = fold
+
+        if sp_detection not in ["auto", "index"]:
+            raise ValueError(
+                "sp_detection must be either 'auto' or 'index'. "
+                f"You provided {sp_detection}."
+            )
+        self.sp_detection = sp_detection
+        self.multiple_sp_to_use = multiple_sp_to_use
 
         self.log_plots_param = log_plots
         if self.log_plots_param is True:

--- a/tests/benchmarks/test_time_series_sp_detection.py
+++ b/tests/benchmarks/test_time_series_sp_detection.py
@@ -1,0 +1,29 @@
+"""Module to benchmark auto detection of time series seasonal period
+"""
+from pycaret.datasets import get_data
+from pycaret.time_series import TSForecastingExperiment
+
+
+def test_benchmark_sp_to_use_using_auto():
+    """Benchmark auto detection of seasonal periods. Any future changes must
+    beat this benchmark."""
+
+    properties = get_data("index", folder="time_series/seasonal", verbose=False)
+    properties[["index", "s"]]
+    detected_sp = []
+
+    exp = TSForecastingExperiment()
+    for _, (index, _) in enumerate(properties[["index", "s"]].values):
+        y = get_data(index, folder="time_series/seasonal", verbose=False)
+        exp.setup(data=y, session_id=index)
+        detected_sp.append(exp.primary_sp_to_use)
+    properties["detected_sp"] = detected_sp
+    properties["equal"] = properties["s"] == properties["detected_sp"]
+    properties["multiple"] = properties["detected_sp"] % properties["s"] == 0
+
+    per_correct = len(properties.query("equal == True")) / len(properties)
+    per_correct_multiple = len(properties.query("multiple == True")) / len(properties)
+
+    # Current benchmark to beat ----
+    assert per_correct > 0.8076  # 0.9211
+    assert per_correct_multiple > 0.8173  # 0.9307

--- a/tests/benchmarks/test_time_series_sp_detection.py
+++ b/tests/benchmarks/test_time_series_sp_detection.py
@@ -25,5 +25,5 @@ def test_benchmark_sp_to_use_using_auto():
     per_correct_multiple = len(properties.query("multiple == True")) / len(properties)
 
     # Current benchmark to beat ----
-    assert per_correct > 0.8076  # 0.9211
-    assert per_correct_multiple > 0.8173  # 0.9307
+    assert per_correct > 0.9211  # 0.8076
+    assert per_correct_multiple > 0.9307  # 0.8173

--- a/tests/test_time_series_exogenous.py
+++ b/tests/test_time_series_exogenous.py
@@ -37,9 +37,7 @@ def test_create_tune_predict_finalize_model(load_uni_exo_data_target):
     future_exog = future_data.drop(columns=target)
 
     exp = TSForecastingExperiment()
-    exp.setup(
-        data=data_for_modeling, target=target, fh=fh, seasonal_period=4, session_id=42
-    )
+    exp.setup(data=data_for_modeling, target=target, fh=fh, session_id=42)
 
     #######################
     # Test Create Model ##
@@ -108,7 +106,6 @@ def test_blend_models(load_uni_exo_data_target, load_models_uni_mix_exo_noexo):
         data=data_for_modeling,
         target=target,
         fh=fh,
-        seasonal_period=4,
         enforce_exogenous=False,
         session_id=42,
     )
@@ -149,21 +146,21 @@ def test_setup():
     exogenous_present = TSExogenousPresent.NO
 
     # Case 1: pd.Series ----
-    exp.setup(data=data[target], seasonal_period=1)
+    exp.setup(data=data[target])
     assert exp.approach_type == approach_type
     assert exp.exogenous_present == exogenous_present
     assert exp.target_param == target
     assert exp.exogenous_variables == []
 
     # Case 2: pd.DataFrame with 1 column ----
-    exp.setup(data=pd.DataFrame(data[target]), seasonal_period=1)
+    exp.setup(data=pd.DataFrame(data[target]))
     assert exp.approach_type == approach_type
     assert exp.exogenous_present == exogenous_present
     assert exp.target_param == target
     assert exp.exogenous_variables == []
 
     # Case 3: # Target specified & correct ----
-    exp.setup(data=data[target], target=target, seasonal_period=1)
+    exp.setup(data=data[target], target=target)
     assert exp.approach_type == approach_type
     assert exp.exogenous_present == exogenous_present
     assert exp.target_param == target
@@ -176,7 +173,7 @@ def test_setup():
     exogenous_present = TSExogenousPresent.YES
 
     # Case 1: `target` provided, `index` not provided, `ignore_features` not provided ----
-    exp.setup(data=data, target=target, seasonal_period=1)
+    exp.setup(data=data, target=target)
     assert exp.approach_type == approach_type
     assert exp.exogenous_present == exogenous_present
     assert exp.target_param == target
@@ -199,7 +196,7 @@ def test_setup():
     # TODO: Add check for index values
 
     # Case 4: `target` provided, `index` not provided, `ignore_features` provided ----
-    exp.setup(data=data, target=target, ignore_features=["C", "E"], seasonal_period=1)
+    exp.setup(data=data, target=target, ignore_features=["C", "E"])
     assert exp.approach_type == approach_type
     assert exp.exogenous_present == exogenous_present
     assert exp.target_param == target
@@ -218,7 +215,7 @@ def test_setup_raises():
     # Target Not Specified ####
     ##############################
     with pytest.raises(ValueError) as errmsg:
-        exp.setup(data=data, seasonal_period=1)
+        exp.setup(data=data)
 
     exceptionmsg = errmsg.value.args[0]
 
@@ -236,7 +233,7 @@ def test_setup_raises():
     # Case 1: Without exogenous ----
     column = "A"
     with pytest.raises(ValueError) as errmsg:
-        exp.setup(data=data[column], target=target, seasonal_period=1)
+        exp.setup(data=data[column], target=target)
 
     exceptionmsg = errmsg.value.args[0]
 
@@ -248,7 +245,7 @@ def test_setup_raises():
 
     # Case 2: With exogenous ----
     with pytest.raises(ValueError) as errmsg:
-        exp.setup(data=data, target=target, seasonal_period=1)
+        exp.setup(data=data, target=target)
 
     exceptionmsg = errmsg.value.args[0]
     assert exceptionmsg == f"Target Column '{target}' is not present in the data."

--- a/tests/test_time_series_feat_eng.py
+++ b/tests/test_time_series_feat_eng.py
@@ -99,7 +99,7 @@ def test_fe_exogenous(load_uni_exo_data_target, model, expected_equal):
 
     # Baseline
     exp = TSForecastingExperiment()
-    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    exp.setup(data=data, target=target, fh=fh, session_id=42)
     features1 = exp.get_config("X_transformed").columns
     _ = exp.create_model(model)
     metrics1 = exp.pull()
@@ -110,7 +110,6 @@ def test_fe_exogenous(load_uni_exo_data_target, model, expected_equal):
         data=data,
         target=target,
         fh=fh,
-        seasonal_period=4,
         fe_exogenous=fe_exogenous,
         session_id=42,
     )

--- a/tests/test_time_series_indices.py
+++ b/tests/test_time_series_indices.py
@@ -54,7 +54,7 @@ def test_time_series_indices():
     exp = TSForecastingExperiment()
     data = get_data("airline")
     data.reset_index(drop=True, inplace=True)
-    exp.setup(data=data, fh=12, fold=2, seasonal_period=12, session_id=42)
+    exp.setup(data=data, fh=12, fold=2, session_id=42)
     create_models(exp)
 
     #######################
@@ -100,7 +100,6 @@ def test_time_series_indices():
         data=data,
         target="gdp_change",
         ignore_features=["date"],
-        seasonal_period=4,
         fh=2,
         fold=2,
         session_id=42,

--- a/tests/test_time_series_metrics.py
+++ b/tests/test_time_series_metrics.py
@@ -153,7 +153,6 @@ def test_metrics_with_missing_values_exo():
         data=data,
         target=target,
         fh=FH,
-        seasonal_period=4,
         session_id=42,
         numeric_imputation_target="drift",
         numeric_imputation_exogenous="drift",

--- a/tests/test_time_series_plots.py
+++ b/tests/test_time_series_plots.py
@@ -47,14 +47,13 @@ _all_plots_estimator_ts_results = _return_all_plots_estimator_ts_results()
 
 @pytest.mark.parametrize("data", _data_with_without_period_index)
 @pytest.mark.parametrize("plot", _ALL_PLOTS_DATA)
-def testplot_model_data(data, plot):
+def test_plot_model_data(data, plot):
     """Tests the plot_model functionality on original dataset
     NOTE: Want to show multiplicative plot here so can not take data with negative values
     """
     exp = TSForecastingExperiment()
     fh = np.arange(1, 13)
     fold = 2
-    sp = 1 if isinstance(data.index, pd.RangeIndex) else None
 
     ######################
     # OOP Approach ####
@@ -67,7 +66,6 @@ def testplot_model_data(data, plot):
         fold_strategy="sliding",
         verbose=False,
         session_id=42,
-        seasonal_period=sp,
     )
 
     exp.plot_model(plot=plot)
@@ -84,7 +82,6 @@ def testplot_model_data(data, plot):
         fold_strategy="expanding",
         session_id=42,
         n_jobs=-1,
-        seasonal_period=sp,
     )
     plot_model(plot=plot)
 
@@ -92,7 +89,7 @@ def testplot_model_data(data, plot):
 @pytest.mark.parametrize("model_name", _model_names_for_plots)
 @pytest.mark.parametrize("data", _data_with_without_period_index)
 @pytest.mark.parametrize("plot", _ALL_PLOTS_ESTIMATOR)
-def testplot_model_estimator(model_name, data, plot):
+def test_plot_model_estimator(model_name, data, plot):
     """Tests the plot_model functionality on estimators
     NOTE: Want to show multiplicative plot here so can not take data with negative values
     """
@@ -100,8 +97,6 @@ def testplot_model_estimator(model_name, data, plot):
 
     fh = np.arange(1, 13)
     fold = 2
-
-    sp = 1 if isinstance(data.index, pd.RangeIndex) else None
 
     ######################
     # OOP Approach ####
@@ -114,7 +109,6 @@ def testplot_model_estimator(model_name, data, plot):
         fold_strategy="sliding",
         verbose=False,
         session_id=42,
-        seasonal_period=sp,
     )
 
     model = exp.create_model(model_name)
@@ -132,14 +126,13 @@ def testplot_model_estimator(model_name, data, plot):
         fold_strategy="expanding",
         session_id=42,
         n_jobs=-1,
-        seasonal_period=sp,
     )
     model = create_model(model_name)
     plot_model(estimator=model, plot=plot)
 
 
 @pytest.mark.parametrize("plot", _ALL_PLOTS_ESTIMATOR_NOT_DATA)
-def testplot_model_data_raises(load_pos_and_neg_data, plot):
+def test_plot_model_data_raises(load_pos_and_neg_data, plot):
     """Tests the plot_model functionality when it raises an exception
     on data plots (i.e. estimator is not passed)
     """
@@ -175,7 +168,7 @@ def testplot_model_data_raises(load_pos_and_neg_data, plot):
 
 
 @pytest.mark.parametrize("data", _data_with_without_period_index)
-def testplot_model_customization(data):
+def test_plot_model_customization(data):
     """Tests the customization of plot_model
     NOTE: Want to show multiplicative plot here so can not take data with negative values
     """
@@ -184,8 +177,6 @@ def testplot_model_customization(data):
     fh = np.arange(1, 13)
     fold = 2
 
-    sp = 1 if isinstance(data.index, pd.RangeIndex) else None
-
     exp.setup(
         data=data,
         fh=fh,
@@ -193,7 +184,6 @@ def testplot_model_customization(data):
         fold_strategy="sliding",
         verbose=False,
         session_id=42,
-        seasonal_period=sp,
     )
 
     model = exp.create_model("naive")
@@ -218,7 +208,7 @@ def testplot_model_customization(data):
 
 @pytest.mark.parametrize("data", _data_with_without_period_index)
 @pytest.mark.parametrize("plot", _ALL_PLOTS_DATA)
-def testplot_model_return_data_original_data(data, plot):
+def test_plot_model_return_data_original_data(data, plot):
     """Tests whether the return_data parameter of the plot_model function works
     properly or not for the original data
     """
@@ -227,8 +217,6 @@ def testplot_model_return_data_original_data(data, plot):
     fh = np.arange(1, 13)
     fold = 2
 
-    sp = 1 if isinstance(data.index, pd.RangeIndex) else None
-
     exp.setup(
         data=data,
         fh=fh,
@@ -236,7 +224,6 @@ def testplot_model_return_data_original_data(data, plot):
         fold_strategy="sliding",
         verbose=False,
         session_id=42,
-        seasonal_period=sp,
     )
 
     plot_data = exp.plot_model(plot=plot, return_data=True)
@@ -248,7 +235,7 @@ def testplot_model_return_data_original_data(data, plot):
 @pytest.mark.parametrize("data", _data_with_without_period_index)
 @pytest.mark.parametrize("model_name", _model_names_for_plots)
 @pytest.mark.parametrize("plot", _ALL_PLOTS_ESTIMATOR)
-def testplot_model_return_data_estimator(data, model_name, plot):
+def test_plot_model_return_data_estimator(data, model_name, plot):
     """Tests whether the return_data parameter of the plot_model function works
     properly or not for the estimator
     """
@@ -257,8 +244,6 @@ def testplot_model_return_data_estimator(data, model_name, plot):
     fh = np.arange(1, 13)
     fold = 2
 
-    sp = 1 if isinstance(data.index, pd.RangeIndex) else None
-
     exp.setup(
         data=data,
         fh=fh,
@@ -266,7 +251,6 @@ def testplot_model_return_data_estimator(data, model_name, plot):
         fold_strategy="sliding",
         verbose=False,
         session_id=42,
-        seasonal_period=sp,
     )
 
     model = exp.create_model(model_name)

--- a/tests/test_time_series_plots.py
+++ b/tests/test_time_series_plots.py
@@ -3,7 +3,6 @@
 import os
 
 import numpy as np  # type: ignore
-import pandas as pd  # type: ignore
 import pytest
 from time_series_test_utils import (
     _ALL_PLOTS_DATA,

--- a/tests/test_time_series_preprocess.py
+++ b/tests/test_time_series_preprocess.py
@@ -113,7 +113,7 @@ def test_pipeline_types_exo(load_uni_exo_data_target):
     exp = TSForecastingExperiment()
 
     # Default
-    exp.setup(data=data, target=target, seasonal_period=4)
+    exp.setup(data=data, target=target)
     assert isinstance(exp.pipeline, ForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
@@ -121,7 +121,6 @@ def test_pipeline_types_exo(load_uni_exo_data_target):
     exp.setup(
         data=data,
         target=target,
-        seasonal_period=4,
         numeric_imputation_target=True,
     )
     assert isinstance(exp.pipeline, ForecastingPipeline)
@@ -131,7 +130,6 @@ def test_pipeline_types_exo(load_uni_exo_data_target):
     exp.setup(
         data=data,
         target=target,
-        seasonal_period=4,
         numeric_imputation_exogenous=True,
     )
     assert isinstance(exp.pipeline, ForecastingPipeline)
@@ -141,7 +139,6 @@ def test_pipeline_types_exo(load_uni_exo_data_target):
     exp.setup(
         data=data,
         target=target,
-        seasonal_period=4,
         numeric_imputation_target=True,
         numeric_imputation_exogenous=True,
     )
@@ -149,7 +146,7 @@ def test_pipeline_types_exo(load_uni_exo_data_target):
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
     # No preprocessing (still sets empty pipeline internally)
-    exp.setup(data=data, target=target, seasonal_period=4)
+    exp.setup(data=data, target=target)
     assert isinstance(exp.pipeline, ForecastingPipeline)
     assert isinstance(exp.pipeline.steps[-1][1], TransformedTargetForecaster)
 
@@ -180,7 +177,7 @@ def test_preprocess_setup_raises_missing_exo(load_uni_exo_data_target_missing):
 
     exp = TSForecastingExperiment()
     with pytest.raises(ValueError) as errmsg:
-        exp.setup(data=data, target=target, seasonal_period=4)
+        exp.setup(data=data, target=target)
     exceptionmsg = errmsg.value.args[0]
     assert "Please enable imputation to proceed" in exceptionmsg
 
@@ -189,7 +186,6 @@ def test_preprocess_setup_raises_missing_exo(load_uni_exo_data_target_missing):
         exp.setup(
             data=data,
             target=target,
-            seasonal_period=4,
             numeric_imputation_target=None,
         )
     exceptionmsg = errmsg.value.args[0]
@@ -200,7 +196,6 @@ def test_preprocess_setup_raises_missing_exo(load_uni_exo_data_target_missing):
         exp.setup(
             data=data,
             target=target,
-            seasonal_period=4,
             numeric_imputation_exogenous=None,
         )
     exceptionmsg = errmsg.value.args[0]
@@ -244,7 +239,6 @@ def test_preprocess_setup_raises_negative_exo(load_uni_exo_data_target, method):
         exp.setup(
             data=data,
             target=target,
-            seasonal_period=4,
             transform_target=method,
         )
     exceptionmsg = errmsg.value.args[0]
@@ -265,7 +259,6 @@ def test_preprocess_setup_raises_negative_exo(load_uni_exo_data_target, method):
         exp.setup(
             data=data,
             target=target,
-            seasonal_period=4,
             transform_exogenous=method,
         )
     exceptionmsg = errmsg.value.args[0]
@@ -326,7 +319,6 @@ def test_pipeline_works_exo(load_uni_exo_data_target_missing, model_name):
         data=data,
         target=target,
         fh=FH,
-        seasonal_period=4,
         numeric_imputation_target="drift",
         numeric_imputation_exogenous="drift",
         enforce_exogenous=False,
@@ -473,7 +465,6 @@ def test_impute_str_exo(load_uni_exo_data_target_missing, method):
         data=data,
         target=target,
         fh=FH,
-        seasonal_period=4,
         numeric_imputation_target=method,
         numeric_imputation_exogenous=method,
     )
@@ -501,7 +492,6 @@ def test_impute_num_exo(load_uni_exo_data_target_missing):
         data=data,
         target=target,
         fh=FH,
-        seasonal_period=4,
         numeric_imputation_target=impute_val,
         numeric_imputation_exogenous=impute_val,
     )
@@ -546,7 +536,6 @@ def test_transform_exo(load_uni_exo_data_target_positive, method):
         data=data,
         target=target,
         fh=FH,
-        seasonal_period=4,
         transform_target=method,
         transform_exogenous=method,
     )
@@ -573,7 +562,6 @@ def test_scale_exo(load_uni_exo_data_target, method):
         data=data,
         target=target,
         fh=FH,
-        seasonal_period=4,
         scale_target=method,
         scale_exogenous=method,
     )
@@ -704,7 +692,6 @@ def test_no_transform_exo(load_uni_exo_data_target_missing):
         data=data,
         target=target,
         fh=FH,
-        seasonal_period=4,
         numeric_imputation_target="mean",
         numeric_imputation_exogenous="mean",
     )

--- a/tests/test_time_series_setup.py
+++ b/tests/test_time_series_setup.py
@@ -172,11 +172,11 @@ def test_enforce_exogenous_exo_data(load_uni_exo_data_target):
     data, target = load_uni_exo_data_target
 
     exp1 = TSForecastingExperiment()
-    exp1.setup(data=data, target=target, seasonal_period=4, enforce_exogenous=True)
+    exp1.setup(data=data, target=target, enforce_exogenous=True)
     num_models1 = len(exp1.models())
 
     exp2 = TSForecastingExperiment()
-    exp2.setup(data=data, target=target, seasonal_period=4, enforce_exogenous=False)
+    exp2.setup(data=data, target=target, enforce_exogenous=False)
     num_models2 = len(exp2.models())
 
     # We know that some models do not offer exogenous variables support, so the
@@ -184,16 +184,16 @@ def test_enforce_exogenous_exo_data(load_uni_exo_data_target):
     assert num_models1 < num_models2
 
 
-def test_seasonal_period_to_use():
+def test_sp_to_use_using_index():
+    """Seasonal Period detection using Indices (used before 3.0.0rc5)."""
 
     exp = TSForecastingExperiment()
-    fh = 12
-
-    # Airline Data with seasonality of 12
     data = get_data("airline", verbose=False)
+
+    # 1.1 Airline Data with seasonality of 12
     exp.setup(
         data=data,
-        fh=fh,
+        sp_detection="index",
         verbose=False,
         session_id=42,
     )
@@ -201,18 +201,23 @@ def test_seasonal_period_to_use():
     assert exp.all_sp_values == [12]
     assert exp.primary_sp_to_use == 12
 
-    # Airline Data with seasonality of M (12), 6
-    data = get_data("airline", verbose=False)
-    exp.setup(data=data, fh=fh, verbose=False, session_id=42, seasonal_period=["M", 6])
+    # 1.2 Airline Data with seasonality of M (12), 6
+    exp.setup(
+        data=data,
+        sp_detection="index",
+        verbose=False,
+        session_id=42,
+        seasonal_period=["M", 6],
+    )
     assert exp.seasonal_period == [12, 6]
     assert exp.all_sp_values == [12, 6]
     assert exp.primary_sp_to_use == 12
 
-    # White noise Data with seasonality of 12
+    # 1.3 White noise Data with seasonality of 12
     data = get_data("1", folder="time_series/white_noise", verbose=False)
     exp.setup(
         data=data,
-        fh=fh,
+        sp_detection="index",
         seasonal_period=12,
         verbose=False,
         session_id=42,
@@ -222,6 +227,49 @@ def test_seasonal_period_to_use():
     assert exp.seasonal_period == 12
     assert exp.all_sp_values == [1]
     assert exp.primary_sp_to_use == 1
+
+
+def test_sp_to_use_using_auto():
+    """Seasonal Period detection using Statistical tests (used on and after 3.0.0rc5)."""
+
+    exp = TSForecastingExperiment()
+    data = get_data("airline", verbose=False)
+
+    # 1.1 Auto Detection of Seasonal Period ----
+    exp.setup(
+        data=data,
+        sp_detection="auto",
+        verbose=False,
+        session_id=42,
+    )
+    assert exp.seasonal_period == [12, 24, 36, 11, 48]
+    assert exp.all_sp_values == [12]
+    assert exp.primary_sp_to_use == 12
+
+    # 1.2 Auto Detection with multiple values allowed ----
+    # 1.2.1 Multiple Seasonalities < tested and detected ----
+    exp.setup(
+        data=data,
+        sp_detection="auto",
+        multiple_sp_to_use=2,
+        verbose=False,
+        session_id=42,
+    )
+    assert exp.seasonal_period == [12, 24, 36, 11, 48]
+    assert exp.all_sp_values == [12, 11]
+    assert exp.primary_sp_to_use == 12
+
+    # 1.2.2 Multiple Seasonalities > tested and detected ----
+    exp.setup(
+        data=data,
+        sp_detection="auto",
+        multiple_sp_to_use=100,
+        verbose=False,
+        session_id=42,
+    )
+    assert exp.seasonal_period == [12, 24, 36, 11, 48]
+    assert exp.all_sp_values == [12, 11]
+    assert exp.primary_sp_to_use == 12
 
 
 @pytest.mark.parametrize("seasonal_key, seasonal_value", _get_seasonal_values())
@@ -512,7 +560,7 @@ def test_train_test_split_uni_exo(load_uni_exo_data_target):
     # Integer fh ----
     exp = TSForecastingExperiment()
     fh = 12
-    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    exp.setup(data=data, target=target, fh=fh, session_id=42)
     assert np.all(exp.dataset.index == data.index)
     assert np.all(exp.train.index == data.iloc[: (len(data) - fh)].index)
     assert np.all(exp.test.index == data.iloc[-fh:].index)
@@ -535,7 +583,7 @@ def test_train_test_split_uni_exo(load_uni_exo_data_target):
     # Numpy fh ----
     exp = TSForecastingExperiment()
     fh = np.arange(1, 10)  # 9 values
-    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    exp.setup(data=data, target=target, fh=fh, session_id=42)
     assert np.all(exp.dataset.index == data.index)
     assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
     assert np.all(exp.test.index == data.iloc[-len(fh) :].index)
@@ -564,7 +612,7 @@ def test_train_test_split_uni_exo(load_uni_exo_data_target):
     # List fh ----
     exp = TSForecastingExperiment()
     fh = [1, 2, 3, 4, 5, 6]
-    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    exp.setup(data=data, target=target, fh=fh, session_id=42)
     assert np.all(exp.dataset.index == data.index)
     assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
     assert np.all(exp.test.index == data.iloc[-len(fh) :].index)
@@ -597,7 +645,7 @@ def test_train_test_split_uni_exo(load_uni_exo_data_target):
     # Numpy fh ----
     exp = TSForecastingExperiment()
     fh = np.arange(7, 13)  # 6 values
-    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    exp.setup(data=data, target=target, fh=fh, session_id=42)
     assert np.all(exp.dataset.index == data.index)
     assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
     # `test`` call still refers to y_test indices and not X_test indices
@@ -620,7 +668,7 @@ def test_train_test_split_uni_exo(load_uni_exo_data_target):
     # List fh ----
     exp = TSForecastingExperiment()
     fh = [4, 5, 6]
-    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    exp.setup(data=data, target=target, fh=fh, session_id=42)
     assert np.all(exp.dataset.index == data.index)
     assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
     # `test`` call still refers to y_test indices and not X_test indices
@@ -647,7 +695,7 @@ def test_train_test_split_uni_exo(load_uni_exo_data_target):
     # Numpy fh ----
     exp = TSForecastingExperiment()
     fh = np.array([4, 5, 6, 10, 11, 12])  # 6 values
-    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    exp.setup(data=data, target=target, fh=fh, session_id=42)
     assert np.all(exp.dataset.index == data.index)
     assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
     # `test`` call still refers to y_test indices and not X_test indices
@@ -679,7 +727,7 @@ def test_train_test_split_uni_exo(load_uni_exo_data_target):
     # List fh ----
     exp = TSForecastingExperiment()
     fh = [4, 5, 6, 10, 11, 12]
-    exp.setup(data=data, target=target, fh=fh, seasonal_period=4, session_id=42)
+    exp.setup(data=data, target=target, fh=fh, session_id=42)
     assert np.all(exp.dataset.index == data.index)
     assert np.all(exp.train.index == data.iloc[: (len(data) - max(fh))].index)
     # `test`` call still refers to y_test indices and not X_test indices

--- a/tests/test_time_series_setup.py
+++ b/tests/test_time_series_setup.py
@@ -256,7 +256,7 @@ def test_sp_to_use_using_auto():
         session_id=42,
     )
     assert exp.seasonal_period == [12, 24, 36, 11, 48]
-    assert exp.all_sp_values == [12, 11]
+    assert exp.all_sp_values == [12, 24]
     assert exp.primary_sp_to_use == 12
 
     # 1.2.2 Multiple Seasonalities > tested and detected ----
@@ -268,7 +268,7 @@ def test_sp_to_use_using_auto():
         session_id=42,
     )
     assert exp.seasonal_period == [12, 24, 36, 11, 48]
-    assert exp.all_sp_values == [12, 11]
+    assert exp.all_sp_values == [12, 24, 36, 11, 48]
     assert exp.primary_sp_to_use == 12
 
 

--- a/tests/test_time_series_utils_forecasting_pipeline.py
+++ b/tests/test_time_series_utils_forecasting_pipeline.py
@@ -117,7 +117,6 @@ def test_get_imputed_data_exo(load_uni_exo_data_target_missing):
         data=data,
         target=target,
         fh=FH,
-        seasonal_period=4,
         numeric_imputation_target="drift",
         numeric_imputation_exogenous="drift",
     )
@@ -131,7 +130,6 @@ def test_get_imputed_data_exo(load_uni_exo_data_target_missing):
         data=data,
         target=target,
         fh=FH,
-        seasonal_period=4,
         numeric_imputation_target="drift",
         numeric_imputation_exogenous="drift",
         transform_target="exp",
@@ -153,7 +151,7 @@ def test_get_imputed_data_exo(load_uni_exo_data_target_missing):
     X_no_miss = data_no_miss.drop(columns=target)
 
     # 2A: Missing Values not Present: No imputation step in Pipeline ----
-    exp.setup(data=data_no_miss, target=target, fh=FH, seasonal_period=4)
+    exp.setup(data=data_no_miss, target=target, fh=FH)
     y_imputed, X_imputed = _get_imputed_data(
         pipeline=exp.pipeline, y=y_no_miss, X=X_no_miss
     )
@@ -165,7 +163,6 @@ def test_get_imputed_data_exo(load_uni_exo_data_target_missing):
         data=data_no_miss,
         target=target,
         fh=FH,
-        seasonal_period=4,
         numeric_imputation_target="drift",
         numeric_imputation_exogenous="drift",
     )
@@ -180,7 +177,6 @@ def test_get_imputed_data_exo(load_uni_exo_data_target_missing):
         data=data_no_miss,
         target=target,
         fh=FH,
-        seasonal_period=4,
         numeric_imputation_target="drift",
         numeric_imputation_exogenous="drift",
         transform_target="exp",
@@ -249,7 +245,6 @@ def test_are_pipeline_tansformations_empty_exo(load_uni_exo_data_target_missing)
         data=data,
         target=target,
         fh=FH,
-        seasonal_period=4,
         numeric_imputation_target="drift",
         numeric_imputation_exogenous="drift",
     )
@@ -263,7 +258,6 @@ def test_are_pipeline_tansformations_empty_exo(load_uni_exo_data_target_missing)
         data=data_no_miss,
         target=target,
         fh=FH,
-        seasonal_period=4,
         numeric_imputation_target="drift",
     )
     assert not _transformations_present_X(pipeline=exp.pipeline)
@@ -276,7 +270,6 @@ def test_are_pipeline_tansformations_empty_exo(load_uni_exo_data_target_missing)
         data=data_no_miss,
         target=target,
         fh=FH,
-        seasonal_period=4,
         numeric_imputation_exogenous="drift",
     )
     assert _transformations_present_X(pipeline=exp.pipeline)
@@ -288,7 +281,7 @@ def test_are_pipeline_tansformations_empty_exo(load_uni_exo_data_target_missing)
     ###########################
 
     # 2A: No Imputation in Pipeline ----
-    exp.setup(data=data_no_miss, target=target, fh=FH, seasonal_period=4)
+    exp.setup(data=data_no_miss, target=target, fh=FH)
     assert not _transformations_present_X(pipeline=exp.pipeline)
     assert not _transformations_present_y(pipeline=exp.pipeline)
     assert _are_pipeline_tansformations_empty(pipeline=exp.pipeline)
@@ -363,12 +356,7 @@ def test_add_model_to_pipeline_exo(load_uni_exo_data_target):
     # 1: Empty Pipeline ####
     ###########################
 
-    exp.setup(
-        data=data,
-        target=target,
-        fh=FH,
-        seasonal_period=4,
-    )
+    exp.setup(data=data, target=target, fh=FH)
 
     # Check that the final model has changed ----
     assert isinstance(exp.pipeline.steps[-1][1].steps[-1][1], DummyForecaster)
@@ -394,7 +382,6 @@ def test_add_model_to_pipeline_exo(load_uni_exo_data_target):
         data=data,
         target=target,
         fh=FH,
-        seasonal_period=4,
         numeric_imputation_target="drift",
         numeric_imputation_exogenous="drift",
     )

--- a/tests/time_series_test_utils.py
+++ b/tests/time_series_test_utils.py
@@ -145,11 +145,7 @@ def _return_model_names():
     """Return all model names."""
     data = get_data("airline")
     exp = TSForecastingExperiment()
-    exp.setup(
-        data=data,
-        seasonal_period=2,
-        session_id=42,
-    )
+    exp.setup(data=data, session_id=42)
     model_containers = get_all_ts_model_containers(exp)
 
     models_to_ignore = (


### PR DESCRIPTION
# Related Issue or bug

Closes #2175
Closes #1408

# Describe the changes you've made

- Added the ability in time series to automatically detect the seasonal period. This is an important enhancement since it will not longer need users to enter a seasonal period when the index is not of type `PeriodIindex` or `DateTimeIndex`. Also removes the reliance on the index frequency to set the seasonal period by default and switches to using statistical tests instead.
- Added a benchmarking module in unit tests. 
  - Currently, it includes benchmarks for time series seasonal period autodetection.
  - Later, we could add benchmarks for regression, classification, etc. as well.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Unit tests have been added
- Benchmarks tests have been added

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

