### PR TITLE
Dependencies: Permit NumPy up to 1.26. CI: Run Python 3.11 on `test_linux` workflow.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 ipython>=5.5.0
 ipywidgets>=7.6.5  # required by pycaret.internal.display
 tqdm>=4.62.0  # required by pycaret.internal.display
-numpy>=1.21, <1.24  # Can't >=1.24 because of np.float deprecation
+numpy>=1.21, <1.27
 pandas>=1.3.0, <2.0.0  # Can't >=2.0.0 because of sktime
 jinja2>=1.2  # Required by pycaret.internal.utils --> pandas.io.formats.style
 scipy~=1.10.1  # Can't >=2.0.0 due to sktime, optimization breaks with >1.10.1


### PR DESCRIPTION
Hi again,

in order to support GH-3756, this patch demonstrates that running the test suite succeeds on Python 3.11 without much ado, by permitting an installation of a more recent version of NumPy. This will probably also open the door for eventually thinking about upgrading pandas.

We exercised it at [^1] already, where Python 3.11/Linux succeeded, and we think the test suite failing on Windows 3.8 might be unrelated. Maybe you can have a closer look?

![image](https://github.com/pycaret/pycaret/assets/453543/74f6b299-2830-4ce9-b7f3-6c7bb29f10ef)

With kind regards,
Andreas.

[^1]: https://github.com/crate-workbench/pycaret/actions/runs/6762683108
