### PR TITLE
Move `CleanColumnNames` to the end of pipeline

### DIFF
--- a/pycaret/classification/oop.py
+++ b/pycaret/classification/oop.py
@@ -794,10 +794,6 @@ class ClassificationExperiment(_NonTSSupervisedExperiment, Preprocessor):
         if preprocess:
             self.logger.info("Preparing preprocessing pipeline...")
 
-            # Remove weird characters from column names
-            if any(re.search("[^A-Za-z0-9_]", col) for col in self.dataset):
-                self._clean_column_names()
-
             # Encode the target column
             y_unique = self.y.unique()
             if sorted(list(y_unique)) != list(range(len(y_unique))):
@@ -886,6 +882,12 @@ class ClassificationExperiment(_NonTSSupervisedExperiment, Preprocessor):
         # Add custom transformers to the pipeline
         if custom_pipeline:
             self._add_custom_pipeline(custom_pipeline, custom_pipeline_position)
+
+        # Remove weird characters from column names
+        # This has to be done right before the estimator, as modifying column
+        # names early messes self._fxs up
+        if any(re.search("[^A-Za-z0-9_]", col) for col in self.dataset):
+            self._clean_column_names()
 
         # Remove placeholder step
         if ("placeholder", None) in self.pipeline.steps and len(self.pipeline) > 1:

--- a/pycaret/regression/oop.py
+++ b/pycaret/regression/oop.py
@@ -759,10 +759,6 @@ class RegressionExperiment(_NonTSSupervisedExperiment, Preprocessor):
         if preprocess:
             self.logger.info("Preparing preprocessing pipeline...")
 
-            # Remove weird characters from column names
-            if any(re.search("[^A-Za-z0-9_]", col) for col in self.dataset):
-                self._clean_column_names()
-
             # Power transform the target to be more Gaussian-like
             if transform_target:
                 self._target_transformation(transform_target_method)
@@ -846,6 +842,12 @@ class RegressionExperiment(_NonTSSupervisedExperiment, Preprocessor):
         # Add custom transformers to the pipeline
         if custom_pipeline:
             self._add_custom_pipeline(custom_pipeline, custom_pipeline_position)
+
+        # Remove weird characters from column names
+        # This has to be done right before the estimator, as modifying column
+        # names early messes self._fxs up
+        if any(re.search("[^A-Za-z0-9_]", col) for col in self.dataset):
+            self._clean_column_names()
 
             # Remove placeholder step
         if ("placeholder", None) in self.pipeline.steps and len(self.pipeline) > 1:

--- a/pycaret/regression/oop.py
+++ b/pycaret/regression/oop.py
@@ -849,7 +849,7 @@ class RegressionExperiment(_NonTSSupervisedExperiment, Preprocessor):
         if any(re.search("[^A-Za-z0-9_]", col) for col in self.dataset):
             self._clean_column_names()
 
-            # Remove placeholder step
+        # Remove placeholder step
         if ("placeholder", None) in self.pipeline.steps and len(self.pipeline) > 1:
             self.pipeline.steps.remove(("placeholder", None))
 

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -494,4 +494,7 @@ def test_custom_pipeline_positions(pos):
         custom_pipeline=[("scaler", StandardScaler())],
         custom_pipeline_position=pos,
     )
+    # The last element is always CleanColumnNames.
+    if pos < 0:
+        pos -= 1
     assert pc.pipeline.steps[pos][0] == "scaler"


### PR DESCRIPTION
# Related Issue or bug

Info about Issue or bug

Closes https://github.com/pycaret/pycaret/issues/3324

# Describe the changes you've made

Moves `CleanColumnNames` to be the last step in the pipeline before the estimator. Otherwise, the column names we have mapped to data types in `self._fxs` get mismatched and cause issues with preprocessors later on.

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

A clear and concise description of it.

# Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

# Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
