### PR TITLE
Fix weights not being set in `blend_models`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ dask*/
 /.devcontainer
 tmp/
 nbtest1.ipynb
+.DS_Store

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -387,7 +387,6 @@ class _SupervisedExperiment(_TabularExperiment):
         parallel: Optional[ParallelBackend] = None,
         caller_params: Optional[dict] = None,
     ) -> List[Any]:
-
         """
         This function train all the models available in the model library and scores them
         using Cross Validation. The output prints a score grid with Accuracy,
@@ -729,7 +728,6 @@ class _SupervisedExperiment(_TabularExperiment):
             self.logger.info(f"Time budget is {budget_time} minutes")
 
         for i, model in enumerate(model_library):
-
             model_id = (
                 model
                 if (
@@ -966,7 +964,6 @@ class _SupervisedExperiment(_TabularExperiment):
                     full_logging = True
 
                 if self.logging_param and cross_validation and model is not None:
-
                     self._log_model(
                         model=model,
                         model_results=results,
@@ -1298,7 +1295,6 @@ class _SupervisedExperiment(_TabularExperiment):
         return_train_score: bool = False,
         **kwargs,
     ) -> Any:
-
         """
         Internal version of ``create_model`` with private arguments.
         """
@@ -1614,7 +1610,6 @@ class _SupervisedExperiment(_TabularExperiment):
         return_train_score: bool = False,
         **kwargs,
     ) -> Any:
-
         """
         This function creates a model and scores it using Cross Validation.
         The output prints a score grid that shows Accuracy, AUC, Recall, Precision,
@@ -1791,7 +1786,6 @@ class _SupervisedExperiment(_TabularExperiment):
         return_train_score: bool = False,
         **kwargs,
     ) -> Any:
-
         """
         This function tunes the hyperparameters of a model and scores it using Cross Validation.
         The output prints a score grid that shows Accuracy, AUC, Recall
@@ -2463,7 +2457,6 @@ class _SupervisedExperiment(_TabularExperiment):
                 )
 
             elif search_library == "tune-sklearn":
-
                 early_stopping_translator = {
                     "asha": "ASHAScheduler",
                     "hyperband": "HyperBandScheduler",
@@ -2510,7 +2503,6 @@ class _SupervisedExperiment(_TabularExperiment):
                     pipeline_with_model
                 ) if do_early_stop else nullcontext():
                     if search_algorithm == "grid":
-
                         self.logger.info("Initializing tune_sklearn.TuneGridSearchCV")
                         model_grid = TuneGridSearchCV(
                             estimator=pipeline_with_model,
@@ -2910,7 +2902,6 @@ class _SupervisedExperiment(_TabularExperiment):
 
         # check boosting conflict
         if method == "Boosting":
-
             boosting_model_definition = self._all_models_internal["ada"]
 
             check_model = estimator
@@ -3162,7 +3153,6 @@ class _SupervisedExperiment(_TabularExperiment):
         verbose: bool = True,
         return_train_score: bool = False,
     ) -> Any:
-
         """
         This function creates a Soft Voting / Majority Rule classifier for all the
         estimators in the model library (excluding the few when turbo is True) or
@@ -3293,7 +3283,6 @@ class _SupervisedExperiment(_TabularExperiment):
                 if self._ml_usecase == MLUsecase.CLASSIFICATION:
                     # checking method parameter with estimator list
                     if method != "hard":
-
                         for i in estimator_list:
                             if not hasattr(i, "predict_proba"):
                                 if method != "auto":
@@ -3437,7 +3426,10 @@ class _SupervisedExperiment(_TabularExperiment):
 
         if self._ml_usecase == MLUsecase.CLASSIFICATION:
             model = voting_model_definition.class_def(
-                estimators=estimator_list, voting=method, n_jobs=self.gpu_n_jobs_param
+                estimators=estimator_list,
+                voting=method,
+                weights=weights,
+                n_jobs=self.gpu_n_jobs_param,
             )
         elif self._ml_usecase == MLUsecase.TIME_SERIES:
             model = voting_model_definition.class_def(
@@ -3553,7 +3545,6 @@ class _SupervisedExperiment(_TabularExperiment):
         verbose: bool = True,
         return_train_score: bool = False,
     ) -> Any:
-
         """
         This function trains a meta model and scores it using Cross Validation.
         The predictions from the base level models as passed in the estimator_list parameter
@@ -3930,7 +3921,6 @@ class _SupervisedExperiment(_TabularExperiment):
         save: Union[str, bool] = False,
         **kwargs,  # added in pycaret==2.1
     ):
-
         """
         This function takes a trained model object and returns an interpretation plot
         based on the test / hold-out set. It only supports tree based algorithms.
