### PR TITLE
pass plot_kwargs to ValidationCurve

### DIFF
--- a/pycaret/internal/pycaret_experiment/tabular_experiment.py
+++ b/pycaret/internal/pycaret_experiment/tabular_experiment.py
@@ -1743,6 +1743,17 @@ class _TabularExperiment(_PyCaretExperiment):
 
                     from yellowbrick.model_selection import ValidationCurve
 
+                    if 'param_name' in plot_kwargs:
+                        param_name = plot_kwargs['param_name']
+                        plot_kwargs.pop('param_name')
+                    if 'param_range' in plot_kwargs:
+                        param_range = plot_kwargs['param_range']
+                        plot_kwargs.pop('param_range')
+
+                    # ignore explicit arguments
+                    for arg in ['cv', 'groups', 'random_state', 'n_jobs']:
+                        plot_kwargs.pop(arg, None)
+                        
                     viz = ValidationCurve(
                         estimator,
                         param_name=param_name,
@@ -1751,6 +1762,7 @@ class _TabularExperiment(_PyCaretExperiment):
                         groups=groups,
                         random_state=self.seed,
                         n_jobs=self.gpu_n_jobs_param,
+                        **plot_kwargs
                     )
                     return show_yellowbrick_plot(
                         visualizer=viz,


### PR DESCRIPTION
- pass `plot_kwargs` to ValidationCurve()
- explicitly set `param_name` and `param_range` if they are included in `plot_kwargs`

# Related Issue or bug
https://github.com/pycaret/pycaret/issues/3746

Info about Issue or bug
Closes #3746 

# Describe the changes you've made

- pass `plot_kwargs` to ValidationCurve()
- explicitly set `param_name` and `param_range` if they are included in `plot_kwargs`

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Just tested locally

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

# Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
![Validation Curve](https://github.com/pycaret/pycaret/assets/2118854/b9c4d25e-b3ea-4342-86e8-70a7efd3a668)  |  
![Validation Curve](https://github.com/pycaret/pycaret/assets/2118854/2ae3f80f-aa9b-48d4-a89d-f2b0fb7eaff6)

