### PR TITLE
Fixed dead links in Tutorial docs

### DIFF
--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -5,30 +5,33 @@ Classification
 **************
 Learn how to prepare the data for modeling, create a classification model, tune hyperparameters of a model, analyze the performance, and consume the model for predictions.
 
-- `Binary Classification Tutorial - Level Beginner (CLF101) <https://github.com/pycaret/pycaret/blob/master/tutorials/Binary%20Classification%20Tutorial%20Level%20Beginner%20-%20%20CLF101.ipynb>`_
+- `Binary Classification Tutorial <https://github.com/mbellitti/pycaret/blob/master/tutorials/Tutorial%20-%20Binary%20Classification.ipynb>`_
 
-- `Binary Classification Tutorial - Level Intermediate (CLF102) <https://github.com/pycaret/pycaret/blob/master/tutorials/Binary%20Classification%20Tutorial%20Level%20Intermediate%20-%20CLF102.ipynb>`_
-
-- `Multiclass Classification Tutorial - Level Beginner (MCLF101) <https://github.com/pycaret/pycaret/blob/master/tutorials/Multiclass%20Classification%20Tutorial%20Level%20Beginner%20-%20MCLF101.ipynb>`_
-
+- `Multiclass Classification Tutorial <https://github.com/mbellitti/pycaret/blob/master/tutorials/Tutorial%20-%20Multiclass%20Classification.ipynb>`_
 
 Regression
 **************
 Learn how to prepare the data for modeling, create a regression model, tune hyperparameters of a model, evaluate model errors, and consume the model for predictions.
 
-- `Regression Tutorial - Level Beginner (REG101) <https://github.com/pycaret/pycaret/blob/master/tutorials/Regression%20Tutorial%20Level%20Beginner%20-%20REG101.ipynb>`_
-
-- `Regression Tutorial - Level Intermediate (REG102) <https://github.com/pycaret/pycaret/blob/master/tutorials/Regression%20Tutorial%20Level%20Intermediate%20-%20REG102.ipynb>`_
+- `Regression Tutorial <https://github.com/mbellitti/pycaret/blob/master/tutorials/Tutorial%20-%20Regression.ipynb>`_
 
 Clustering
 **************
 Learn how to prepare the data for modeling, create a K-Means clustering model, assign the labels, analyze results, and consume a trained model for predictions on unseen data.
 
-- `Clustering Tutorial - Level Beginner (CLU101) <https://github.com/pycaret/pycaret/blob/master/tutorials/Clustering%20Tutorial%20Level%20Beginner%20-%20CLU101.ipynb>`_
+- `Clustering Tutorial <https://github.com/mbellitti/pycaret/blob/master/tutorials/Tutorial%20-%20Clustering.ipynb>`_
 
 
 Anomaly Detection
 *****************
 Learn how to prepare the data for modeling, create an unsupervised anomaly detector, evaluate the results of the trained model, and consume the model for predictions on unseen data.
 
-- `Anomaly Detection Tutorial - Level Beginner (ANO101) <https://github.com/pycaret/pycaret/blob/master/tutorials/Anomaly%20Detection%20Tutorial%20Level%20Beginner%20-%20ANO101.ipynb>`_
+- `Anomaly Detection Tutorial <https://github.com/mbellitti/pycaret/blob/master/tutorials/Tutorial%20-%20Anomaly%20Detection.ipynb>`_
+
+
+Time Series Forecasting
+***********************
+Learn how to prepare the data for modeling, create and compare a time series model, analyze it, use it to make predictions, and save the model.
+
+
+- `Time Series Forecasting Tutorial <https://github.com/mbellitti/pycaret/blob/master/tutorials/Tutorial%20-%20Time%20Series%20Forecasting.ipynb>`_

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -5,28 +5,28 @@ Classification
 **************
 Learn how to prepare the data for modeling, create a classification model, tune hyperparameters of a model, analyze the performance, and consume the model for predictions.
 
-- `Binary Classification Tutorial <https://github.com/mbellitti/pycaret/blob/master/tutorials/Tutorial%20-%20Binary%20Classification.ipynb>`_
+- `Binary Classification Tutorial <https://github.com/pycaret/pycaret/blob/master/tutorials/Tutorial%20-%20Binary%20Classification.ipynb>`_
 
-- `Multiclass Classification Tutorial <https://github.com/mbellitti/pycaret/blob/master/tutorials/Tutorial%20-%20Multiclass%20Classification.ipynb>`_
+- `Multiclass Classification Tutorial <https://github.com/pycaret/pycaret/blob/master/tutorials/Tutorial%20-%20Multiclass%20Classification.ipynb>`_
 
 Regression
 **************
 Learn how to prepare the data for modeling, create a regression model, tune hyperparameters of a model, evaluate model errors, and consume the model for predictions.
 
-- `Regression Tutorial <https://github.com/mbellitti/pycaret/blob/master/tutorials/Tutorial%20-%20Regression.ipynb>`_
+- `Regression Tutorial <https://github.com/pycaret/pycaret/blob/master/tutorials/Tutorial%20-%20Regression.ipynb>`_
 
 Clustering
 **************
 Learn how to prepare the data for modeling, create a K-Means clustering model, assign the labels, analyze results, and consume a trained model for predictions on unseen data.
 
-- `Clustering Tutorial <https://github.com/mbellitti/pycaret/blob/master/tutorials/Tutorial%20-%20Clustering.ipynb>`_
+- `Clustering Tutorial <https://github.com/pycaret/pycaret/blob/master/tutorials/Tutorial%20-%20Clustering.ipynb>`_
 
 
 Anomaly Detection
 *****************
 Learn how to prepare the data for modeling, create an unsupervised anomaly detector, evaluate the results of the trained model, and consume the model for predictions on unseen data.
 
-- `Anomaly Detection Tutorial <https://github.com/mbellitti/pycaret/blob/master/tutorials/Tutorial%20-%20Anomaly%20Detection.ipynb>`_
+- `Anomaly Detection Tutorial <https://github.com/pycaret/pycaret/blob/master/tutorials/Tutorial%20-%20Anomaly%20Detection.ipynb>`_
 
 
 Time Series Forecasting
@@ -34,4 +34,4 @@ Time Series Forecasting
 Learn how to prepare the data for modeling, create and compare a time series model, analyze it, use it to make predictions, and save the model.
 
 
-- `Time Series Forecasting Tutorial <https://github.com/mbellitti/pycaret/blob/master/tutorials/Tutorial%20-%20Time%20Series%20Forecasting.ipynb>`_
+- `Time Series Forecasting Tutorial <https://github.com/pycaret/pycaret/blob/master/tutorials/Tutorial%20-%20Time%20Series%20Forecasting.ipynb>`_


### PR DESCRIPTION
The links to Jupyter notebooks in the [Tutorial page](https://pycaret.readthedocs.io/en/latest/tutorials.html) are currently dead. I fixed them to point to the correct files on the main repo. 

I also added a link to the Time Series Forecasting tutorial notebook, which was missing from the list of tutorials.