### PR TITLE
Fix for sktime changes in recent versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,11 +102,88 @@ jobs:
       - name: Test with pytest
         run: pytest --durations=0
 
+  test_linux_3p7:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        # SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
+        # pyLDAvis 3.3.1 having an "sklearn" dependency
+        run: |
+          export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
+          python -m pip install -U pip
+          python -m pip install -U pytest numpy
+
+          pip install ".[full, test]"
+          if [ -f requirements-prophet.txt ]; then pip install -r requirements-prophet.txt; fi
+      - name: Python version and dependency list
+        run: |
+          echo "Python version expected: ${{ matrix.python-version }}"
+          python --version
+          which python
+          pip list
+      - name: Remove tests
+        run: |
+          rm tests/test_classification_tuning.py
+          rm tests/test_classification_plots.py
+          rm tests/test_regression_plots.py
+          rm tests/test_regression_tuning.py
+          rm tests/test_time_series_tune_grid.py
+          rm tests/test_time_series_tune_random.py
+          rm tests/test_time_series_plots.py
+          rm tests/test_time_series_utils_plots.py
+          rm tests/benchmarks/*.py
+      - name: Test with pytest
+        run: pytest --durations=0
+
   test_windows:
     runs-on: windows-latest
     strategy:
       matrix:
         python-version: [3.8, 3.9, "3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        # SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
+        # pyLDAvis 3.3.1 having an "sklearn" dependency
+        run: |
+          $env:SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL = 'True'
+          python -m pip install -U pip
+          python -m pip install -U pytest numpy
+
+          pip install ".[full, test]"
+          pip install -r requirements-prophet.txt
+      - name: Python version and dependency list
+        run: |
+          echo "Python version expected: ${{ matrix.python-version }}"
+          python --version
+          which python
+          pip list
+      - name: Remove tests
+        run: |
+          remove-item tests/* -Include @('test_clustering.py', 'test_classification_tuning.py','test_classification_plots.py','test_regression_plots.py', 'test_regression_tuning.py', 'test_time_series_tune_grid.py', 'test_time_series_tune_random.py', 'test_create_api.py', 'test_create_docker.py', 'test_drift_report.py', 'test_eda.py', 'test_time_series_plots.py', 'test_time_series_utils_plots.py')
+          remove-item tests/benchmarks/*
+      - name: Test with pytest
+        run: pytest --durations=0
+
+  test_windows_3p7:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
 
     steps:
       - uses: actions/checkout@v3
@@ -268,69 +345,3 @@ jobs:
       - name: Run benchmarks
         run: pytest tests/benchmarks --durations=0
 
-  # test_tuning:
-
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Set up Python 3.8
-  #     uses: actions/setup-python@v4
-  #     with:
-  #       python-version: 3.8
-  #   - name: Install dependencies
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       python -m pip install -U pytest
-  #       python -m pip install codecov
-  #       pip install ".[full]"
-  #       python -m pip install hpbandster ConfigSpace
-  #   - name: Remove tests
-  #     run: |
-  #       find tests -type f -not -name '__init__.py' -not -name 'test_classification_tuning.py' -not -name 'test_regression_tuning.py' -delete
-  #   - name: Test with pytest
-  #     run: pytest --durations=0
-
-  # test_tuning_clf_windows:
-
-  #   runs-on: windows-latest
-
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Set up Python 3.8
-  #     uses: actions/setup-python@v4
-  #     with:
-  #       python-version: 3.8
-  #   - name: Install dependencies
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       python -m pip install -U pytest
-  #       python -m pip install codecov
-  #       pip install ".[full]"
-  #   - name: Remove tests
-  #     run: |
-  #       remove-item tests/* -Exclude @('__init__.py','test_classification_tuning.py')
-  #   - name: Test with pytest
-  #     run: pytest --durations=0
-
-  # test_tuning_reg_windows:
-
-  #   runs-on: windows-latest
-
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Set up Python 3.8
-  #     uses: actions/setup-python@v4
-  #     with:
-  #       python-version: 3.8
-  #   - name: Install dependencies
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       python -m pip install -U pytest
-  #       python -m pip install codecov
-  #       pip install ".[full]"
-  #   - name: Remove tests
-  #     run: |
-  #       remove-item tests/* -Exclude @('__init__.py','test_regression_tuning.py')
-  #   - name: Test with pytest
-  #     run: pytest --durations=0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v3
@@ -106,7 +106,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pycaret/containers/models/time_series.py
+++ b/pycaret/containers/models/time_series.py
@@ -8,11 +8,11 @@ required parameters in the `__init__` and then call `super().__init__` to comple
 the process. Refer to the existing classes for examples.
 """
 
-from inspect import getfullargspec
 import logging
 import random
 import warnings
 from abc import abstractmethod
+from inspect import getfullargspec
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np  # type: ignore

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,9 @@ plotly-resampler>=0.8.3.1
 statsmodels>=0.12.1
 # Can not be ==0.17.1 due to this bug in 0.17.1: https://github.com/sktime/sktime/issues/4468
 # Can not be >=0.17.2 due to this bug (fixed in 0.18.1): https://github.com/sktime/sktime/issues/4587
-sktime>=0.16.1,!=0.17.1,!=0.17.2,!=0.18.0
+# Can't >=0.22.0 because of legacy_interface default will switch to False in 0.22.0
+# This restriction can be removed if the new interface is handled in pycaret for newer versions
+# of sktime and the older interface is handled in pycaret for older versions of sktime
+sktime>=0.16.1,!=0.17.1,!=0.17.2,!=0.18.0,<0.22.0
 tbats>=1.1.3
 pmdarima>=1.8.0,!=1.8.1,<3.0.0 # Matches sktime


### PR DESCRIPTION
# Related Issue or bug

Tests were failing on CI for time series and other modules. This PR is to fix the time series tests.

# Describe the changes you've made

- `sktime` `BoxCoxTrandformer` supports negative values in recent versions. Hence, tests have been updated appropriately
- Recent versions of sktime introduced a legacy interface argument. This needs to be incorporated in Prophet Patched class in pycaret.
- Pinned sktime upper limit for now. Once the new interface is supported (along with older interface - depending on sktime version), we can remove the limit.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Failing time series unit tests have been checked locally for sktime vesions 0.19.1 and 0.21.0.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.