### PR TITLE
fix np array check  when get_feature_names_out is unavailable

### DIFF
--- a/pycaret/internal/preprocess/transformers.py
+++ b/pycaret/internal/preprocess/transformers.py
@@ -8,6 +8,7 @@ from inspect import signature
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_numeric_dtype
 from scipy import stats
 from sklearn.base import BaseEstimator, TransformerMixin, clone
 from sklearn.covariance import EllipticEnvelope
@@ -81,7 +82,15 @@ class TransformerWrapper(BaseEstimator, TransformerMixin):
         # If columns were added or removed
         temp_cols = []
         for i, col in enumerate(array.T, start=2):
-            mask = df.apply(lambda c: np.array_equal(c, col, equal_nan=True))
+            # equal_nan=True fails for non-numeric arrays
+            mask = df.apply(
+                lambda c: np.array_equal(
+                    c,
+                    col,
+                    equal_nan=is_numeric_dtype(c)
+                    and np.issubdtype(col.dtype, np.number),
+                )
+            )
             if any(mask) and mask[mask].index.values[0] not in temp_cols:
                 temp_cols.append(mask[mask].index.values[0])
             else:


### PR DESCRIPTION
Closes #3469

# Describe the changes you've made

Fixes a bug where non numerical array checks would fail when `get_feature_names_out` is not available in a transformer.

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
