### PR TITLE
limiting statsforecast due to deprecation of parallel argument

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -16,7 +16,8 @@ catboost>=0.23.2; platform_system != "Darwin"
 catboost>=0.23.2,<1.2; platform_system == "Darwin"  # https://github.com/pycaret/pycaret/issues/3563
 kmodes>=0.11.1
 mlxtend>=0.19.0
-statsforecast>=0.5.5
+# Can not be 1.6.0 since parallel argument in AutoARIMA was deprecated and this is not fixed in sktime
+statsforecast>=0.5.5,<1.6.0
 scikit-learn-intelex>=2023.0.1; platform_machine == 'x86_64' or platform_machine == 'AMD64'
 
 # Tuners


### PR DESCRIPTION
# Related Issue or bug

Closes #3721

Tests are failing on GitHub due to nixtla statsfoecast deprecating parallel argument in AutoARIMA in 1.6.0 (https://github.com/Nixtla/statsforecast/issues/576). This has also been reported to sktime: https://github.com/sktime/sktime/issues/5207

![image](https://github.com/pycaret/pycaret/assets/33585645/97b8ac77-344f-4c39-919f-2b8c549d2976)


# Describe the changes you've made

Limited statsforecast version to < 1.6.0

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tests pass locally now. Should also pass on GH

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

