### PR TITLE
DagsHubLogger: support programmatic logging / Bug Fix: incorrect url splitter, mlflow nested run

### DIFF
--- a/pycaret/loggers/base_logger.py
+++ b/pycaret/loggers/base_logger.py
@@ -28,7 +28,7 @@ class BaseLogger(ABC):
     def set_tags(self, source, experiment_custom_tags, runtime):
         pass
 
-    def _construct_pipeline_if_needed(model, prep_pipe: Pipeline) -> Pipeline:
+    def _construct_pipeline_if_needed(self, model, prep_pipe: Pipeline) -> Pipeline:
         """If model is a pipeline, return it, else append model to copy of prep_pipe."""
         if not isinstance(model, Pipeline):
             prep_pipe_temp = deepcopy(prep_pipe)

--- a/pycaret/loggers/dagshub_logger.py
+++ b/pycaret/loggers/dagshub_logger.py
@@ -30,6 +30,9 @@ class DagshubLogger(MlflowLogger):
 
         if repo:
             self.repo_name, self.repo_owner = self.splitter(repo)
+        elif self.remote and self.remote.startswith("https://dagshub.com"):
+            self.repo_owner = self.remote.split(os.sep)[-2],
+            self.repo_name = self.remote.split(os.sep)[-1].replace(".mlflow", "")
         else:
             self.repo_name, self.repo_owner = None, None
 

--- a/pycaret/loggers/dagshub_logger.py
+++ b/pycaret/loggers/dagshub_logger.py
@@ -65,8 +65,8 @@ class DagshubLogger(MlflowLogger):
                 self.remote = os.getenv("MLFLOW_TRACKING_URI")
 
             self.repo = Repo(
-                owner=self.remote.split(os.sep)[-2],
-                name=self.remote.split(os.sep)[-1].replace(".mlflow", ""),
+                owner=self.remote.split("/")[-2],
+                name=self.remote.split("/")[-1].replace(".mlflow", ""),
                 branch=os.getenv("BRANCH", "main"),
             )
             self.dvc_folder = self.repo.directory(str(self.paths["dvc_directory"]))

--- a/pycaret/loggers/dagshub_logger.py
+++ b/pycaret/loggers/dagshub_logger.py
@@ -31,7 +31,7 @@ class DagshubLogger(MlflowLogger):
         if repo:
             self.repo_name, self.repo_owner = self.splitter(repo)
         elif self.remote and self.remote.startswith("https://dagshub.com"):
-            self.repo_owner = self.remote.split(os.sep)[-2],
+            self.repo_owner = (self.remote.split(os.sep)[-2],)
             self.repo_name = self.remote.split(os.sep)[-1].replace(".mlflow", "")
         else:
             self.repo_name, self.repo_owner = None, None


### PR DESCRIPTION
# New Feature:
DagsHub Logger supports programmatic logging (won't be blocked by the authentication process)

# Related Issue or bug
1. Nested run issue: when running `compare model` with either mlflow logger or dagshublogger, the next algorithm experiment will be logged nested in the previous experiment.
2. Incorrect URL splitter: #3435 
Closes #3435 

# Describe the changes you've made
## Programmatic Logging Feature Support:
By running `dagshub.init()` before the setup(), users can programmatically log the experiments without interrupt by the authentication.
```
dagshub.init(repo_name, repo_owner)
```
## Bug Fix:
1. Nested run issue: The nested run in `compare_model` happens because of raising an error in `_construct_pipeline_if_needed`, which led to the failure of ending the active run. The fix is to add the `self` in the function argument.
2. Incorrect URL splitter: replace the `os.sep()` splitter to `"/"`


# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

# Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.