@@ -4109,7 +4099,6 @@ class _SupervisedExperiment(_TabularExperiment):
         shap_plot = None
 
         def summary(show: bool = True):
-
             self.logger.info("Creating TreeExplainer")
             explainer = shap.TreeExplainer(model)
             self.logger.info("Compiling shap values")
@@ -4131,16 +4120,13 @@ class _SupervisedExperiment(_TabularExperiment):
             return shap_plot
 
         def correlation(show: bool = True):
-
             if feature is None:
-
                 self.logger.warning(
                     f"No feature passed. Default value of feature used for correlation plot: {test_X.columns[0]}"
                 )
                 dependence = test_X.columns[0]
 
             else:
-
                 self.logger.warning(
                     f"feature value passed. Feature used for correlation plot: {feature}"
                 )
@@ -4241,7 +4227,6 @@ class _SupervisedExperiment(_TabularExperiment):
                     )
 
                 else:
-
                     row_to_show = observation
                     data_for_prediction = test_X.iloc[row_to_show]
 
@@ -4261,17 +4246,14 @@ class _SupervisedExperiment(_TabularExperiment):
             return shap_plot
 
         def pdp(show: bool = True):
-
             self.logger.info("Checking feature parameter passed")
             if feature is None:
-
                 self.logger.warning(
                     f"No feature passed. Default value of feature used for pdp : {test_X.columns[0]}"
                 )
                 pdp_feature = test_X.columns[0]
 
             else:
-
                 self.logger.warning(
                     f"feature value passed. Feature used for correlation plot: {feature}"
                 )
@@ -4356,7 +4338,6 @@ class _SupervisedExperiment(_TabularExperiment):
         internal: bool = False,
         raise_errors: bool = True,
     ) -> pd.DataFrame:
-
         """
         Returns table of models available in model library.
 
@@ -4636,7 +4617,6 @@ class _SupervisedExperiment(_TabularExperiment):
         model_only: bool = False,
         experiment_custom_tags: Optional[Dict[str, Any]] = None,
     ) -> Any:  # added in pycaret==2.2.0
-
         """
         This function fits the complete pipeline with the estimator on the
         complete dataset passed during the setup() stage. The purpose of
@@ -4762,7 +4742,6 @@ class _SupervisedExperiment(_TabularExperiment):
         ml_usecase: Optional[MLUsecase] = None,
         preprocess: Union[bool, str] = True,
     ) -> pd.DataFrame:
-
         """
         This function is used to predict label and probability score on the new dataset
         using a trained estimator. New unseen data can be passed to data parameter as pandas
@@ -5079,7 +5058,6 @@ class _SupervisedExperiment(_TabularExperiment):
             1, "Finalizing models" if finalize_models else "Collecting models"
         )
         for i, model_results_tuple in enumerate(model_container):
-
             model_results = model_results_tuple["scores"]
             model = model_results_tuple["model"]
             try:
@@ -5136,7 +5114,6 @@ class _SupervisedExperiment(_TabularExperiment):
     def check_fairness(
         self, estimator, sensitive_features: list, plot_kwargs: dict = {}
     ):
-
         """
         There are many approaches to conceptualizing fairness. This function follows
         the approach known as group fairness, which asks: Which groups of individuals
@@ -5224,7 +5201,6 @@ class _SupervisedExperiment(_TabularExperiment):
         turbo: bool = True,
         return_train_score: bool = False,
     ) -> Any:
-
         """
         This function returns the best model out of all models created in
         current active environment based on metric defined in optimize parameter.
@@ -5410,7 +5386,6 @@ class _SupervisedExperiment(_TabularExperiment):
                 all_inputs.append(gr.inputs.Textbox(label=i))
 
         def predict(*dict_input):
-
             input_df = pd.DataFrame.from_dict([dict_input])
             input_df.columns = list(self.X.columns)
             return (


### PR DESCRIPTION
# Related Issue or bug

Fix for #3331.

Closes #[3331]

# Describe the changes you've made

Added weights variable in the following piece of code of supervised_experiment.py

 if self._ml_usecase == MLUsecase.CLASSIFICATION:
     model = voting_model_definition.class_def(
         estimators=estimator_list, voting=method, n_jobs=self.gpu_n_jobs_param
         estimators=estimator_list,
         voting=method,
         weights=weights,
         n_jobs=self.gpu_n_jobs_param,
     )

Also added updated .gitignore

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

I ran the piece of code presented in Issue # 3331, and now it show the weights used instead of None. Before the change, the voting classifier was giving each classifier the same weight but now it give the weights which is provided by the user because it shows the provided weights when you print the model.

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

NA

# Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ x] My code follows the style guidelines of this project.
- [ x] I have performed a self-review of my own code.
- [ x] My changes generate no new warnings.
- [x ] New and existing unit tests pass locally with my changes.


