### PR TITLE
Redirect C-level and child output, warn on metric failure

### DIFF
--- a/pycaret/internal/logging.py
+++ b/pycaret/internal/logging.py
@@ -9,25 +9,28 @@ import warnings
 from contextlib import redirect_stderr, redirect_stdout
 from typing import Callable, Optional, Union
 
+from wurlitzer import pipes
+
 
 # From https://stackoverflow.com/a/66209331
 class LoggerWriter:
     """Writer allowing redirection of streams to logger methods."""
 
-    def __init__(self, logfct: Callable):
-        self.logfct = logfct
-        self.buf = []
+    def __init__(self, writer: Callable):
+        self._writer = writer
+        self._msg = ""
 
-    def write(self, msg: str):
-        if msg.endswith("\n"):
-            self.buf.append(msg.rstrip("\n"))
-            self.logfct("".join(self.buf))
-            self.buf = []
-        else:
-            self.buf.append(msg)
+    def write(self, message: str):
+        self._msg = self._msg + message
+        while "\n" in self._msg:
+            pos = self._msg.find("\n")
+            self._writer(self._msg[:pos])
+            self._msg = self._msg[pos + 1 :]
 
     def flush(self):
-        pass
+        if self._msg != "":
+            self._writer(self._msg)
+            self._msg = ""
 
 
 class redirect_output:
@@ -35,16 +38,24 @@ class redirect_output:
 
     def __init__(self, logger: Optional[logging.Logger] = None):
         self.logger = logger or DummyLogger("dummy")
-        self.redirect_stdout = redirect_stdout(LoggerWriter(logger.info))
-        self.redirect_stderr = redirect_stderr(LoggerWriter(logger.warning))
+        # Current Python process redirects
+        self.redirect_stdout = redirect_stdout(LoggerWriter(self.logger.info))
+        self.redirect_stderr = redirect_stderr(LoggerWriter(self.logger.warning))
+        # This redirects stdout/stderr from C libraries and child processes (joblib)
+        self.c_redirect = pipes(
+            stdout=LoggerWriter(self.logger.info),
+            stderr=LoggerWriter(self.logger.warning),
+        )
 
     def __enter__(self):
         self.redirect_stdout.__enter__()
         self.redirect_stderr.__enter__()
+        self.c_redirect.__enter__()
 
     def __exit__(self, *args, **kwargs):
-        self.redirect_stdout.__exit__(*args, **kwargs)
+        self.c_redirect.__exit__(*args, **kwargs)
         self.redirect_stderr.__exit__(*args, **kwargs)
+        self.redirect_stdout.__exit__(*args, **kwargs)
 
 
 class DummyLogger(logging.Logger):

--- a/pycaret/internal/metrics.py
+++ b/pycaret/internal/metrics.py
@@ -1,5 +1,15 @@
+import traceback
+import warnings
+
 import numpy as np
+from sklearn.exceptions import FitFailedWarning
 from sklearn.metrics._scorer import _PredictScorer, _ProbaScorer, _ThresholdScorer
+
+_fit_failed_message_warning = (
+    "Metric {0} failed and error score {1} has been returned instead. "
+    "This usually means that the error is in the metric code. "
+    "Full exception below:\n{2}"
+)
 
 
 class BinaryMulticlassScoreFunc:
@@ -60,6 +70,12 @@ class _ThresholdScorerWithErrorScore(_ThresholdScorer):
                 sample_weight=sample_weight,
             )
         except Exception:
+            warnings.warn(
+                _fit_failed_message_warning.format(
+                    repr(self), self.error_score, traceback.format_exc()
+                ),
+                FitFailedWarning,
+            )
             return self.error_score
 
     def _factory_args(self):
@@ -109,6 +125,12 @@ class _ProbaScorerWithErrorScore(_ProbaScorer):
                 sample_weight=sample_weight,
             )
         except Exception:
+            warnings.warn(
+                _fit_failed_message_warning.format(
+                    repr(self), self.error_score, traceback.format_exc()
+                ),
+                FitFailedWarning,
+            )
             return self.error_score
 
     def _factory_args(self):
@@ -157,6 +179,12 @@ class _PredictScorerWithErrorScore(_PredictScorer):
                 sample_weight=sample_weight,
             )
         except Exception:
+            warnings.warn(
+                _fit_failed_message_warning.format(
+                    repr(self), self.error_score, traceback.format_exc()
+                ),
+                FitFailedWarning,
+            )
             return self.error_score
 
 

--- a/pycaret/internal/metrics.py
+++ b/pycaret/internal/metrics.py
@@ -6,8 +6,9 @@ from sklearn.exceptions import FitFailedWarning
 from sklearn.metrics._scorer import _PredictScorer, _ProbaScorer, _ThresholdScorer
 
 _fit_failed_message_warning = (
-    "Metric {0} failed and error score {1} has been returned instead. "
-    "This usually means that the error is in the metric code. "
+    "Metric '{0}' failed and error score {1} has been returned instead. "
+    "If this is a custom metric, this usually means that the error is "
+    "in the metric code. "
     "Full exception below:\n{2}"
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ pickle5; python_version < "3.8"
 cloudpickle
 deprecation>=2.1.0
 xxhash  # for faster hashing
+wurlitzer
 
 # Plotting
 matplotlib>=3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pickle5; python_version < "3.8"
 cloudpickle
 deprecation>=2.1.0
 xxhash  # for faster hashing
-wurlitzer
+wurlitzer; platform_system != 'Windows'
 
 # Plotting
 matplotlib>=3.3.0


### PR DESCRIPTION
# Related Issue or bug

Info about Issue or bug

Closes https://github.com/pycaret/pycaret/issues/3351
Closes https://github.com/pycaret/pycaret/issues/3273

# Describe the changes you've made

This PR introduces two changes:
1. The output from C-level libraries and child processes (spawned by eg. joblib) is now correctly redirected to loggers. The `LoggerWriter` has also been improved.
2. Metrics will warn if there was an error on fit.

This PR adds a single new dependency, which is already a dependency of one of the other dependencies, so there shouldn't be any issues.

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

A clear and concise description of it.

# Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

# Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
