### PR TITLE
Pin pydantic, remove Ray python requirements

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -18,9 +18,8 @@ dpcpp-cpp-rt; platform_machine == 'x86_64' or platform_machine == 'AMD64'  # req
 scikit-learn-intelex>=2021.6.3; platform_machine == 'x86_64' or platform_machine == 'AMD64'
 
 # Tuners
-tune-sklearn>=0.2.1; python_version < '3.10' or platform_system != 'Windows'
-protobuf<4.0.0; python_version < '3.10' or platform_system != 'Windows'  # broken in Ray <1.13
-ray[tune]>=1.0.0; python_version < '3.10' or platform_system != 'Windows'
+tune-sklearn>=0.2.1; platform_system != 'Windows'
+ray[tune]>=1.0.0; platform_system != 'Windows'
 hyperopt>=0.2.7
 optuna>=3.0.0
 scikit-optimize>=0.9.0
@@ -38,6 +37,7 @@ evidently>=0.1.45.dev0  # for drift reporting
 nltk>=3.7
 pyLDAvis>=3.3.1
 gensim>=4.1.2
+pydantic<1.10.3; python_version < '3.8'  # spacy dependency, broken in 1.10.3, see https://github.com/pydantic/pydantic/issues/4885
 spacy>=3.2.3
 wordcloud>=1.8.1
 textblob>=0.17.1


### PR DESCRIPTION
# Related Issue or bug

Info about Issue or bug

Closes #[issue number that will be closed through this PR]

# Describe the changes you've made

Pins `pydantic<1.10.3` (spacy dependency) due to https://github.com/pydantic/pydantic/issues/4885, removes a condition causing Ray to not be installed on Python 3.10 (Ray is now available for that version).

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

A clear and concise description of it.

# Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

# Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
