### PR TITLE
fix for sktime 0.15.0

### DIFF
--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -4991,7 +4991,6 @@ class TSForecastingExperiment(_SupervisedExperiment, TSForecastingPreprocessor):
                     initial_window=initial_window,
                     step_length=step_length,
                     fh=self.fh,
-                    start_with_window=True,
                 )
 
             if fold_strategy == "sliding":

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pandas>=1.3.0, <1.6.0  # Can't >=1.6 because of sktime
 jinja2>=1.2  # Required by pycaret.internal.utils --> pandas.io.formats.style
 scipy<2.0.0  # Can't >=2.0.0 due to sktime
 joblib>=1.2.0  # joblib<1.2.0 is vulnerable to Arbitrary Code Execution (https://github.com/advisories/GHSA-6hrg-qmvc-2xh8)
-scikit-learn>=1.0
+scikit-learn>=1.0, <1.2.0 # params are deprecated from models in 1.2.0
 pyod>=0.9.8
 imbalanced-learn>=0.8.1
 category-encoders>=2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 ipython>=5.5.0
 ipywidgets>=7.6.5  # required by pycaret.internal.display
 tqdm>=4.62.0  # required by pycaret.internal.display
-numpy>=1.21, <1.23  # Can't >=1.23 because of sktime/numba
+numpy>=1.21, <1.25  # Can't >=1.25 because of sktime/numba
 pandas>=1.3.0, <1.6.0  # Can't >=1.6 because of sktime
 jinja2>=1.2  # Required by pycaret.internal.utils --> pandas.io.formats.style
 scipy<2.0.0  # Can't >=2.0.0 due to sktime
@@ -32,6 +32,6 @@ plotly-resampler>=0.7.2.2
 
 # Time-series
 statsmodels>=0.12.1
-sktime>=0.14.0, <0.15.0
+sktime>=0.15.0
 tbats>=1.1.0
 pmdarima>=1.8.0,!=1.8.1,<3.0.0 # Matches sktime

--- a/tests/test_time_series_setup.py
+++ b/tests/test_time_series_setup.py
@@ -90,7 +90,6 @@ def test_splitter_pass_cv_object(load_pos_and_neg_data):
         step_length=12,
         # window_length=12,
         fh=fh,
-        start_with_window=True,
     )
 
     exp_name = setup(


### PR DESCRIPTION
# Related Issue or bug

- Fix for deprecations in sktime 0.15.0
- Pinned sklearn due to API changes in 1.2.0 ([Link](https://scikit-learn.org/1.0/modules/generated/sklearn.linear_model.LinearRegression.html#sklearn.linear_model.LinearRegression))
   

![image](https://user-images.githubusercontent.com/33585645/209441791-56eef7cb-edc4-41e4-b3f6-e8b9d3b757ba.png)


# Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Existing unit tests to pass

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
