### PR TITLE
Update sklearnex requirements

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -14,8 +14,7 @@ catboost>=0.23.2
 kmodes>=0.11.1
 mlxtend>=0.19.0
 statsforecast>=0.5.5
-dpcpp-cpp-rt; platform_machine == 'x86_64' or platform_machine == 'AMD64'  # required for intelex, https://github.com/intel/scikit-learn-intelex/issues/1098
-scikit-learn-intelex>=2021.6.3; platform_machine == 'x86_64' or platform_machine == 'AMD64'
+scikit-learn-intelex>=2023.0.1; platform_machine == 'x86_64' or platform_machine == 'AMD64'
 
 # Tuners
 tune-sklearn>=0.2.1; platform_system != 'Windows'

--- a/tests/test_classification_engines.py
+++ b/tests/test_classification_engines.py
@@ -130,8 +130,7 @@ def test_compare_models_engines_local_args():
     assert isinstance(model, sklearn.linear_model._logistic.LogisticRegression)
 
 
-# "rbfsvm" is broken in CI intel/scikit-learn-intelex/issues/1158
-@pytest.mark.parametrize("algo", ("lr", "knn"))
+@pytest.mark.parametrize("algo", ("lr", "knn", "rbfsvm"))
 def test_sklearnex_model(algo: str):
     juice_dataframe = pycaret.datasets.get_data("juice")
     exp = pycaret.classification.ClassificationExperiment()

--- a/tests/test_regression_engines.py
+++ b/tests/test_regression_engines.py
@@ -128,8 +128,7 @@ def test_compare_models_engines_local_args():
     assert isinstance(model, sklearn.linear_model._base.LinearRegression)
 
 
-# "svm" is broken in CI intel/scikit-learn-intelex/issues/1158
-@pytest.mark.parametrize("algo", ("lr", "lasso", "ridge", "en", "knn"))
+@pytest.mark.parametrize("algo", ("lr", "lasso", "ridge", "en", "knn", "svm"))
 def test_sklearnex_model(algo: str):
     boston_dataframe = pycaret.datasets.get_data("boston")
     exp = pycaret.regression.RegressionExperiment()


### PR DESCRIPTION
Pin sklearnex to 2023.0.1 and upper
Remove dpcpp-cpp-rt

# Related Issue or bug

Implements https://github.com/intel/scikit-learn-intelex/issues/1158
Solves fails: https://github.com/pycaret/pycaret/actions/runs/3921915807/jobs/6704526852

# Describe the changes you've made

Update to 2023.0.1 version of scikit-learn-intelex which doesn't require dpcpp-cpp-rt to run.

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Local run of sklearn tests for SVM with sklearnex 2023.0.1 and without installed dpcpp-cpp-rt: no device availability exceptions appeared.

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

N/A

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

