### PR TITLE
Use inner joins when concatting X and y, set random state on `RemoveOutliers`

### DIFF
--- a/pycaret/anomaly/functional.py
+++ b/pycaret/anomaly/functional.py
@@ -115,6 +115,8 @@ def setup(
             - If str: Name of the column to use as index.
             - If sequence: Array with shape=(n_samples,) to use as index.
 
+        Index must be composed of unique values.
+
 
     ordinal_features: dict, default = None
         Categorical features to be encoded ordinally. For example, a categorical

--- a/pycaret/classification/functional.py
+++ b/pycaret/classification/functional.py
@@ -141,6 +141,8 @@ def setup(
             - If str: Name of the column to use as index.
             - If sequence: Array with shape=(n_samples,) to use as index.
 
+        Index must be composed of unique values.
+
 
     train_size: float, default = 0.7
         Proportion of the dataset to be used for training and validation. Should be

--- a/pycaret/classification/oop.py
+++ b/pycaret/classification/oop.py
@@ -239,6 +239,8 @@ class ClassificationExperiment(_NonTSSupervisedExperiment, Preprocessor):
                 - If str: Name of the column to use as index.
                 - If sequence: Array with shape=(n_samples,) to use as index.
 
+        Index must be composed of unique values.
+
 
         train_size: float, default = 0.7
             Proportion of the dataset to be used for training and validation. Should be

--- a/pycaret/clustering/functional.py
+++ b/pycaret/clustering/functional.py
@@ -114,6 +114,8 @@ def setup(
             - If str: Name of the column to use as index.
             - If sequence: Array with shape=(n_samples,) to use as index.
 
+        Index must be composed of unique values.
+
 
     ordinal_features: dict, default = None
         Categorical features to be encoded ordinally. For example, a categorical

--- a/pycaret/internal/preprocess/preprocessor.py
+++ b/pycaret/internal/preprocess/preprocessor.py
@@ -198,6 +198,13 @@ class Preprocessor:
                 f"can not be the same as the target column, got {target}."
             )
 
+        if not df.index.unique:
+            raise ValueError(
+                "Invalid value for the index parameter. "
+                f"Selected column {self.index} cannot be used as an index as it "
+                "contains non-unique values."
+            )
+
         return df
 
     def _prepare_train_test(
@@ -808,7 +815,6 @@ class Preprocessor:
             RemoveOutliers(
                 method=outliers_method,
                 threshold=outliers_threshold,
-                random_state=self.seed,
             ),
         )
 

--- a/pycaret/internal/preprocess/preprocessor.py
+++ b/pycaret/internal/preprocess/preprocessor.py
@@ -808,6 +808,7 @@ class Preprocessor:
             RemoveOutliers(
                 method=outliers_method,
                 threshold=outliers_threshold,
+                random_state=self.seed,
             ),
         )
 

--- a/pycaret/internal/preprocess/preprocessor.py
+++ b/pycaret/internal/preprocess/preprocessor.py
@@ -172,6 +172,12 @@ class Preprocessor:
         target = df.columns[-1]
 
         if getattr(self, "index", True) is True:  # True gets caught by isinstance(int)
+            if not df.index.unique:
+                raise ValueError(
+                    "Data cannot be used as its index contains non-unique values. "
+                    "Ensure that the index contains only unique values or set "
+                    "`index=False` in `setup()`."
+                )
             return df
         elif self.index is False:
             df = df.reset_index(drop=True)

--- a/pycaret/internal/pycaret_experiment/non_ts_supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/non_ts_supervised_experiment.py
@@ -34,6 +34,7 @@ class _NonTSSupervisedExperiment(_SupervisedExperiment):
         return pd.concat(
             [self.X_train_transformed, self.y_train_transformed],
             axis=1,
+            join="inner",
         )
 
     @property
@@ -60,8 +61,7 @@ class _NonTSSupervisedExperiment(_SupervisedExperiment):
     def test_transformed(self):
         """Transformed test set."""
         return pd.concat(
-            [self.X_test_transformed, self.y_test_transformed],
-            axis=1,
+            [self.X_test_transformed, self.y_test_transformed], axis=1, join="inner"
         )
 
     @property

--- a/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
@@ -175,6 +175,8 @@ class _UnsupervisedExperiment(_TabularExperiment, Preprocessor):
                 - If str: Name of the column to use as index.
                 - If sequence: Array with shape=(n_samples,) to use as index.
 
+        Index must be composed of unique values.
+
 
         ordinal_features: dict, default = None
             Categorical features to be encoded ordinally. For example, a categorical

--- a/pycaret/regression/functional.py
+++ b/pycaret/regression/functional.py
@@ -140,6 +140,8 @@ def setup(
             - If str: Name of the column to use as index.
             - If sequence: Array with shape=(n_samples,) to use as index.
 
+        Index must be composed of unique values.
+
 
     train_size: float, default = 0.7
         Proportion of the dataset to be used for training and validation. Should be

--- a/pycaret/regression/oop.py
+++ b/pycaret/regression/oop.py
@@ -199,6 +199,8 @@ class RegressionExperiment(_NonTSSupervisedExperiment, Preprocessor):
                 - If str: Name of the column to use as index.
                 - If sequence: Array with shape=(n_samples,) to use as index.
 
+        Index must be composed of unique values.
+
 
         train_size: float, default = 0.7
             Proportion of the dataset to be used for training and validation. Should be

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -90,10 +90,11 @@ def test_assign_index_is_true():
     assert pc.dataset.index[0] == 100
 
 
-@pytest.mark.parametrize("index", [1, "WeekofPurchase", list(range(2, 1072))])
+@pytest.mark.parametrize("index", [1, "MyIndex", list(range(2, 1072))])
 def test_assign_index(index):
     """Assert that the index can be assigned."""
     data = pycaret.datasets.get_data("juice")
+    data.insert(1, "MyIndex", list(range(1, len(data) + 1)))
     pc = pycaret.classification.setup(
         data=data,
         index=index,
@@ -388,11 +389,6 @@ def test_remove_outliers(outliers_method):
         outliers_threshold=0.2,
     )
     assert pc.pipeline.steps[-1][0] == "remove_outliers"
-    # Test that we do not add rows back in when joining X and y
-    assert len(pc.train_transformed) == len(pc.X_train_transformed)
-    assert len(pc.dataset_transformed) == len(pc.train_transformed) + len(
-        pc.test_transformed
-    )
 
 
 def test_polynomial_features():

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -388,6 +388,11 @@ def test_remove_outliers(outliers_method):
         outliers_threshold=0.2,
     )
     assert pc.pipeline.steps[-1][0] == "remove_outliers"
+    # Test that we do not add rows back in when joining X and y
+    assert len(pc.train_transformed) == len(pc.X_train_transformed)
+    assert len(pc.dataset_transformed) == len(pc.train_transformed) + len(
+        pc.test_transformed
+    )
 
 
 def test_polynomial_features():


### PR DESCRIPTION
# Related Issue or bug

Info about Issue or bug

Closes https://github.com/pycaret/pycaret/issues/3365

# Describe the changes you've made

Uses inner joins to ensure that rows are not added back again if the preprocessor removed it from X or y but not both at the same time. Sets random state on `RemoveOutliers` for reproducibility.

Due to the first change, the index is now required to be unique.

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

A clear and concise description of it.

# Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

# Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
