### PR TITLE
Added ability to filter out harmonics in seasonal detection

### DIFF
--- a/pycaret/containers/models/time_series.py
+++ b/pycaret/containers/models/time_series.py
@@ -1113,7 +1113,7 @@ class TBATSContainer(TimeSeriesContainer):
         if not self.active:
             return
 
-        self.sp = experiment.all_sp_values
+        self.sp = experiment.all_sps_to_use
 
         self.seasonality_present = experiment.seasonality_present
 
@@ -1242,8 +1242,6 @@ class ProphetContainer(TimeSeriesContainer):
         if not self.active:
             return
 
-        # sp = experiment.seasonal_period
-        # self.sp = sp if sp is not None else 1
         # Disable Prophet if Index is not of allowed type (e.g. if it is RangeIndex)
         allowed_index_types = [pd.PeriodIndex, pd.DatetimeIndex]
         index_type = experiment.index_type

--- a/pycaret/time_series/forecasting/functional.py
+++ b/pycaret/time_series/forecasting/functional.py
@@ -45,7 +45,7 @@ def setup(
     sp_detection: str = "auto",
     max_sp_to_consider: Optional[int] = None,
     remove_harmonics: bool = False,
-    harmonic_order_method: str = "harmonics",
+    harmonic_order_method: str = "harmonic_max",
     num_sps_to_use: int = 1,
     point_alpha: Optional[float] = None,
     coverage: Union[float, List[float]] = 0.9,
@@ -320,21 +320,21 @@ def setup(
         use for modeling.
 
 
-    harmonic_order_method: str, default = "harmonics"
+    harmonic_order_method: str, default = "harmonic_max"
         Applicable when remove_harmonics = True. This determines how the harmonics
         are replaced. Allowed values are "harmonic_strength", "harmonic_max" or "raw_strength.
-        - If set to  "harmonic_strength", then lower seasonal period is replaced by its
-        highest strength harmonic seasonal period in same position as the lower seasonal period.
         - If set to  "harmonic_max", then lower seasonal period is replaced by its
         highest harmonic seasonal period in same position as the lower seasonal period.
+        - If set to  "harmonic_strength", then lower seasonal period is replaced by its
+        highest strength harmonic seasonal period in same position as the lower seasonal period.
         - If set to  "raw_strength", then lower seasonal periods is removed and the
         higher harmonic seasonal periods is retained in its original position
         based on its seasonal strength.
 
         e.g. Assuming detected seasonal periods in strength order are [2, 3, 4, 50]
         and remove_harmonics = True, then:
-        - If harmonic_order_method = "harmonic_strength", result = [4, 3, 50]
         - If harmonic_order_method = "harmonic_max", result = [50, 3, 4]
+        - If harmonic_order_method = "harmonic_strength", result = [4, 3, 50]
         - If harmonic_order_method = "raw_strength", result = [3, 4, 50]
 
 

--- a/pycaret/time_series/forecasting/functional.py
+++ b/pycaret/time_series/forecasting/functional.py
@@ -43,7 +43,7 @@ def setup(
     fh: Optional[Union[List[int], int, np.ndarray, "ForecastingHorizon"]] = 1,
     seasonal_period: Optional[Union[List[Union[int, str]], int, str]] = None,
     sp_detection: str = "auto",
-    multiple_sp_to_use: int = 1,
+    max_sps_to_use: int = 1,
     point_alpha: Optional[float] = None,
     coverage: Union[float, List[float]] = 0.9,
     enforce_exogenous: bool = True,
@@ -83,7 +83,7 @@ def setup(
     data_func: Callable[[], Union[pd.Series, pd.DataFrame]] = None
             The function that generate ``data`` (the dataframe-like input). This
             is useful when the dataset is large, and you need parallel operations
-            such as ``compare_models``. It can avoid boradcasting large dataset
+            such as ``compare_models``. It can avoid broadcasting large dataset
             from driver to workers. Notice one and only one of ``data`` and
             ``data_func`` must be set.
 
@@ -273,8 +273,8 @@ def setup(
 
 
     seasonal_period: list or int or str, default = None
-        Periods to check when performing seasonality checks. If not provided,
-        then seasonal periods are detected per the sp_detection setting.
+        Seasonal periods to check when performing seasonality checks (i.e. candidates).
+        If not provided, then candidates are detected per the sp_detection setting.
 
         Users can provide `seasonal_period` by passing it as an integer or a
         string corresponding to the keys below (e.g. 'W' for weekly data,
@@ -296,7 +296,7 @@ def setup(
         will be used as the seasonal period.
 
 
-    sp_detection: str = "auto"
+    sp_detection: str, default = "auto"
         If seasonal_period is None, then this parameter determines the algorithm
         to use to detect the seasonal periods to use in the models.
 
@@ -307,11 +307,17 @@ def setup(
         period as shown in seasonal_period.
 
 
-    multiple_sp_to_use: int = 1
-        Applicable only when sp_detection is set to "auto". It determines how
-        many seasonal periods to use in the models. If a model only allows one
-        seasonal period and multiple_sp_to_use > 1, then the most dominant
-        (primary) seasonal that is detected is used.
+    remove_harmonics: bool, default = False
+        Should harmonics be removed when considering what seasonal periods to
+        use for modeling.
+
+
+    max_sps_to_use: int, default = 1
+        It determines the maximum number of seasonal periods to use in the models.
+        Set to -1 to use all detected seasonal periods (in models that allow
+        multiple seasonalities). If a model only allows one seasonal period
+        and max_sps_to_use > 1, then the most dominant (primary) seasonal
+        that is detected is used.
 
 
     point_alpha: Optional[float], default = None
@@ -513,7 +519,7 @@ def setup(
         fh=fh,
         seasonal_period=seasonal_period,
         sp_detection=sp_detection,
-        multiple_sp_to_use=multiple_sp_to_use,
+        max_sps_to_use=max_sps_to_use,
         point_alpha=point_alpha,
         coverage=coverage,
         enforce_exogenous=enforce_exogenous,

--- a/pycaret/time_series/forecasting/functional.py
+++ b/pycaret/time_series/forecasting/functional.py
@@ -43,7 +43,7 @@ def setup(
     fh: Optional[Union[List[int], int, np.ndarray, "ForecastingHorizon"]] = 1,
     seasonal_period: Optional[Union[List[Union[int, str]], int, str]] = None,
     sp_detection: str = "auto",
-    max_sps_to_use: int = 1,
+    num_sps_to_use: int = 1,
     point_alpha: Optional[float] = None,
     coverage: Union[float, List[float]] = 0.9,
     enforce_exogenous: bool = True,
@@ -312,11 +312,11 @@ def setup(
         use for modeling.
 
 
-    max_sps_to_use: int, default = 1
+    num_sps_to_use: int, default = 1
         It determines the maximum number of seasonal periods to use in the models.
         Set to -1 to use all detected seasonal periods (in models that allow
         multiple seasonalities). If a model only allows one seasonal period
-        and max_sps_to_use > 1, then the most dominant (primary) seasonal
+        and num_sps_to_use > 1, then the most dominant (primary) seasonal
         that is detected is used.
 
 
@@ -519,7 +519,7 @@ def setup(
         fh=fh,
         seasonal_period=seasonal_period,
         sp_detection=sp_detection,
-        max_sps_to_use=max_sps_to_use,
+        num_sps_to_use=num_sps_to_use,
         point_alpha=point_alpha,
         coverage=coverage,
         enforce_exogenous=enforce_exogenous,

--- a/pycaret/time_series/forecasting/functional.py
+++ b/pycaret/time_series/forecasting/functional.py
@@ -43,6 +43,9 @@ def setup(
     fh: Optional[Union[List[int], int, np.ndarray, "ForecastingHorizon"]] = 1,
     seasonal_period: Optional[Union[List[Union[int, str]], int, str]] = None,
     sp_detection: str = "auto",
+    max_sp_to_consider: Optional[int] = None,
+    remove_harmonics: bool = False,
+    harmonic_order_method: str = "harmonics",
     num_sps_to_use: int = 1,
     point_alpha: Optional[float] = None,
     coverage: Union[float, List[float]] = 0.9,
@@ -307,9 +310,32 @@ def setup(
         period as shown in seasonal_period.
 
 
+    max_sp_to_consider: Optional[int], default = None,
+        Max period to consider when detecting seasonal periods. If None, all
+        periods up to the length of the data are considered.
+
+
     remove_harmonics: bool, default = False
         Should harmonics be removed when considering what seasonal periods to
         use for modeling.
+
+
+    harmonic_order_method: str, default = "harmonics"
+        Applicable when remove_harmonics = True. This determines how the harmonics
+        are replaced. Allowed values are "harmonic_strength", "harmonic_max" or "raw_strength.
+        - If set to  "harmonic_strength", then lower seasonal period is replaced by its
+        highest strength harmonic seasonal period in same position as the lower seasonal period.
+        - If set to  "harmonic_max", then lower seasonal period is replaced by its
+        highest harmonic seasonal period in same position as the lower seasonal period.
+        - If set to  "raw_strength", then lower seasonal periods is removed and the
+        higher harmonic seasonal periods is retained in its original position
+        based on its seasonal strength.
+
+        e.g. Assuming detected seasonal periods in strength order are [2, 3, 4, 50]
+        and remove_harmonics = True, then:
+        - If harmonic_order_method = "harmonic_strength", result = [4, 3, 50]
+        - If harmonic_order_method = "harmonic_max", result = [50, 3, 4]
+        - If harmonic_order_method = "raw_strength", result = [3, 4, 50]
 
 
     num_sps_to_use: int, default = 1
@@ -519,6 +545,9 @@ def setup(
         fh=fh,
         seasonal_period=seasonal_period,
         sp_detection=sp_detection,
+        max_sp_to_consider=max_sp_to_consider,
+        remove_harmonics=remove_harmonics,
+        harmonic_order_method=harmonic_order_method,
         num_sps_to_use=num_sps_to_use,
         point_alpha=point_alpha,
         coverage=coverage,

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -1334,7 +1334,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         sp_detection: str = "auto",
         max_sp_to_consider: Optional[int] = None,
         remove_harmonics: bool = False,
-        harmonic_order_method: str = "harmonics",
+        harmonic_order_method: str = "harmonic_max",
         num_sps_to_use: int = 1,
         point_alpha: Optional[float] = None,
         coverage: Union[float, List[float]] = 0.9,
@@ -1613,21 +1613,21 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             use for modeling.
 
 
-        harmonic_order_method: str, default = "harmonic_strength"
+        harmonic_order_method: str, default = "harmonic_max"
             Applicable when remove_harmonics = True. This determines how the harmonics
             are replaced. Allowed values are "harmonic_strength", "harmonic_max" or "raw_strength.
-            - If set to  "harmonic_strength", then lower seasonal period is replaced by its
-            highest strength harmonic seasonal period in same position as the lower seasonal period.
             - If set to  "harmonic_max", then lower seasonal period is replaced by its
             highest harmonic seasonal period in same position as the lower seasonal period.
+            - If set to  "harmonic_strength", then lower seasonal period is replaced by its
+            highest strength harmonic seasonal period in same position as the lower seasonal period.
             - If set to  "raw_strength", then lower seasonal periods is removed and the
             higher harmonic seasonal periods is retained in its original position
             based on its seasonal strength.
 
             e.g. Assuming detected seasonal periods in strength order are [2, 3, 4, 50]
             and remove_harmonics = True, then:
-            - If harmonic_order_method = "harmonic_strength", result = [4, 3, 50]
             - If harmonic_order_method = "harmonic_max", result = [50, 3, 4]
+            - If harmonic_order_method = "harmonic_strength", result = [4, 3, 50]
             - If harmonic_order_method = "raw_strength", result = [3, 4, 50]
 
 

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -733,7 +733,9 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         ] or [1]
 
         # 3.0 Remove harmonics based on settings ----
-        significant_sps_no_harmonics = remove_harmonics_from_sp(significant_sps, harmonic_order_method=self.harmonic_order_method)
+        significant_sps_no_harmonics = remove_harmonics_from_sp(
+            significant_sps, harmonic_order_method=self.harmonic_order_method
+        )
 
         # 4.0 Limit seasonal periods to use based on settings ----
         if self.remove_harmonics:
@@ -1867,7 +1869,11 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         self.sp_detection = sp_detection
         self.max_sp_to_consider = max_sp_to_consider
         self.remove_harmonics = remove_harmonics
-        if harmonic_order_method not in ["harmonic_strength", "harmonic_max", "raw_strength"]:
+        if harmonic_order_method not in [
+            "harmonic_strength",
+            "harmonic_max",
+            "raw_strength",
+        ]:
             raise ValueError(
                 "harmonic_order_method must be either 'harmonic_strength', 'harmonic_max' "
                 f"or 'raw_strength'. You provided {harmonic_order_method}."

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -66,6 +66,7 @@ from pycaret.utils.time_series import (
     TSExogenousPresent,
     TSModelTypes,
     auto_detect_sp,
+    remove_harmonics_from_sp,
     get_sp_from_str,
 )
 from pycaret.utils.time_series.forecasting import (
@@ -106,10 +107,12 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         self.variable_keys = self.variable_keys.union(
             {
                 "fh",
-                "seasonal_period",
                 "seasonality_present",
+                "candidate_sps",
+                "significant_sps",
+                "significant_sps_no_harmonics",
+                "all_sps_to_use",
                 "primary_sp_to_use",
-                "all_sp_values",
                 "strictly_positive",
                 "enforce_pi",
                 "enforce_exogenous",
@@ -184,11 +187,17 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             ["Fold Number", self.fold_param],
             ["Enforce Prediction Interval", self.enforce_pi],
             ["Seasonality Detection Algo", self.sp_detection],
-            ["Num Seasonalities to Use", self.multiple_sp_to_use],
-            ["Seasonal Period(s) Tested", self.seasonal_period],
-            ["Seasonality Present", self.seasonality_present],
-            ["Seasonalities Detected", self.all_sp_values],
+            ["Seasonal Period(s) Tested", self.candidate_sps],
+            ["Significant Seasonal Period(s)", self.significant_sps],
+            [
+                "Significant Seasonal Period(s) without Harmonics",
+                self.significant_sps_no_harmonics,
+            ],
+            ["Remove Harmonics", self.remove_harmonics],
+            ["Max Seasonalities to Use", self.max_sps_to_use],
+            ["All Seasonalities to Use", self.all_sps_to_use],
             ["Primary Seasonality", self.primary_sp_to_use],
+            ["Seasonality Present", self.seasonality_present],
             ["Target Strictly Positive", self.strictly_positive],
             ["Target White Noise", self.white_noise],
             ["Recommended d", self.lowercase_d],
@@ -647,25 +656,22 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
 
         return self
 
-    def _check_and_set_seasonal_period(
-        self,
-        seasonal_period: Optional[Union[List[Union[int, str]], int, str]],
-    ) -> "TSForecastingExperiment":
-        """Derived the seasonal periods by either
-        (1) Extracting it from data's index (if seasonal period is not provided), or
-        for each value of seasonal_period:
-            (2) Extracting it from the value if it is of type string, or
-            (3) Using the value as is if it is of type int.
+    def _check_and_set_seasonal_period(self) -> "TSForecastingExperiment":
+        """
+        Derive the seasonal periods to use per teh following algorithm
+        (1) Get the candidate seasonal periods
+        (2) Perform seasonal checks to remove periods that do not indicate seasonality
+        (3) Remove harmonics based on user settings
+        (4) Limit max number of seasonal periods to use based on user settings
+        (5) Set the primary seasonal period & other seasonality related class attributes
 
-        After deriving the seasonal periods, a seasonality test is performed for each
-        value of seasonal_period. Final seasonal period class attribute value is set equal to
-        (1) 1 if seasonality is not detected at any of the derived seasonal periods, or
-        (2) the derived seasonal periods for which seasonality is detected.
+        Getting candidate seasonal periods is performed in the following order
+            (1) Use seasonal_period provided by user (str or int)
+            (2) Based on sp_detection
+                (A) If sp_detection = "auto", extracting it using ACF
+                (B) If sp_detection = "index", extracting it from data's index
 
-        Parameters
-        ----------
-        seasonal_period : Optional[Union[List[Union[int, str]], int, str]]
-            Seasonal Period specified by user
+        NOTE: If no seasonality is detected, seasonal period is set to 1
 
         Returns
         -------
@@ -681,52 +687,62 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
 
         skip_autocorrelation_test = False
 
-        # Set the seasonal periods if not provided ----
-        if seasonal_period is None:
-            if self.sp_detection == "auto":
-                _, seasonal_period, _ = auto_detect_sp(y=self.y_transformed)
-                # Test is already done in detection process so we should skip further tests
-                skip_autocorrelation_test = True
-            elif self.sp_detection == "index":
-                seasonal_period = self.data.index.freqstr
-
-        if not isinstance(seasonal_period, list):
-            seasonal_period = [seasonal_period]
-        seasonal_period = [self._convert_sp_to_int(sp) for sp in seasonal_period]
-
-        # check valid seasonal parameter
         # We use y_transformed here instead of y for 2 reasons:
         # (1) Missing values in y will cause issues with this test (seasonality
         #     will not be detected properly).
         # (2) The actual forecaster will see transformed values of y for training.
         #     Hence, these transformed values should be used to determine seasonality.
+
+        # 1.0 Set the candidate seasonal periods based on inputs and settings ----
+        candidate_sps = self.seasonal_period
+        if candidate_sps is None:
+            if self.sp_detection == "auto":
+                _, candidate_sps, _ = auto_detect_sp(y=self.y_transformed)
+                # Test is already done in detection process so we should skip further tests
+                skip_autocorrelation_test = True
+            elif self.sp_detection == "index":
+                candidate_sps = self.data.index.freqstr
+
+        if not isinstance(candidate_sps, list):
+            candidate_sps = [candidate_sps]
+        candidate_sps = [self._convert_sp_to_int(sp) for sp in candidate_sps]
+
+        # 2.0 Filter candidates based on seasonality check if needed (find significant sp values) ----
         if skip_autocorrelation_test:
-            seasonality_test_results = [True for sp in seasonal_period]
+            seasonality_test_results = [True for sp in candidate_sps]
         else:
             seasonality_test_results = [
                 autocorrelation_seasonality_test(self.y_transformed, sp)
-                for sp in seasonal_period
+                for sp in candidate_sps
             ]
         self.seasonality_present = any(seasonality_test_results)
-        sp_values_and_test_result = zip(seasonal_period, seasonality_test_results)
+        sp_values_and_test_result = zip(candidate_sps, seasonality_test_results)
 
-        # What seasonal period should be used for modeling?
-        self.all_sp_values = [
+        significant_sps = [
             sp
             for sp, seasonality_present in sp_values_and_test_result
             if seasonality_present
         ] or [1]
 
-        if self.sp_detection == "auto":
+        # 3.0 Remove harmonics based on settings ----
+        significant_sps_no_harmonics = remove_harmonics_from_sp(significant_sps)
+
+        # 4.0 Limit seasonal periods to use based on settings ----
+        if self.remove_harmonics:
+            all_sps_to_use = significant_sps_no_harmonics.copy()
+        else:
+            all_sps_to_use = significant_sps.copy()
+        if self.max_sps_to_use > 0:
             # If the number of seasonalities detected is > the number of
             # seasonalities allowed by user, then limit it.
-            if len(self.all_sp_values) > self.multiple_sp_to_use:
-                self.all_sp_values = self.all_sp_values[0 : self.multiple_sp_to_use]
+            if len(all_sps_to_use) > self.max_sps_to_use:
+                all_sps_to_use = all_sps_to_use[0 : self.max_sps_to_use]
 
-        self.primary_sp_to_use = self.all_sp_values[0]
-        self.seasonal_period = (
-            seasonal_period[0] if len(seasonal_period) == 1 else seasonal_period
-        )
+        self.candidate_sps = candidate_sps
+        self.significant_sps = significant_sps
+        self.significant_sps_no_harmonics = significant_sps_no_harmonics
+        self.all_sps_to_use = all_sps_to_use
+        self.primary_sp_to_use = self.all_sps_to_use[0]
 
         return self
 
@@ -1306,7 +1322,8 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         fh: Optional[Union[List[int], int, np.ndarray, ForecastingHorizon]] = 1,
         seasonal_period: Optional[Union[List[Union[int, str]], int, str]] = None,
         sp_detection: str = "auto",
-        multiple_sp_to_use: int = 1,
+        remove_harmonics: bool = False,
+        max_sps_to_use: int = 1,
         point_alpha: Optional[float] = None,
         coverage: Union[float, List[float]] = 0.9,
         enforce_exogenous: bool = True,
@@ -1350,7 +1367,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         data_func: Callable[[], Union[pd.Series, pd.DataFrame]] = None
             The function that generate ``data`` (the dataframe-like input). This
             is useful when the dataset is large, and you need parallel operations
-            such as ``compare_models``. It can avoid boradcasting large dataset
+            such as ``compare_models``. It can avoid broadcasting large dataset
             from driver to workers. Notice one and only one of ``data`` and
             ``data_func`` must be set.
 
@@ -1540,8 +1557,8 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
 
 
         seasonal_period: list or int or str, default = None
-            Periods to check when performing seasonality checks. If not provided,
-            then seasonal periods are detected per the sp_detection setting.
+            Seasonal periods to check when performing seasonality checks (i.e. candidates).
+            If not provided, then candidates are detected per the sp_detection setting.
 
             Users can provide `seasonal_period` by passing it as an integer or a
             string corresponding to the keys below (e.g. 'W' for weekly data,
@@ -1563,7 +1580,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             will be used as the seasonal period.
 
 
-        sp_detection: str = "auto"
+        sp_detection: str, default = "auto"
             If seasonal_period is None, then this parameter determines the algorithm
             to use to detect the seasonal periods to use in the models.
 
@@ -1574,11 +1591,17 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             period as shown in seasonal_period.
 
 
-        multiple_sp_to_use: int = 1
-            Applicable only when sp_detection is set to "auto". It determines how
-            many seasonal periods to use in the models. If a model only allows one
-            seasonal period and multiple_sp_to_use > 1, then the most dominant
-            (primary) seasonal that is detected is used.
+        remove_harmonics: bool, default = False
+            Should harmonics be removed when considering what seasonal periods to
+            use for modeling.
+
+
+        max_sps_to_use: int, default = 1
+            It determines the maximum number of seasonal periods to use in the models.
+            Set to -1 to use all detected seasonal periods (in models that allow
+            multiple seasonalities). If a model only allows one seasonal period
+            and max_sps_to_use > 1, then the most dominant (primary) seasonal
+            that is detected is used.
 
 
         point_alpha: Optional[float], default = None
@@ -1801,13 +1824,16 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
         self.fold_strategy = fold_strategy
         self.fold = fold
 
+        # Variables related to seasonal period and detection ----
+        self.seasonal_period = seasonal_period
         if sp_detection not in ["auto", "index"]:
             raise ValueError(
                 "sp_detection must be either 'auto' or 'index'. "
                 f"You provided {sp_detection}."
             )
         self.sp_detection = sp_detection
-        self.multiple_sp_to_use = multiple_sp_to_use
+        self.remove_harmonics = remove_harmonics
+        self.max_sps_to_use = max_sps_to_use
 
         self.log_plots_param = log_plots
         if self.log_plots_param is True:
@@ -1853,7 +1879,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
             # Since the model will see transformed data, these parameters
             # should also be derived from the transformed data.
             ##################################################################
-            ._check_and_set_seasonal_period(seasonal_period=seasonal_period)
+            ._check_and_set_seasonal_period()
             ._set_multiplicative_components()
             ._perform_setup_eda()
             ._setup_display_container()

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -66,8 +66,8 @@ from pycaret.utils.time_series import (
     TSExogenousPresent,
     TSModelTypes,
     auto_detect_sp,
-    remove_harmonics_from_sp,
     get_sp_from_str,
+    remove_harmonics_from_sp,
 )
 from pycaret.utils.time_series.forecasting import (
     PyCaretForecastingHorizonTypes,

--- a/pycaret/utils/time_series/__init__.py
+++ b/pycaret/utils/time_series/__init__.py
@@ -320,7 +320,7 @@ def remove_harmonics_from_sp(
         for i in range(len(significant_freqs) - 1, 0, -1):
             for j in range(i - 1, -1, -1):
                 fraction = (significant_freqs[i] / significant_freqs[j]) % 1
-                if fraction < 0.01 or fraction > 0.99:
+                if fraction < 0.001 or fraction > 0.999:
                     significant_freqs.pop(i)
                     break
 

--- a/pycaret/utils/time_series/__init__.py
+++ b/pycaret/utils/time_series/__init__.py
@@ -308,7 +308,8 @@ def remove_harmonics_from_sp(significant_sps: list) -> list:
                     break
 
     # Convert frequency back to period
-    filtered_sps = [1 / freq for freq in significant_freqs]
+    # Rounding, else there is precision issues
+    filtered_sps = [round(1 / freq, 4) for freq in significant_freqs]
     # Keep order of significance
     significant_sps = [sp for sp in significant_sps if sp in filtered_sps]
     return significant_sps

--- a/tests/benchmarks/test_time_series_sp_detection.py
+++ b/tests/benchmarks/test_time_series_sp_detection.py
@@ -4,16 +4,18 @@ import pytest
 from pycaret.datasets import get_data
 from pycaret.time_series import TSForecastingExperiment
 
+ids = ["raw_strength", "harmonic_max", "harmonic_strength"]
 params = [
-    ("raw_strength", 0.9211, 0.9307, 0.1230, 0.8365),
-    ("harmonic_max", 0.9211, 0.9307, 0.1211, 0.9538),
-    ("harmonic_strength", 0.9211, 0.9307, 0.1230, 0.9480),
+    (ids[0], 0.9211, 0.9307, 0.1230, 0.8365),
+    (ids[1], 0.9211, 0.9307, 0.1211, 0.9538),
+    (ids[2], 0.9211, 0.9307, 0.1230, 0.9480),
 ]
 
 
 @pytest.mark.parametrize(
     "harmonic_order_method, expected_per_correct, expected_per_correct_multiple, expected_per_correct_harmonics, expected_per_correct_multiple_no_harmonics",
     params,
+    ids=ids,
 )
 def test_benchmark_sp_to_use_using_auto(
     harmonic_order_method,

--- a/tests/benchmarks/test_time_series_sp_detection.py
+++ b/tests/benchmarks/test_time_series_sp_detection.py
@@ -1,6 +1,7 @@
 """Module to benchmark auto detection of time series seasonal period
 """
 import pytest
+
 from pycaret.datasets import get_data
 from pycaret.time_series import TSForecastingExperiment
 

--- a/tests/benchmarks/test_time_series_sp_detection.py
+++ b/tests/benchmarks/test_time_series_sp_detection.py
@@ -10,20 +10,70 @@ def test_benchmark_sp_to_use_using_auto():
 
     properties = get_data("index", folder="time_series/seasonal", verbose=False)
     properties[["index", "s"]]
-    detected_sp = []
+    candidate_sps = []
+
+    sig_sps = []
+    all_sps = []
+    primary_sp = []
+
+    sig_sps_no_harmonics = []
+    all_sp_no_harmonics = []
+    primary_sp_no_harmonics = []
 
     exp = TSForecastingExperiment()
     for _, (index, _) in enumerate(properties[["index", "s"]].values):
         y = get_data(index, folder="time_series/seasonal", verbose=False)
         exp.setup(data=y, session_id=index)
-        detected_sp.append(exp.primary_sp_to_use)
-    properties["detected_sp"] = detected_sp
-    properties["equal"] = properties["s"] == properties["detected_sp"]
-    properties["multiple"] = properties["detected_sp"] % properties["s"] == 0
+        candidate_sps.append(exp.candidate_sps)
+
+        sig_sps.append(exp.significant_sps)
+        all_sps.append(exp.all_sps_to_use)
+        primary_sp.append(exp.primary_sp_to_use)
+
+        sig_sps_no_harmonics.append(exp.significant_sps_no_harmonics)
+        all_sp_no_harmonics.append(
+            exp.significant_sps_no_harmonics[0 : len(exp.all_sps_to_use)]
+        )
+        primary_sp_no_harmonics.append(exp.significant_sps_no_harmonics[0])
+
+    properties["candidate_sps"] = candidate_sps
+
+    # 1.0 Test with harmonics included ----
+
+    properties["sig_sps"] = sig_sps
+    properties["all_sps"] = all_sps
+    properties["primary_sp"] = primary_sp
+
+    properties["equal"] = properties["s"] == properties["primary_sp"]
+    properties["multiple"] = properties["primary_sp"] % properties["s"] == 0
 
     per_correct = len(properties.query("equal == True")) / len(properties)
     per_correct_multiple = len(properties.query("multiple == True")) / len(properties)
 
     # Current benchmark to beat ----
-    assert per_correct > 0.9211  # 0.8076
-    assert per_correct_multiple > 0.9307  # 0.8173
+    assert per_correct > 0.9211
+    assert per_correct_multiple > 0.9307
+
+    # 2.0 Test with harmonics excluded ----
+
+    properties["sig_sps_no_harmonics"] = sig_sps_no_harmonics
+    properties["all_sp_no_harmonics"] = all_sp_no_harmonics
+    properties["primary_sp_no_harmonics"] = primary_sp_no_harmonics
+
+    properties["equal_no_harmonics"] = (
+        properties["s"] == properties["primary_sp_no_harmonics"]
+    )
+    properties["multiple_no_harmonics"] = (
+        properties["primary_sp_no_harmonics"] % properties["s"] == 0
+    )
+
+    per_correct_no_harmonics = len(
+        properties.query("equal_no_harmonics == True")
+    ) / len(properties)
+    per_correct_multiple_no_harmonics = len(
+        properties.query("multiple_no_harmonics == True")
+    ) / len(properties)
+
+    # Current benchmark to beat ----
+    assert per_correct_no_harmonics > 0.1192
+    assert per_correct_multiple_no_harmonics > 0.8153

--- a/tests/benchmarks/test_time_series_sp_detection.py
+++ b/tests/benchmarks/test_time_series_sp_detection.py
@@ -75,5 +75,5 @@ def test_benchmark_sp_to_use_using_auto():
     ) / len(properties)
 
     # Current benchmark to beat ----
-    assert per_correct_no_harmonics > 0.1192
-    assert per_correct_multiple_no_harmonics > 0.8153
+    assert per_correct_no_harmonics > 0.1230  # 0.1192
+    assert per_correct_multiple_no_harmonics > 0.8365  # 0.8153

--- a/tests/test_time_series_setup.py
+++ b/tests/test_time_series_setup.py
@@ -197,8 +197,10 @@ def test_sp_to_use_using_index():
         verbose=False,
         session_id=42,
     )
-    assert exp.seasonal_period == 12
-    assert exp.all_sp_values == [12]
+    assert exp.candidate_sps == [12]
+    assert exp.significant_sps == [12]
+    assert exp.significant_sps_no_harmonics == [12]
+    assert exp.all_sps_to_use == [12]
     assert exp.primary_sp_to_use == 12
 
     # 1.2 Airline Data with seasonality of M (12), 6
@@ -208,9 +210,12 @@ def test_sp_to_use_using_index():
         verbose=False,
         session_id=42,
         seasonal_period=["M", 6],
+        max_sps_to_use=-1,
     )
-    assert exp.seasonal_period == [12, 6]
-    assert exp.all_sp_values == [12, 6]
+    assert exp.candidate_sps == [12, 6]
+    assert exp.significant_sps == [12, 6]
+    assert exp.significant_sps_no_harmonics == [12]
+    assert exp.all_sps_to_use == [12, 6]
     assert exp.primary_sp_to_use == 12
 
     # 1.3 White noise Data with seasonality of 12
@@ -224,8 +229,10 @@ def test_sp_to_use_using_index():
     )
 
     # Should get 1 even though we passed 12
-    assert exp.seasonal_period == 12
-    assert exp.all_sp_values == [1]
+    assert exp.candidate_sps == [12]
+    assert exp.significant_sps == [1]
+    assert exp.significant_sps_no_harmonics == [1]
+    assert exp.all_sps_to_use == [1]
     assert exp.primary_sp_to_use == 1
 
 
@@ -242,8 +249,10 @@ def test_sp_to_use_using_auto():
         verbose=False,
         session_id=42,
     )
-    assert exp.seasonal_period == [12, 24, 36, 11, 48]
-    assert exp.all_sp_values == [12]
+    assert exp.candidate_sps == [12, 24, 36, 11, 48]
+    assert exp.significant_sps == [12, 24, 36, 11, 48]
+    assert exp.significant_sps_no_harmonics == [36, 11, 48]
+    assert exp.all_sps_to_use == [12]
     assert exp.primary_sp_to_use == 12
 
     # 1.2 Auto Detection with multiple values allowed ----
@@ -251,24 +260,28 @@ def test_sp_to_use_using_auto():
     exp.setup(
         data=data,
         sp_detection="auto",
-        multiple_sp_to_use=2,
+        max_sps_to_use=2,
         verbose=False,
         session_id=42,
     )
-    assert exp.seasonal_period == [12, 24, 36, 11, 48]
-    assert exp.all_sp_values == [12, 24]
+    assert exp.candidate_sps == [12, 24, 36, 11, 48]
+    assert exp.significant_sps == [12, 24, 36, 11, 48]
+    assert exp.significant_sps_no_harmonics == [36, 11, 48]
+    assert exp.all_sps_to_use == [12, 24]
     assert exp.primary_sp_to_use == 12
 
     # 1.2.2 Multiple Seasonalities > tested and detected ----
     exp.setup(
         data=data,
         sp_detection="auto",
-        multiple_sp_to_use=100,
+        max_sps_to_use=100,
         verbose=False,
         session_id=42,
     )
-    assert exp.seasonal_period == [12, 24, 36, 11, 48]
-    assert exp.all_sp_values == [12, 24, 36, 11, 48]
+    assert exp.candidate_sps == [12, 24, 36, 11, 48]
+    assert exp.significant_sps == [12, 24, 36, 11, 48]
+    assert exp.significant_sps_no_harmonics == [36, 11, 48]
+    assert exp.all_sps_to_use == [12, 24, 36, 11, 48]
     assert exp.primary_sp_to_use == 12
 
 
@@ -290,7 +303,7 @@ def test_setup_seasonal_period_int(load_pos_and_neg_data, seasonal_key, seasonal
         seasonal_period=seasonal_value,
     )
 
-    assert exp.seasonal_period == seasonal_value
+    assert exp.candidate_sps == [seasonal_value]
 
 
 @pytest.mark.parametrize("seasonal_period, seasonal_value", _get_seasonal_values())
@@ -313,7 +326,7 @@ def test_setup_seasonal_period_str(
         seasonal_period=seasonal_period,
     )
 
-    assert exp.seasonal_period == seasonal_value
+    assert exp.candidate_sps == [seasonal_value]
 
 
 @pytest.mark.parametrize(
@@ -327,7 +340,7 @@ def test_setup_seasonal_period_alphanumeric(
     seasonal_period = prefix + seasonal_period
     prefix = int(prefix)
     lcm = abs(seasonal_value * prefix) // math.gcd(seasonal_value, prefix)
-    expected_seasonal_value = int(lcm / prefix)
+    expected_candidate_sps = [int(lcm / prefix)]
 
     exp = TSForecastingExperiment()
 
@@ -344,7 +357,7 @@ def test_setup_seasonal_period_alphanumeric(
         seasonal_period=seasonal_period,
     )
 
-    assert exp.seasonal_period == expected_seasonal_value
+    assert exp.candidate_sps == expected_candidate_sps
 
 
 def test_train_test_split_uni_no_exo(load_pos_and_neg_data):

--- a/tests/test_time_series_setup.py
+++ b/tests/test_time_series_setup.py
@@ -251,7 +251,7 @@ def test_sp_to_use_using_auto():
     )
     assert exp.candidate_sps == [12, 24, 36, 11, 48]
     assert exp.significant_sps == [12, 24, 36, 11, 48]
-    assert exp.significant_sps_no_harmonics == [36, 11, 48]
+    assert exp.significant_sps_no_harmonics == [48, 36, 11]
     assert exp.all_sps_to_use == [12]
     assert exp.primary_sp_to_use == 12
 
@@ -266,7 +266,7 @@ def test_sp_to_use_using_auto():
     )
     assert exp.candidate_sps == [12, 24, 36, 11, 48]
     assert exp.significant_sps == [12, 24, 36, 11, 48]
-    assert exp.significant_sps_no_harmonics == [36, 11, 48]
+    assert exp.significant_sps_no_harmonics == [48, 36, 11]
     assert exp.all_sps_to_use == [12, 24]
     assert exp.primary_sp_to_use == 12
 
@@ -280,7 +280,7 @@ def test_sp_to_use_using_auto():
     )
     assert exp.candidate_sps == [12, 24, 36, 11, 48]
     assert exp.significant_sps == [12, 24, 36, 11, 48]
-    assert exp.significant_sps_no_harmonics == [36, 11, 48]
+    assert exp.significant_sps_no_harmonics == [48, 36, 11]
     assert exp.all_sps_to_use == [12, 24, 36, 11, 48]
     assert exp.primary_sp_to_use == 12
 
@@ -296,7 +296,7 @@ def test_sp_to_use_upto_max_sp():
     )
     assert exp.candidate_sps == [12, 24, 36, 11, 48]
     assert exp.significant_sps == [12, 24, 36, 11, 48]
-    assert exp.significant_sps_no_harmonics == [36, 11, 48]
+    assert exp.significant_sps_no_harmonics == [48, 36, 11]
     assert exp.all_sps_to_use == [12]
     assert exp.primary_sp_to_use == 12
 

--- a/tests/test_time_series_utils.py
+++ b/tests/test_time_series_utils.py
@@ -8,19 +8,63 @@ def test_harmonic_removal():
     results = remove_harmonics_from_sp([2, 51, 5])
     assert results == [2, 51, 5]
 
-    # 2.0 1 base frequency removed ----
+    # 2.0 One base frequency removed ----
     results = remove_harmonics_from_sp([2, 52, 3])
     assert results == [52, 3]
 
-    # 3.0 Remove more than 1 base period ----
+    # 3.0 Remove more than one base period ----
     results = remove_harmonics_from_sp([50, 3, 11, 100, 39])
     assert results == [11, 100, 39]
 
     # 4.0 Order of replacement ----
-    # TODO: Should this return [3, 52] or [52, 3]
-    # Add an option later to have the user select this.
-    results = remove_harmonics_from_sp([2, 3, 52])
-    assert results == [3, 52]
+
+    # 4.1 Only one removed
+    # 4.1A Ordered by raw strength
+    results = remove_harmonics_from_sp([2, 3, 4, 50])
+    assert results == [3, 4, 50]
+    # 4.1B Ordered by harmonic max
+    results = remove_harmonics_from_sp(
+        [2, 3, 4, 50], harmonic_order_method="harmonic_max"
+    )
+    assert results == [50, 3, 4]
+    # 4.1C Ordered by harmonic strength
+    results = remove_harmonics_from_sp(
+        [2, 3, 4, 50], harmonic_order_method="harmonic_strength"
+    )
+    assert results == [4, 3, 50]
+
+    # 4.2 More than one removed
+    # 4.2A Ordered by raw strength
+    results = remove_harmonics_from_sp([3, 2, 6, 50])
+    assert results == [6, 50]
+    # 4.2B Ordered by harmonic max
+    results = remove_harmonics_from_sp(
+        [3, 2, 6, 50], harmonic_order_method="harmonic_max"
+    )
+    assert results == [6, 50]
+    results = remove_harmonics_from_sp(
+        [2, 3, 6, 50], harmonic_order_method="harmonic_max"
+    )
+    assert results == [50, 6]
+    # 4.2C Ordered by harmonic strength
+    results = remove_harmonics_from_sp(
+        [3, 2, 6, 50], harmonic_order_method="harmonic_strength"
+    )
+    assert results == [6, 50]
+    results = remove_harmonics_from_sp(
+        [2, 3, 6, 50], harmonic_order_method="harmonic_strength"
+    )
+    assert results == [6, 50]
+
+    # 4.2D Other variants
+    results = remove_harmonics_from_sp(
+        [10, 20, 30, 40, 50, 60], harmonic_order_method="harmonic_strength"
+    )
+    assert results == [20, 40, 60, 50]
+    results = remove_harmonics_from_sp(
+        [10, 20, 30, 40, 50, 60], harmonic_order_method="harmonic_max"
+    )
+    assert results == [60, 40, 50]
 
     # 5.0 These were giving precision issues earlier. Now fixed by rounding internally. ----
 

--- a/tests/test_time_series_utils.py
+++ b/tests/test_time_series_utils.py
@@ -1,0 +1,37 @@
+from pycaret.utils.time_series import remove_harmonics_from_sp
+
+
+def test_harmonic_removal():
+    """Tests the removal of harmonics"""
+
+    # 1.0 No harmonics removed ----
+    results = remove_harmonics_from_sp([2, 51, 5])
+    assert results == [2, 51, 5]
+
+    # 2.0 1 base frequency removed ----
+    results = remove_harmonics_from_sp([2, 52, 3])
+    assert results == [52, 3]
+
+    # 3.0 Remove more than 1 base period ----
+    results = remove_harmonics_from_sp([50, 3, 11, 100, 39])
+    assert results == [11, 100, 39]
+
+    # 4.0 Order of replacement ----
+    # TODO: Should this return [3, 52] or [52, 3]
+    # Add an option later to have the user select this.
+    results = remove_harmonics_from_sp([2, 3, 52])
+    assert results == [3, 52]
+
+    # 5.0 These were giving precision issues earlier. Now fixed by rounding internally. ----
+
+    # 5.1
+    results = remove_harmonics_from_sp([50, 100, 150, 49, 200, 51, 23, 27, 10, 250])
+    assert results == [150, 49, 200, 51, 23, 27, 250]
+
+    # 5.2
+    results = remove_harmonics_from_sp([49, 98, 18])
+    assert results == [98, 18]
+
+    # 5.3
+    results = remove_harmonics_from_sp([50, 16, 15, 17, 34, 2, 33, 49, 18, 100, 32])
+    assert results == [15, 34, 33, 49, 18, 100, 32]


### PR DESCRIPTION
# Related Issue or bug

* Follow up to https://github.com/pycaret/pycaret/pull/3151
 
# Describe the changes you've made

* This PR allows the ability for the user to filter out the harmonics and only use the base seasonal period (similar to what is done in KATS and what is derived from ACF and Periodograms manually).
* e.g. if seasonal periods detected are 6, 12, 24. Then filtering harmonics will eliminate 6 and 12 since these are already captured by a period of 24. 
* Also cleaned up internal attributes related to seasonality to make them clear.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Tests added to benchmark module (TBD)
- Existing tests updated for attribute name changes


# Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

# Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
