### PR TITLE
Restrict evidently version

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -30,7 +30,7 @@ boto3>=1.24.56  # For deploy_model method
 fastapi>=0.75.0  # For web api
 uvicorn>=0.17.6  # For web api
 m2cgen>=0.9.0  # For model conversion
-evidently>=0.1.45.dev0  # for drift reporting
+evidently>=0.1.45.dev0,<0.3  # for drift reporting
 
 # Parallel
 fugue>=0.8.0


### PR DESCRIPTION
In https://github.com/evidentlyai/evidently/pull/550 old API will be removed, so you need to restrict evidently version before you switch to new API

