### PR TITLE
Resolve double-printed plots during ts experiment

### DIFF
--- a/pycaret/time_series/forecasting/functional.py
+++ b/pycaret/time_series/forecasting/functional.py
@@ -402,7 +402,7 @@ def setup(
             per FPP (https://otexts.com/fpp2/seasonal-strength.html). NOTE:
             For Multiplicative, the denominator multiplies the seasonal and
             residual components instead of adding them. Rest of the
-            calculations remain the same. If seasonal decompositon fails for
+            calculations remain the same. If seasonal decomposition fails for
             any reason, then defaults to multiplicative seasonality.
         (4) Otherwise, seasonality_type is set to the user provided value.
 
@@ -532,7 +532,7 @@ def setup(
         renderer: The renderer used to display the plotly figure. Can be any value
             supported by Plotly (e.g. "notebook", "png", "svg", etc.). Note that certain
             renderers (like "svg") may need additional libraries to be installed. Users
-            will have to do this manually since they don't come preinstalled wit plotly.
+            will have to do this manually since they don't come preinstalled with plotly.
             When not provided, plots use plotly's default render when data is below a
             certain number of points (determined by `big_data_threshold`) otherwise it
             switches to a static "png" renderer.

--- a/pycaret/time_series/forecasting/functional.py
+++ b/pycaret/time_series/forecasting/functional.py
@@ -1221,8 +1221,9 @@ def plot_model(
         * 'residuals' - Residuals Plot
 
 
-    return_fig: : bool, default = False
+    return_fig: bool, default = False
         When set to True, it returns the figure used for plotting.
+        When set to False (the default), it will print the plot, but not return it.
 
 
     return_data: bool, default = False

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -3894,7 +3894,9 @@ class TSForecastingExperiment(_TSSupervisedExperiment, TSForecastingPreprocessor
                             fig.show(renderer=renderer)
                             self.logger.info("Visual Rendered Successfully")
                         else:
-                            self.logger.info("Visual not rendered, but will be returned from function")
+                            self.logger.info(
+                                "Visual not rendered, but will be returned from function"
+                            )
                     except ValueError as exception:
                         self.logger.info(exception)
                         self.logger.info("Visual Rendered Unsuccessfully")

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -4006,8 +4006,9 @@ class TSForecastingExperiment(_TSSupervisedExperiment, TSForecastingPreprocessor
             * 'residuals' - Residuals Plot
 
 
-        return_fig: : bool, default = False
+        return_fig: bool, default = False
             When set to True, it returns the figure used for plotting.
+            When set to False (the default), it will print the plot, but not return it.
 
 
         return_data: bool, default = False
@@ -4041,6 +4042,7 @@ class TSForecastingExperiment(_TSSupervisedExperiment, TSForecastingPreprocessor
 
             To display plots in Streamlit (https://www.streamlit.io/), set this to
             'streamlit'.
+
 
         data_kwargs: dict, default = None
             Dictionary of arguments passed to the data for plotting.

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -3890,8 +3890,11 @@ class TSForecastingExperiment(_TSSupervisedExperiment, TSForecastingPreprocessor
                             data=data,
                             X=X,
                         )
-                        fig.show(renderer=renderer)
-                        self.logger.info("Visual Rendered Successfully")
+                        if not return_fig:
+                            fig.show(renderer=renderer)
+                            self.logger.info("Visual Rendered Successfully")
+                        else:
+                            self.logger.info("Visual not rendered, but will be returned from function")
                     except ValueError as exception:
                         self.logger.info(exception)
                         self.logger.info("Visual Rendered Unsuccessfully")

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -3857,23 +3857,26 @@ class TSForecastingExperiment(_TSSupervisedExperiment, TSForecastingPreprocessor
 
             elif system:
                 if display_format == "streamlit":
-                    st.write(fig)
+                    if not return_fig:
+                        st.write(fig)
                 elif display_format == "plotly-widget":
-                    fig.update_layout(autosize=True)
-                    ipython_display(
-                        FigureWidgetResampler(
+                    if not return_fig:
+                        fig.update_layout(autosize=True)
+                        ipython_display(
+                            FigureWidgetResampler(
+                                fig,
+                                **resampler_kwargs,
+                                convert_traces_kwargs=dict(limit_to_views=True),
+                            )
+                        )
+                elif display_format == "plotly-dash":
+                    if not return_fig:
+                        fig.update_layout(autosize=True)
+                        FigureResampler(
                             fig,
                             **resampler_kwargs,
                             convert_traces_kwargs=dict(limit_to_views=True),
-                        )
-                    )
-                elif display_format == "plotly-dash":
-                    fig.update_layout(autosize=True)
-                    FigureResampler(
-                        fig,
-                        **resampler_kwargs,
-                        convert_traces_kwargs=dict(limit_to_views=True),
-                    ).show_dash(**show_dash_kwargs)
+                        ).show_dash(**show_dash_kwargs)
                 else:  # just a plain plotly-figure
                     try:
                         big_data_threshold = _resolve_dict_keys(

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -677,7 +677,7 @@ class TSForecastingExperiment(_TSSupervisedExperiment, TSForecastingPreprocessor
 
     def _check_and_set_seasonal_period(self) -> "TSForecastingExperiment":
         """
-        Derive the seasonal periods to use per teh following algorithm
+        Derive the seasonal periods to use per the following algorithm
         (1) Get the candidate seasonal periods
         (2) Perform seasonal checks to remove periods that do not indicate seasonality
         (3) Remove harmonics based on user settings
@@ -1178,7 +1178,7 @@ class TSForecastingExperiment(_TSSupervisedExperiment, TSForecastingPreprocessor
             (https://otexts.com/fpp2/seasonal-strength.html).
             NOTE: For Multiplicative, the denominator multiplies the seasonal and
             residual components instead of adding them. Rest of the calculations
-            remain the same. If seasonal decompositon fails for any reason, then
+            remain the same. If seasonal decomposition fails for any reason, then
             defaults to multiplicative seasonality.
         (4) Otherwise, seasonality_type is set to the user provided value.
 
@@ -1196,7 +1196,7 @@ class TSForecastingExperiment(_TSSupervisedExperiment, TSForecastingPreprocessor
         self._set_strictly_positive()
 
         # ---------------------------------------------------------------------#
-        # Override seasonality_type depending on various conditons
+        # Override seasonality_type depending on various conditions
         # ---------------------------------------------------------------------#
         if not self.seasonality_present:
             seasonality_type = None
@@ -1205,7 +1205,7 @@ class TSForecastingExperiment(_TSSupervisedExperiment, TSForecastingPreprocessor
             seasonality_type = "add"
         elif seasonality_type == "auto":
             if self.seasonality_present and self.strictly_positive:
-                # Try out additive and multiplicative seasonal decompostion
+                # Try out additive and multiplicative seasonal decomposition
                 # Check residuals and select the one with the least amount of variance
                 data_to_use = pd.DataFrame(
                     self._get_y_data(
@@ -1814,7 +1814,7 @@ class TSForecastingExperiment(_TSSupervisedExperiment, TSForecastingPreprocessor
                 per FPP (https://otexts.com/fpp2/seasonal-strength.html). NOTE:
                 For Multiplicative, the denominator multiplies the seasonal and
                 residual components instead of adding them. Rest of the
-                calculations remain the same. If seasonal decompositon fails for
+                calculations remain the same. If seasonal decomposition fails for
                 any reason, then defaults to multiplicative seasonality.
             (4) Otherwise, seasonality_type is set to the user provided value.
 
@@ -1950,7 +1950,7 @@ class TSForecastingExperiment(_TSSupervisedExperiment, TSForecastingPreprocessor
             renderer: The renderer used to display the plotly figure. Can be any value
                 supported by Plotly (e.g. "notebook", "png", "svg", etc.). Note that certain
                 renderers (like "svg") may need additional libraries to be installed. Users
-                will have to do this manually since they don't come preinstalled wit plotly.
+                will have to do this manually since they don't come preinstalled with plotly.
                 When not provided, plots use plotly's default render when data is below a
                 certain number of points (determined by `big_data_threshold`) otherwise it
                 switches to a static "png" renderer.


### PR DESCRIPTION
Closes: #3669

## Changes

Enabled a safe `if` check when running `fig.show()` during TimeSeries experiments. Without this change, then plots will be printed twice when we set the parameter: `return_fig=True`.

Full description included in:
- #3669

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No. It wasn't a bug previously, only a logical issue.

## Describe if there is any unusual behaviour of your code

NA

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.