### PR TITLE
Fix LightGBM special chars error and unsupervised encoding

### DIFF
--- a/pycaret/anomaly/functional.py
+++ b/pycaret/anomaly/functional.py
@@ -207,7 +207,7 @@ def setup(
     encoding_method: category-encoders estimator, default = None
         A `category-encoders` estimator to encode the categorical columns
         with more than `max_encoding_ohe` unique values. If None,
-        `category_encoders.leave_one_out.LeaveOneOutEncoder` is used.
+        `category_encoders.basen.BaseN` is used.
 
 
     rare_to_value: float or None, default=None

--- a/pycaret/classification/oop.py
+++ b/pycaret/classification/oop.py
@@ -1,6 +1,7 @@
 import datetime
 import gc
 import logging
+import re
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -791,6 +792,10 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
         if preprocess:
             self.logger.info("Preparing preprocessing pipeline...")
 
+            # Remove weird characters from column names
+            if any(re.search("[^A-Za-z0-9_]", col) for col in self.dataset):
+                self._clean_column_names()
+
             # Encode the target column
             y_unique = self.y.unique()
             if sorted(list(y_unique)) != list(range(len(y_unique))):
@@ -903,7 +908,7 @@ class ClassificationExperiment(_SupervisedExperiment, Preprocessor):
             container.append(
                 ["Target mapping", ", ".join([f"{k}: {v}" for k, v in mapping.items()])]
             )
-        container.append(["Original data shape", self.dataset.shape])
+        container.append(["Original data shape", self.data.shape])
         container.append(["Transformed data shape", self.dataset_transformed.shape])
         container.append(["Transformed train set shape", self.train_transformed.shape])
         container.append(["Transformed test set shape", self.test_transformed.shape])

--- a/pycaret/clustering/functional.py
+++ b/pycaret/clustering/functional.py
@@ -206,7 +206,7 @@ def setup(
     encoding_method: category-encoders estimator, default = None
         A `category-encoders` estimator to encode the categorical columns
         with more than `max_encoding_ohe` unique values. If None,
-        `category_encoders.leave_one_out.LeaveOneOutEncoder` is used.
+        `category_encoders.basen.BaseN` is used.
 
 
     rare_to_value: float or None, default=None

--- a/pycaret/internal/preprocess/preprocessor.py
+++ b/pycaret/internal/preprocess/preprocessor.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 
 import numpy as np
 import pandas as pd
+from category_encoders.basen import BaseNEncoder
 from category_encoders.leave_one_out import LeaveOneOutEncoder
 from category_encoders.one_hot import OneHotEncoder
 from category_encoders.ordinal import OrdinalEncoder
@@ -66,6 +67,7 @@ from pycaret.containers.models import (
 )
 from pycaret.internal.preprocess.iterative_imputer import IterativeImputer
 from pycaret.internal.preprocess.transformers import (
+    CleanColumnNames,
     DropImputer,
     EmbedTextFeatures,
     ExtractDateTimeFeatures,
@@ -363,6 +365,13 @@ class Preprocessor:
             self.fold_generator = TimeSeriesSplit(fold)
         else:
             self.fold_generator = fold_strategy
+
+    def _clean_column_names(self):
+        """Add CleanColumnNames to the pipeline."""
+        self.logger.info("Set up column name cleaning.")
+        self.pipeline.steps.append(
+            ("clean_column_names", TransformerWrapper(CleanColumnNames()))
+        )
 
     def _encode_target_column(self):
         """Add LabelEncoder to the pipeline."""
@@ -676,11 +685,18 @@ class Preprocessor:
             # Encode the rest of the categorical columns
             if len(rest_cols) > 0:
                 if not encoding_method:
-                    encoding_method = LeaveOneOutEncoder(
-                        handle_missing="return_nan",
-                        handle_unknown="value",
-                        random_state=self.seed,
-                    )
+                    if self._ml_usecase in (MLUsecase.ANOMALY, MLUsecase.CLUSTERING):
+                        encoding_method = BaseNEncoder(
+                            base=5,
+                            handle_missing="return_nan",
+                            handle_unknown="value",
+                        )
+                    else:
+                        encoding_method = LeaveOneOutEncoder(
+                            handle_missing="return_nan",
+                            handle_unknown="value",
+                            random_state=self.seed,
+                        )
 
                 rest_estimator = TransformerWrapper(
                     transformer=encoding_method,

--- a/pycaret/internal/preprocess/transformers.py
+++ b/pycaret/internal/preprocess/transformers.py
@@ -2,6 +2,7 @@
 # License: MIT
 
 
+import re
 from collections import defaultdict
 from inspect import signature
 
@@ -260,6 +261,19 @@ class TransformerWrapperWithInverse(TransformerWrapper):
         y = to_series(y, index=getattr(y, "index", None))
         output = self.transformer.inverse_transform(y)
         return to_series(output, index=y.index, name=y.name)
+
+
+class CleanColumnNames(BaseEstimator, TransformerMixin):
+    """Remove weird characters from column names."""
+
+    def __init__(self, match="[^A-Za-z0-9_]+"):
+        self.match = match
+
+    def fit(self, X, y=None):
+        return self
+
+    def transform(self, X, y=None):
+        return X.rename(columns=lambda x: re.sub(self.match, "", str(x)))
 
 
 class ExtractDateTimeFeatures(BaseEstimator, TransformerMixin):

--- a/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
@@ -272,7 +272,7 @@ class _UnsupervisedExperiment(_TabularExperiment, Preprocessor):
         encoding_method: category-encoders estimator, default = None
             A `category-encoders` estimator to encode the categorical columns
             with more than `max_encoding_ohe` unique values. If None,
-            `category_encoders.leave_one_out.LeaveOneOutEncoder` is used.
+            `category_encoders.basen.BaseN` is used.
 
 
         rare_to_value: float or None, default=None
@@ -659,7 +659,7 @@ class _UnsupervisedExperiment(_TabularExperiment, Preprocessor):
 
         container = []
         container.append(["Session id", self.seed])
-        container.append(["Original data shape", self.dataset.shape])
+        container.append(["Original data shape", self.data.shape])
         container.append(["Transformed data shape", self.dataset_transformed.shape])
         for fx, cols in self._fxs.items():
             if len(cols) > 0:

--- a/pycaret/regression/oop.py
+++ b/pycaret/regression/oop.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -758,9 +759,9 @@ class RegressionExperiment(_SupervisedExperiment, Preprocessor):
         if preprocess:
             self.logger.info("Preparing preprocessing pipeline...")
 
-            # Encode the target column
-            if self.y.dtype.kind not in "ifu":
-                self._encode_target_column()
+            # Remove weird characters from column names
+            if any(re.search("[^A-Za-z0-9_]", col) for col in self.dataset):
+                self._clean_column_names()
 
             # Power transform the target to be more Gaussian-like
             if transform_target:
@@ -863,9 +864,10 @@ class RegressionExperiment(_SupervisedExperiment, Preprocessor):
         container.append(["Session id", self.seed])
         container.append(["Target", self.target_param])
         container.append(["Target type", "Regression"])
-        container.append(["Data shape", self.dataset_transformed.shape])
-        container.append(["Train data shape", self.train_transformed.shape])
-        container.append(["Test data shape", self.test_transformed.shape])
+        container.append(["Original data shape", self.data.shape])
+        container.append(["Transformed data shape", self.dataset_transformed.shape])
+        container.append(["Transformed train set shape", self.train_transformed.shape])
+        container.append(["Transformed test set shape", self.test_transformed.shape])
         for fx, cols in self._fxs.items():
             if len(cols) > 0:
                 container.append([f"{fx} features", len(cols)])

--- a/pycaret/utils/generic.py
+++ b/pycaret/utils/generic.py
@@ -104,9 +104,8 @@ def to_df(data, index=None, columns=None, dtypes=None):
             if dtypes is not None:
                 data = data.astype(dtypes)
 
-        else:
-            # Convert all column names to str
-            data.columns = [str(col) for col in data.columns]
+        # Convert all column names to str
+        data = data.rename(columns=lambda col: str(col))
 
     return data
 

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -119,6 +119,15 @@ def test_ignore_features():
     assert "Purchase" not in X
 
 
+def test_weird_chars_in_column_names():
+    """Assert that weird characters from column names are dropped."""
+    data = pycaret.datasets.get_data("parkinsons")
+    assert "#" in data.columns[0]
+
+    pc = pycaret.regression.setup(data)
+    assert "#" not in pc.dataset_transformed.columns[0]
+
+
 def test_encode_target():
     """Assert that the target column is automatically encoded."""
     data = pycaret.datasets.get_data("telescope")


### PR DESCRIPTION
# Related Issue or bug

Closes #3182
Closes #3181

# Describe the changes you've made

* Column names must have characters [^A-Za-z0-9_] to avoid LightGBM special character error
* Default rest_encoder in unuspervised is now BaseN

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
