### PR TITLE
Return figure object in case of Streamlit to provide more flexibility

### DIFF
--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -3583,7 +3583,7 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
 
             elif system:
                 if display_format == "streamlit":
-                    st.write(fig)
+                    return fig
                 elif display_format == "plotly-widget":
                     fig.update_layout(autosize=True)
                     ipython_display(


### PR DESCRIPTION
Gives more flexibility on where to place the plot within Streamlit. One can use either `st.plotly_chart(exp.plot_model(*))` or `col.plotly_chart(exp.plot_model(*))` where `col` belongs to instance of `st.columns`

# Related Issue or bug

Info about Issue or bug

Closes #[issue number that will be closed through this PR]

# Describe the changes you've made

A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!

# Type of change

Please delete options that are not relevant.
<!--
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

A clear and concise description of it.

# Checklist:

- [x] I have performed a self-review of my own code.


