### PR TITLE
Fix yellowbrick plots being saved without legend

### DIFF
--- a/pycaret/internal/plots/yellowbrick.py
+++ b/pycaret/internal/plots/yellowbrick.py
@@ -107,7 +107,7 @@ def show_yellowbrick_plot(
         if not isinstance(save, bool):
             plot_filename = os.path.join(save, plot_filename)
         logger.info(f"Saving '{plot_filename}'")
-        plt.savefig(plot_filename, bbox_inches="tight")
+        visualizer.show(outpath=plot_filename, clear_figure=True, bbox_inches="tight")
     else:
         if display_format == "streamlit":
             show_yellowbrick_in_streamlit(visualizer, clear_figure=True)


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

# Related Issue or bug

Info about Issue or bug

Closes https://github.com/pycaret/pycaret/issues/2659

# Describe the changes you've made

Uses yellowbrick method instead of `plt.savefig` directly to make sure the plot is saved with all elements.

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

A clear and concise description of it.

# Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

# Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
