### PR TITLE
Fix IterativeImputer if only one data type is used

### DIFF
--- a/pycaret/internal/preprocess/iterative_imputer.py
+++ b/pycaret/internal/preprocess/iterative_imputer.py
@@ -220,11 +220,21 @@ class IterativeImputer(SklearnIterativeImputer):
         X_filled = X_filled[:, reorder_indices]
 
         combined_statistics = np.zeros(X.shape[1])
+        # Use getattr as the imputers may not have been fitted if there have
+        # been no columns with the required dtype
         num_statistics = list(
-            self.initial_imputer_.named_transformers_["num_imputer"].statistics_
+            getattr(
+                self.initial_imputer_.named_transformers_["num_imputer"],
+                "statistics_",
+                [],
+            )
         )
         cat_statistics = list(
-            self.initial_imputer_.named_transformers_["cat_imputer"].statistics_
+            getattr(
+                self.initial_imputer_.named_transformers_["cat_imputer"],
+                "statistics_",
+                [],
+            )
         )
         for i in range(len(combined_statistics)):
             if i in categorical_indices:


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

# Related Issue or bug

Edge case in `IterativeImputer` caused an exception if only numerical or only categorical columns were present.

Closes https://github.com/pycaret/pycaret/issues/3227

# Describe the changes you've made

The `statistics_` attribute will not be present on `SimpleImputers` that were not fitted if there were no columns with required dtype. This PR uses `getattr` with a default value to avoid an exception. Test case added.

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

A clear and concise description of it.

# Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

# Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
