### PR TITLE
Prepare for XGBoost 2.0

### DIFF
--- a/pycaret/containers/models/classification.py
+++ b/pycaret/containers/models/classification.py
@@ -1141,14 +1141,24 @@ class XGBClassifierContainer(ClassifierContainer):
             return
 
         from xgboost import XGBClassifier
+        
+        #If XGBoost > 2 change and add new parameters
+        xgboost_version = tuple(map(int, xgb.__version__.split('.')))
+        xgboost_2_or_higher = xgboost_version >= (2, 0, 0)
 
         args = {
             "random_state": experiment.seed,
             "n_jobs": experiment.n_jobs_param,
             "verbosity": 0,
-            "booster": "gbtree",
-            "tree_method": "gpu_hist" if experiment.gpu_param else "auto",
+            "booster": "gbtree",            
         }
+        
+        if xgboost_2_or_higher:
+            args["tree_method"] = "hist"
+            args["device"] = "cuda"
+        else:
+            args["tree_method"] = "gpu_hist" if experiment.gpu_param else "auto"
+        
         tune_args = {}
         tune_grid = {
             "learning_rate": [

--- a/pycaret/containers/models/regression.py
+++ b/pycaret/containers/models/regression.py
@@ -1519,14 +1519,24 @@ class XGBRegressorContainer(RegressorContainer):
             return
 
         from xgboost import XGBRegressor
+        
+        #If XGBoost > 2 change and add new parameters
+        xgboost_version = tuple(map(int, xgb.__version__.split('.')))
+        xgboost_2_or_higher = xgboost_version >= (2, 0, 0)
 
         args = {
             "random_state": experiment.seed,
             "n_jobs": experiment.n_jobs_param,
             "verbosity": 0,
-            "booster": "gbtree",
-            "tree_method": "gpu_hist" if experiment.gpu_param else "auto",
+            "booster": "gbtree",            
         }
+        
+        if xgboost_2_or_higher:
+            args["tree_method"] = "hist"
+            args["device"] = "cuda"
+        else:
+            args["tree_method"] = "gpu_hist" if experiment.gpu_param else "auto"
+            
         tune_args = {}
         tune_grid = {
             "learning_rate": [


### PR DESCRIPTION
# Related Issue or bug

Closes #3640

# Describe the changes you've made

The tree method `gpu_hist` is deprecated since 2.0.0, should use "hist" instead "gpu_hist".
Added new parameter "device" with "cuda" value.