### PR TITLE
[Time Series] Fixed handling of integer indices through data frame column

### DIFF
--- a/pycaret/time_series/forecasting/functional.py
+++ b/pycaret/time_series/forecasting/functional.py
@@ -110,9 +110,12 @@ def setup(
 
 
     index: Optional[str], default = None
-        Column name to be used as the datetime index for modeling. Column is
-        internally converted to datetime using `pd.to_datetime()`. If None,
-        then the data's index is used as is for modeling.
+        Column name to be used as the datetime index for modeling. If 'index'
+        column is specified & is of type string, it is assumed to be coercible
+        to pd.DatetimeIndex using `pd.to_datetime()`. It can also be of type
+        Int (e.g. RangeIndex, Int64Index), or DatetimeIndex or PeriodIndex
+        in which case, it is processed appropriately. If None, then the
+        data's index is used as is for modeling.
 
 
     ignore_features: Optional[List], default = None
@@ -522,12 +525,12 @@ def setup(
             aggregation.
 
         resampler_kwargs: The keyword arguments that are fed to configure the
-            `plotly-resampler` visualizations (i.e., `display_format` "plotly-dash" or
-            "plotly-widget") which downsampler will be used; how many datapoints are
-            shown in the front-end. When the plotly-resampler figure is renderd via Dash
-            (by setting the `display_format` to "plotly-dash"), one can also use the
-            "show_dash" key within this dictionary to configure the show_dash method its
-            args.
+            `plotly-resampler` visualizations (i.e., `display_format` "plotly-dash"
+            or "plotly-widget") which down sampler will be used; how many data points
+            are shown in the front-end. When the plotly-resampler figure is rendered
+            via Dash (by setting the `display_format` to "plotly-dash"), one can
+            also use the "show_dash" key within this dictionary to configure the
+            show_dash method its args.
 
             example::
 

--- a/pycaret/utils/time_series/forecasting/model_selection.py
+++ b/pycaret/utils/time_series/forecasting/model_selection.py
@@ -136,15 +136,15 @@ def _fit_and_score(
     test_expanded = np.arange(train[-1], test[-1]) + 1
 
     # y_train, X_train, X_test can have missing values since pipeline will impute them
-    y_train = y[train]
+    y_train = y.iloc[train]
     X_train = None if X is None else X.iloc[train]
     X_test = None if X is None else X.iloc[test_expanded]
 
     # y_test is "y_true" and used for metrics, hence it can not have missing values
     # Hence using y_imputed
     # Refer to: https://github.com/pycaret/pycaret/issues/2369
-    y_test_imputed = y_imputed[test]
-    y_train_imputed = y_imputed[train]  # Needed for MASE, RMSSE, etc.
+    y_test_imputed = y_imputed.iloc[test]
+    y_train_imputed = y_imputed.iloc[train]  # Needed for MASE, RMSSE, etc.
 
     if y_test_imputed.isna().sum() != 0:
         raise ValueError(

--- a/tests/test_time_series_indices.py
+++ b/tests/test_time_series_indices.py
@@ -1,6 +1,8 @@
 import os
+from typing import Any
 
 import pandas as pd
+import pytest
 
 from pycaret.datasets import get_data
 from pycaret.time_series import TSForecastingExperiment
@@ -8,7 +10,161 @@ from pycaret.time_series import TSForecastingExperiment
 os.environ["PYCARET_TESTING"] = "1"
 
 
-def create_models(exp: TSForecastingExperiment, prophet: bool = True):
+# =============================================================================#
+# Data set generation begins here
+# =============================================================================#
+
+
+def _get_univar_noexo_data_with_index_index():
+    """Generates multiple datasets of univariate data without exogenous variables
+    where the index has been set to various types of indices.
+    """
+    # PeriodIndex
+    data1 = get_data("airline")
+
+    # DatetimeIndex
+    data2 = data1.copy()
+    data2 = data2.to_timestamp()
+
+    # Int64Index
+    data3 = data1.copy()
+    data3.reset_index(drop=True, inplace=True)
+
+    ids = ["Period", "Datetime", "Int"]
+
+    # DateTimeIndex is coerced and returned as PeriodIndex in PyCaret
+    return [
+        [(data1, pd.PeriodIndex), (data2, pd.PeriodIndex), (data3, pd.Int64Index)],
+        ids,
+    ]
+
+
+def _get_univar_noexo_data_with_index_column():
+    """Generates multiple datasets of univariate data without exogenous variables
+    where the index is specified through a column of different.
+    """
+    # PeriodIndex column
+    data1 = pd.DataFrame(get_data("airline"))
+
+    # DatetimeIndex column
+    data2 = data1.copy()
+    data2 = data2.to_timestamp()
+
+    # Int64Index column
+    data3 = data1.copy()
+    data3.reset_index(drop=True, inplace=True)
+
+    data1.reset_index(inplace=True)
+    data2.reset_index(inplace=True)
+    data3.reset_index(inplace=True)
+
+    data1.rename(columns={"Period": "index"}, inplace=True)
+    data2.rename(columns={"Period": "index"}, inplace=True)
+
+    # String Index (created from datetime index)
+    data4 = data2.copy()
+    data4["index"] = data4["index"].dt.strftime("%m/%d/%Y")
+
+    ids = ["Period", "Datetime", "Int", "String"]
+
+    # DateTimeIndex & String index column is coerced and returned as PeriodIndex
+    # in PyCaret
+    return [
+        [
+            (data1, pd.PeriodIndex),
+            (data2, pd.PeriodIndex),
+            (data3, pd.Int64Index),
+            (data4, pd.PeriodIndex),
+        ],
+        ids,
+    ]
+
+
+def _get_univar_exo_data_with_index_index():
+    """Generates multiple datasets of univariate data with exogenous variables
+    where the index has been set to various types of indices.
+    """
+    # TODO: Find a better source of data ----
+    data1 = pd.read_csv(
+        "https://raw.githubusercontent.com/ngupta23/DS6373_TimeSeries/2b40f0071c3b7ec6a05dc0106f64e041f8cbaaef/Projects/gdp_prediction/data/economic_indicators_all_ex_3mo_china_inc_treas3mo.csv"
+    )
+    data1["date"] = pd.to_datetime(data1["date"].str.replace(" ", "-"))
+    data1.set_index("date", inplace=True)
+
+    # PeriodIndex
+    data1.index = data1.index.to_period()
+
+    # DatetimeIndex
+    data2 = data1.copy()
+    data2 = data2.to_timestamp()
+
+    # Int64Index
+    data3 = data1.copy()
+    data3.reset_index(drop=True, inplace=True)
+
+    ids = ["Period", "Datetime", "Int"]
+
+    # DateTimeIndex is coerced and returned as PeriodIndex in PyCaret
+    return [
+        [(data1, pd.PeriodIndex), (data2, pd.PeriodIndex), (data3, pd.Int64Index)],
+        ids,
+    ]
+
+
+def _get_univar_exo_data_with_index_column():
+    """Generates multiple datasets of univariate data with exogenous variables
+    where the index is specified through a column of different.
+    """
+    # TODO: Find a better source of data ----
+    data1 = pd.read_csv(
+        "https://raw.githubusercontent.com/ngupta23/DS6373_TimeSeries/2b40f0071c3b7ec6a05dc0106f64e041f8cbaaef/Projects/gdp_prediction/data/economic_indicators_all_ex_3mo_china_inc_treas3mo.csv"
+    )
+    data1["date"] = pd.to_datetime(data1["date"].str.replace(" ", "-"))
+    data1.set_index("date", inplace=True)
+
+    # PeriodIndex
+    data1.index = data1.index.to_period()
+
+    # DatetimeIndex column
+    data2 = data1.copy()
+    data2 = data2.to_timestamp()
+
+    # Int64Index column
+    data3 = data1.copy()
+    data3.reset_index(drop=True, inplace=True)
+
+    data1.reset_index(inplace=True)
+    data2.reset_index(inplace=True)
+    data3.reset_index(inplace=True)
+
+    data1.rename(columns={"date": "index"}, inplace=True)
+    data2.rename(columns={"date": "index"}, inplace=True)
+
+    # String Index (created from datetime index)
+    data4 = data2.copy()
+    data4["index"] = data4["index"].dt.strftime("%m/%d/%Y")
+
+    ids = ["Period", "Datetime", "Int", "String"]
+
+    # DateTimeIndex & String index column is coerced and returned as PeriodIndex
+    # in PyCaret
+    return [
+        [
+            (data1, pd.PeriodIndex),
+            (data2, pd.PeriodIndex),
+            (data3, pd.Int64Index),
+            (data4, pd.PeriodIndex),
+        ],
+        ids,
+    ]
+
+
+# =============================================================================#
+# Checker function(s)
+# =============================================================================#
+def _check_model_creation_and_indices(
+    exp: TSForecastingExperiment, model: str, expected_return_index_type: Any
+):
     """Function to create a few trial models that support both univariate and
     multivariate forecasting.
 
@@ -19,89 +175,142 @@ def create_models(exp: TSForecastingExperiment, prophet: bool = True):
     prophet : bool, optional
         Should Prophet model be created, by default True
     """
-
-    model = exp.create_model("arima")
-    exp.predict_model(model)
-    exp.plot_model(model)
-
-    if "prophet" in exp.models().index:
-        model = exp.create_model("prophet")
-        exp.predict_model(model)
+    if model in exp.models().index:
+        model = exp.create_model(model)
+        preds = exp.predict_model(model)
+        assert isinstance(preds.index, expected_return_index_type)
         exp.plot_model(model)
 
 
-def test_time_series_indices():
-    """Checks working with various types of indices with both univariate and multivariate datasets"""
+# =============================================================================#
+# Tests begin here
+# =============================================================================#
 
-    ####################
-    # Univariate ####
-    ####################
+# Includes models from statistical family, reduced regression family and prophet
+# since prophet has special handling for indices in patched version in pycaret.
+# ETS and Exponential Smoothing are included since ETS was failing in manual testing.
+models = ["arima", "ets", "exp_smooth", "lr_cds_dt", "prophet"]
 
-    # With Period Index ----
+# -----------------------------------------------------------------------------#
+# Test 1: Univariate No Exogenous Variables with Data Index set to various types
+# -----------------------------------------------------------------------------#
+
+(
+    univar_noexo_data_with_index_index_plus_return_type,
+    ids_univar_noexo_data_with_index_index,
+) = _get_univar_noexo_data_with_index_index()
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize(
+    "data, expected_return_index_type",
+    univar_noexo_data_with_index_index_plus_return_type,
+    ids=ids_univar_noexo_data_with_index_index,
+)
+def test_ts_indices_univar_noexo_index_index(data, model, expected_return_index_type):
+    """
+    Checks working with various types of indices with univariate data without
+    exogenous variables when index is already set in the dataframe.
+    """
     exp = TSForecastingExperiment()
-    data = get_data("airline")
     exp.setup(data=data, fh=12, fold=2, session_id=42)
-    create_models(exp)
-
-    # With Datetime Index ----
-    exp = TSForecastingExperiment()
-    data = get_data("airline")
-    data = data.to_timestamp()
-    exp.setup(data=data, fh=12, fold=2, session_id=42)
-    create_models(exp)
-
-    # With Int Index ----
-    exp = TSForecastingExperiment()
-    data = get_data("airline")
-    data.reset_index(drop=True, inplace=True)
-    exp.setup(data=data, fh=12, fold=2, session_id=42)
-    create_models(exp)
-
-    #######################
-    # Multivariate  ####
-    #######################
-
-    # TODO: Find a better source of data ----
-    data = pd.read_csv(
-        "https://raw.githubusercontent.com/ngupta23/DS6373_TimeSeries/2b40f0071c3b7ec6a05dc0106f64e041f8cbaaef/Projects/gdp_prediction/data/economic_indicators_all_ex_3mo_china_inc_treas3mo.csv"
+    _check_model_creation_and_indices(
+        exp, model=model, expected_return_index_type=expected_return_index_type
     )
-    data["date"] = pd.to_datetime(data["date"].str.replace(" ", "-"))
 
-    # With Datetime Index Column ----
+
+# -----------------------------------------------------------------------------#
+# Test 2: Univariate No Exogenous Variables with Data Index provided through column
+# -----------------------------------------------------------------------------#
+
+(
+    univar_noexo_data_with_index_column_plus_return_type,
+    ids_univar_noexo_data_with_index_column,
+) = _get_univar_noexo_data_with_index_column()
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize(
+    "data, expected_return_index_type",
+    univar_noexo_data_with_index_column_plus_return_type,
+    ids=ids_univar_noexo_data_with_index_column,
+)
+def test_ts_indices_univar_noexo_index_column(data, model, expected_return_index_type):
+    """
+    Checks working with various types of indices with univariate data without
+    exogenous variables when index is provided through a column.
+    """
+    exp = TSForecastingExperiment()
+    exp.setup(data=data, index="index", fh=12, fold=2, session_id=42)
+    _check_model_creation_and_indices(
+        exp, model=model, expected_return_index_type=expected_return_index_type
+    )
+
+
+# -----------------------------------------------------------------------------#
+# Test 3: Univariate with Exogenous Variables with Data Index set to various types
+# -----------------------------------------------------------------------------#
+
+(
+    univar_exo_data_with_index_index_plus_return_type,
+    ids_univar_exo_data_with_index_index,
+) = _get_univar_exo_data_with_index_index()
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize(
+    "data, expected_return_index_type",
+    univar_exo_data_with_index_index_plus_return_type,
+    ids=ids_univar_exo_data_with_index_index,
+)
+def test_ts_indices_univar_exo_index_index(data, model, expected_return_index_type):
+    """
+    Checks working with various types of indices with univariate data with exogenous
+    variables when index is already set in the dataframe.
+    """
     exp = TSForecastingExperiment()
     exp.setup(
         data=data,
         target="gdp_change",
-        index="date",
         fh=2,
         fold=2,
         session_id=42,
     )
-    create_models(exp)
+    _check_model_creation_and_indices(
+        exp, model=model, expected_return_index_type=expected_return_index_type
+    )
 
-    # With Datetime Index ----
-    data_temp = data.copy()
-    data_temp.set_index("date", inplace=True)
-    exp = TSForecastingExperiment()
-    exp.setup(data=data_temp, target="gdp_change", fh=2, fold=2, session_id=42)
-    create_models(exp)
 
-    # With Period Index ----
-    data_temp = data.copy()
-    data_temp.set_index("date", inplace=True)
-    data_temp.index = data_temp.index.to_period()
-    exp = TSForecastingExperiment()
-    exp.setup(data=data_temp, target="gdp_change", fh=2, fold=2, session_id=42)
-    create_models(exp)
+# -----------------------------------------------------------------------------#
+# Test 4: Univariate with Exogenous Variables with Data Index provided through column
+# -----------------------------------------------------------------------------#
 
-    # With Int Index ----
+(
+    univar_exo_data_with_index_column_plus_return_type,
+    ids_univar_exo_data_with_index_column,
+) = _get_univar_exo_data_with_index_column()
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize(
+    "data, expected_return_index_type",
+    univar_exo_data_with_index_column_plus_return_type,
+    ids=ids_univar_exo_data_with_index_column,
+)
+def test_ts_indices_univar_exo_index_column(data, model, expected_return_index_type):
+    """
+    Checks working with various types of indices with univariate data with exogenous
+    variables when index is already set in the dataframe.
+    """
     exp = TSForecastingExperiment()
     exp.setup(
         data=data,
         target="gdp_change",
-        ignore_features=["date"],
+        index="index",
         fh=2,
         fold=2,
         session_id=42,
     )
-    create_models(exp)
+    _check_model_creation_and_indices(
+        exp, model=model, expected_return_index_type=expected_return_index_type
+    )

--- a/tests/test_time_series_indices.py
+++ b/tests/test_time_series_indices.py
@@ -172,8 +172,10 @@ def _check_model_creation_and_indices(
     ----------
     exp : TSForecastingExperiment
         The Time Series experiment object
-    prophet : bool, optional
-        Should Prophet model be created, by default True
+    model : str
+        The model to create using the experiment provided
+    expected_return_index_type: Any
+        The expected return type of the index of the predictions dataframe
     """
     if model in exp.models().index:
         model = exp.create_model(model)


### PR DESCRIPTION
# Related Issue or bug

Closes #3270

# Describe the changes you've made

When a column is passed as an index, previously, it was coerced to DatetimeIndex/TimeIndex irrespective of the column type. With this change, if it is of type integer, it will not be coerced and the integer type will be preserved.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

More modular unit tests added for index handling, plus existing unit tests to pass

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

