### PR TITLE
More Python 3.11 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
   test_linux:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11"]
 
@@ -147,6 +148,7 @@ jobs:
   test_windows:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11"]
 
@@ -217,6 +219,7 @@ jobs:
   test_plots:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11"]
 
@@ -249,6 +252,7 @@ jobs:
   test_ts_tune_random:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11"]
 
@@ -283,6 +287,7 @@ jobs:
   test_ts_tune_grid:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11"]
 
@@ -317,6 +322,7 @@ jobs:
   test_benchmarks:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11"]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           pip install -U pytest pytest-xdist nbmake
@@ -53,7 +53,7 @@ jobs:
           python -m ipykernel install --user --name cikernel
       - name: Python version and dependency list
         run: |
-          echo "Python version expected: 3.10"
+          echo "Python version expected: 3.11"
           python --version
           which python
           pip list
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -250,7 +250,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -284,7 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -318,7 +318,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pycaret/internal/pycaret_experiment/tabular_experiment.py
+++ b/pycaret/internal/pycaret_experiment/tabular_experiment.py
@@ -303,7 +303,7 @@ class _TabularExperiment(_PyCaretExperiment):
 
         # Global attrs
         self.USI = secrets.token_hex(nbytes=2)
-        self.seed = random.randint(150, 9000) if session_id is None else session_id
+        self.seed = int(random.randint(150, 9000) if session_id is None else session_id)
         np.random.seed(self.seed)
 
         # Initialization =========================================== >>

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -8,7 +8,7 @@ Flask==2.2.3  # https://github.com/oegedijk/explainerdashboard/issues/259
 fairlearn==0.7.0  # For check_fairness method
 
 # Models
-xgboost>=1.1.0
+xgboost>=1.1.0; python_version != "3.11" or platform_system != "Windows"
 catboost>=0.23.2; platform_system != "Darwin"
 catboost>=0.23.2,<1.2; platform_system == "Darwin"  # https://github.com/pycaret/pycaret/issues/3563
 kmodes>=0.11.1

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -18,8 +18,8 @@ statsforecast>=0.5.5,<1.6.0
 scikit-learn-intelex>=2023.0.1; platform_machine == 'x86_64' or platform_machine == 'AMD64'
 
 # Tuners
-tune-sklearn>=0.2.1
-ray[tune]>=1.0.0
+tune-sklearn>=0.2.1; python_version != "3.11" or platform_system != "Windows"
+ray[tune]>=1.0.0; python_version != "3.11" or platform_system != "Windows"
 hyperopt>=0.2.7
 optuna>=3.0.0
 scikit-optimize>=0.9.0

--- a/tests/test_overflow.py
+++ b/tests/test_overflow.py
@@ -1,10 +1,12 @@
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.abspath(".."))
 
 
-def test_overflow():
+def test_overflow_gbr_lightgbm():
     from pycaret.datasets import get_data
 
     data = get_data("boston")
@@ -19,8 +21,26 @@ def test_overflow():
     )
     gbr = create_model("gbr")
     tune_model(gbr)
-    xgboost = create_model("xgboost")
-    tune_model(xgboost)
     lightgbm = create_model("lightgbm")
     tune_model(lightgbm)
+    assert 1 == 1
+
+
+def test_overflow_xgboost():
+    pytest.importorskip("xgboost", reason="Package xgboost not installed")
+
+    from pycaret.datasets import get_data
+
+    data = get_data("boston")
+    from pycaret.regression import create_model, setup, tune_model
+
+    setup(
+        data,
+        target="medv",
+        html=False,
+        session_id=123,
+        n_jobs=1,
+    )
+    xgboost = create_model("xgboost")
+    tune_model(xgboost)
     assert 1 == 1


### PR DESCRIPTION
## About
Based on GH-3813 and GH-3756, this patch aims to activate Python 3.11 across the board, modulo Dockerfiles.

## Outcome
![image](https://github.com/pycaret/pycaret/assets/453543/7d1c4beb-8fb6-4430-ac45-c1ca227e6a0b)

-- https://github.com/crate-workbench/pycaret/actions/runs/6763789876

## Backlog
Fix error on Python3.11/Windows. pytest does not even start.
```python
Run pytest --durations=0
ImportError while loading conftest 'D:\a\pycaret\pycaret\tests\conftest.py'.
tests\conftest.py:4: in <module>
    import pycaret.anomaly.functional
E   ModuleNotFoundError: No module named 'pycaret'
Error: Process completed with exit code 1.
```
-- https://github.com/crate-workbench/pycaret/actions/runs/6763789876/job/18381329119#step:7:15