### PR TITLE
Optimize CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
   test_linux:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11"]
 
@@ -147,6 +148,7 @@ jobs:
   test_windows:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11"]
 
@@ -217,6 +219,7 @@ jobs:
   test_plots:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11"]
 
@@ -249,6 +252,7 @@ jobs:
   test_ts_tune_random:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11"]
 
@@ -283,6 +287,7 @@ jobs:
   test_ts_tune_grid:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11"]
 
@@ -317,6 +322,7 @@ jobs:
   test_benchmarks:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11"]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   code_quality:
     runs-on: ubuntu-latest
+    name: Code quality checks
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
@@ -39,6 +40,7 @@ jobs:
   # JOBS MUST START WITH test !!!!
   test_notebooks:
     runs-on: ubuntu-latest
+    name: Test notebooks
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
@@ -60,13 +62,19 @@ jobs:
       - name: Run notebooks
         run: pytest --nbmake --nbmake-kernel=cikernel -n=auto --nbmake-timeout=3000 --ignore=./tutorials/translations ./tutorials/
 
-  test_linux:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        os: [ 'ubuntu-latest', 'windows-latest' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
 
+    defaults:
+      run:
+        shell: bash
+
+    name: Python ${{ matrix.python-version }} on OS ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -89,132 +97,8 @@ jobs:
           python --version
           which python
           pip list
-      - name: Remove tests
-        run: |
-          rm tests/test_classification_tuning.py
-          rm tests/test_classification_plots.py
-          rm tests/test_regression_plots.py
-          rm tests/test_regression_tuning.py
-          rm tests/test_time_series_tune_grid.py
-          rm tests/test_time_series_tune_random.py
-          rm tests/test_time_series_plots.py
-          rm tests/test_time_series_utils_plots.py
-          rm tests/benchmarks/*.py
       - name: Test with pytest
-        run: pytest --durations=0
-
-  # test_linux_3p11:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       python-version: ["3.11"]
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: Install dependencies
-  #       # SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
-  #       # pyLDAvis 3.3.1 having an "sklearn" dependency
-  #       run: |
-  #         export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
-  #         python -m pip install -U pip
-  #         python -m pip install -U pytest numpy
-
-  #         pip install ".[full, test]"
-  #         if [ -f requirements-prophet.txt ]; then pip install -r requirements-prophet.txt; fi
-  #     - name: Python version and dependency list
-  #       run: |
-  #         echo "Python version expected: ${{ matrix.python-version }}"
-  #         python --version
-  #         which python
-  #         pip list
-  #     - name: Remove tests
-  #       run: |
-  #         rm tests/test_classification_tuning.py
-  #         rm tests/test_classification_plots.py
-  #         rm tests/test_regression_plots.py
-  #         rm tests/test_regression_tuning.py
-  #         rm tests/test_time_series_tune_grid.py
-  #         rm tests/test_time_series_tune_random.py
-  #         rm tests/test_time_series_plots.py
-  #         rm tests/test_time_series_utils_plots.py
-  #         rm tests/benchmarks/*.py
-  #     - name: Test with pytest
-  #       run: pytest --durations=0
-
-  test_windows:
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        # SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
-        # pyLDAvis 3.3.1 having an "sklearn" dependency
-        run: |
-          $env:SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL = 'True'
-          python -m pip install -U pip
-          python -m pip install -U pytest numpy
-
-          pip install ".[full, test]"
-          pip install -r requirements-prophet.txt
-      - name: Python version and dependency list
-        run: |
-          echo "Python version expected: ${{ matrix.python-version }}"
-          python --version
-          which python
-          pip list
-      - name: Remove tests
-        run: |
-          remove-item tests/* -Include @('test_clustering.py', 'test_classification_tuning.py','test_classification_plots.py','test_regression_plots.py', 'test_regression_tuning.py', 'test_time_series_tune_grid.py', 'test_time_series_tune_random.py', 'test_create_api.py', 'test_create_docker.py', 'test_drift_report.py', 'test_eda.py', 'test_time_series_plots.py', 'test_time_series_utils_plots.py')
-          remove-item tests/benchmarks/*
-      - name: Test with pytest
-        run: pytest --durations=0
-
-  # test_windows_3p11:
-  #   runs-on: windows-latest
-  #   strategy:
-  #     matrix:
-  #       python-version: ["3.11"]
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: Install dependencies
-  #       # SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
-  #       # pyLDAvis 3.3.1 having an "sklearn" dependency
-  #       run: |
-  #         $env:SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL = 'True'
-  #         python -m pip install -U pip
-  #         python -m pip install -U pytest numpy
-
-  #         pip install ".[full, test]"
-  #         pip install -r requirements-prophet.txt
-  #     - name: Python version and dependency list
-  #       run: |
-  #         echo "Python version expected: ${{ matrix.python-version }}"
-  #         python --version
-  #         which python
-  #         pip list
-  #     - name: Remove tests
-  #       run: |
-  #         remove-item tests/* -Include @('test_clustering.py', 'test_classification_tuning.py','test_classification_plots.py','test_regression_plots.py', 'test_regression_tuning.py', 'test_time_series_tune_grid.py', 'test_time_series_tune_random.py', 'test_create_api.py', 'test_create_docker.py', 'test_drift_report.py', 'test_eda.py', 'test_time_series_plots.py', 'test_time_series_utils_plots.py')
-  #         remove-item tests/benchmarks/*
-  #     - name: Test with pytest
-  #       run: pytest --durations=0
+        run: pytest --durations=0 -m "not (benchmark or plotting or tuning_random)"
 
   test_plots:
     runs-on: ubuntu-latest
@@ -223,6 +107,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
 
+    name: Test plotting
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -243,11 +128,8 @@ jobs:
           python --version
           which python
           pip list
-      - name: Remove tests
-        run: |
-          find tests -type f -not -name '__init__.py' -not -name 'test_classification_plots.py' -not -name 'test_regression_plots.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'test_time_series_plots.py' -not -name 'test_time_series_utils_plots.py' -delete
       - name: Test with pytest
-        run: pytest --durations=0
+        run: pytest --durations=0 -m "plotting"
 
   test_ts_tune_random:
     runs-on: ubuntu-latest
@@ -256,6 +138,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
 
+    name: Test random tuning
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -278,11 +161,8 @@ jobs:
           python --version
           which python
           pip list
-      - name: Remove tests
-        run: |
-          find tests -type f -not -name '__init__.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'test_time_series_tune_random.py' -delete
       - name: Test with pytest
-        run: pytest --durations=0
+        run: pytest --durations=0 -m "tuning_random"
 
   test_ts_tune_grid:
     runs-on: ubuntu-latest
@@ -291,6 +171,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
 
+    name: Test grid tuning
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -313,11 +194,8 @@ jobs:
           python --version
           which python
           pip list
-      - name: Remove tests
-        run: |
-          find tests -type f -not -name '__init__.py' -not -name 'conftest.py' -not -name 'time_series_test_utils.py' -not -name 'test_time_series_tune_grid.py' -delete
       - name: Test with pytest
-        run: pytest --durations=0
+        run: pytest --durations=0 -m "tuning_grid"
 
   test_benchmarks:
     runs-on: ubuntu-latest
@@ -326,6 +204,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
 
+    name: Benchmark tests
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -349,5 +228,4 @@ jobs:
           which python
           pip list
       - name: Run benchmarks
-        run: pytest tests/benchmarks --durations=0
-
+        run: pytest --durations=0 -m "benchmark"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           pip install -U pytest pytest-xdist nbmake
@@ -53,7 +53,7 @@ jobs:
           python -m ipykernel install --user --name cikernel
       - name: Python version and dependency list
         run: |
-          echo "Python version expected: 3.10"
+          echo "Python version expected: 3.11"
           python --version
           which python
           pip list
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -250,7 +250,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -284,7 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -318,7 +318,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pycaret/internal/pycaret_experiment/tabular_experiment.py
+++ b/pycaret/internal/pycaret_experiment/tabular_experiment.py
@@ -303,7 +303,7 @@ class _TabularExperiment(_PyCaretExperiment):
 
         # Global attrs
         self.USI = secrets.token_hex(nbytes=2)
-        self.seed = random.randint(150, 9000) if session_id is None else session_id
+        self.seed = int(random.randint(150, 9000) if session_id is None else session_id)
         np.random.seed(self.seed)
 
         # Initialization =========================================== >>

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -8,7 +8,7 @@ Flask==2.2.3  # https://github.com/oegedijk/explainerdashboard/issues/259
 fairlearn==0.7.0  # For check_fairness method
 
 # Models
-xgboost>=1.1.0
+xgboost>=1.1.0; python_version != "3.11" or platform_system != "Windows"
 catboost>=0.23.2; platform_system != "Darwin"
 catboost>=0.23.2,<1.2; platform_system == "Darwin"  # https://github.com/pycaret/pycaret/issues/3563
 kmodes>=0.11.1

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -18,8 +18,8 @@ statsforecast>=0.5.5,<1.6.0
 scikit-learn-intelex>=2023.0.1; platform_machine == 'x86_64' or platform_machine == 'AMD64'
 
 # Tuners
-tune-sklearn>=0.2.1
-ray[tune]>=1.0.0
+tune-sklearn>=0.2.1; python_version != "3.11" or platform_system != "Windows"
+ray[tune]>=1.0.0; python_version != "3.11" or platform_system != "Windows"
 hyperopt>=0.2.7
 optuna>=3.0.0
 scikit-optimize>=0.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,3 +31,8 @@ per-file-ignores =
 testpaths = tests/
 python_files = *.py
 python_functions = test_*
+markers =
+    benchmark
+    plotting
+    tuning_grid
+    tuning_random

--- a/tests/benchmarks/test_memory_performance.py
+++ b/tests/benchmarks/test_memory_performance.py
@@ -18,6 +18,11 @@ from pycaret.datasets import get_data
 from pycaret.internal.memory import fast_hash  # noqa
 from pycaret.regression import RegressionExperiment
 
+pytestmark = [
+    pytest.mark.benchmark,
+]
+
+
 data_df = get_data(verbose=False)
 supervised_datasets_df = data_df.copy()
 supervised_datasets_df["Items"] = (

--- a/tests/benchmarks/test_time_series_sp_detection.py
+++ b/tests/benchmarks/test_time_series_sp_detection.py
@@ -5,6 +5,11 @@ import pytest
 from pycaret.datasets import get_data
 from pycaret.time_series import TSForecastingExperiment
 
+pytestmark = [
+    pytest.mark.benchmark,
+]
+
+
 ids = ["raw_strength", "harmonic_max", "harmonic_strength"]
 params = [
     (ids[0], 0.9211, 0.9307, 0.1230, 0.8365),

--- a/tests/test_classification_plots.py
+++ b/tests/test_classification_plots.py
@@ -1,9 +1,11 @@
 import pandas as pd
+import pytest
 
 import pycaret.classification
 import pycaret.datasets
 
 
+@pytest.mark.plotting
 def test_plot():
     # loading dataset
     data = pycaret.datasets.get_data("juice")

--- a/tests/test_classification_tuning.py
+++ b/tests/test_classification_tuning.py
@@ -11,6 +11,10 @@ os.environ["TUNE_DISABLE_AUTO_CALLBACK_LOGGERS"] = "1"
 os.environ["TUNE_MAX_LEN_IDENTIFIER"] = "1"
 
 
+if "CI" in os.environ:
+    pytest.skip("Skipping test module on CI", allow_module_level=True)
+
+
 @pytest.mark.skip(reason="no way of currently testing this")
 def test_classification_tuning():
     # loading dataset

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,3 +1,4 @@
+import sys
 import uuid
 
 import pandas as pd
@@ -6,6 +7,9 @@ from mlflow.tracking import MlflowClient
 
 import pycaret.clustering
 import pycaret.datasets
+
+if sys.platform == "win32":
+    pytest.skip("Skipping test module on Windows", allow_module_level=True)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_create_api.py
+++ b/tests/test_create_api.py
@@ -1,6 +1,13 @@
+import sys
+
+import pytest
+
 import pycaret.classification
 import pycaret.datasets
 import pycaret.regression
+
+if sys.platform == "win32":
+    pytest.skip("Skipping test module on Windows", allow_module_level=True)
 
 
 def test_classification_create_api():

--- a/tests/test_create_docker.py
+++ b/tests/test_create_docker.py
@@ -1,6 +1,13 @@
+import sys
+
+import pytest
+
 import pycaret.classification
 import pycaret.datasets
 import pycaret.regression
+
+if sys.platform == "win32":
+    pytest.skip("Skipping test module on Windows", allow_module_level=True)
 
 
 def test_classification_create_docker():

--- a/tests/test_overflow.py
+++ b/tests/test_overflow.py
@@ -1,10 +1,12 @@
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.abspath(".."))
 
 
-def test_overflow():
+def test_overflow_gbr_lightgbm():
     from pycaret.datasets import get_data
 
     data = get_data("boston")
@@ -19,8 +21,26 @@ def test_overflow():
     )
     gbr = create_model("gbr")
     tune_model(gbr)
-    xgboost = create_model("xgboost")
-    tune_model(xgboost)
     lightgbm = create_model("lightgbm")
     tune_model(lightgbm)
+    assert 1 == 1
+
+
+def test_overflow_xgboost():
+    pytest.importorskip("xgboost", reason="Package xgboost not installed")
+
+    from pycaret.datasets import get_data
+
+    data = get_data("boston")
+    from pycaret.regression import create_model, setup, tune_model
+
+    setup(
+        data,
+        target="medv",
+        html=False,
+        session_id=123,
+        n_jobs=1,
+    )
+    xgboost = create_model("xgboost")
+    tune_model(xgboost)
     assert 1 == 1

--- a/tests/test_regression_plots.py
+++ b/tests/test_regression_plots.py
@@ -1,9 +1,11 @@
 import pandas as pd
+import pytest
 
 import pycaret.datasets
 import pycaret.regression
 
 
+@pytest.mark.plotting
 def test_plot():
     # loading dataset
     data = pycaret.datasets.get_data("boston")

--- a/tests/test_regression_tuning.py
+++ b/tests/test_regression_tuning.py
@@ -1,9 +1,14 @@
+import sys
+
 import pandas as pd
 import pytest
 
 import pycaret.datasets
 import pycaret.regression
 from pycaret.utils.generic import can_early_stop
+
+if sys.platform == "linux":
+    pytest.skip("Skipping test module on Linux", allow_module_level=True)
 
 
 @pytest.mark.skip(reason="no way of currently testing this")

--- a/tests/test_time_series_models.py
+++ b/tests/test_time_series_models.py
@@ -64,7 +64,7 @@ def test_custom_models(load_pos_data):
     # Test Create Custom Model ----
     ##################################
     my_custom_model = exp.create_model(forecaster)
-    assert type(my_custom_model) == type(forecaster)
+    assert type(my_custom_model) is type(forecaster)
 
     ################################
     # Test Tune Custom Model ----
@@ -76,7 +76,7 @@ def test_custom_models(load_pos_data):
         custom_grid=my_grid,
         return_tuner=True,
     )
-    assert type(tuned_model) == type(forecaster)
+    assert type(tuned_model) is type(forecaster)
     assert "param_forecaster__model__impute__method" in pd.DataFrame(tuner.cv_results_)
     for index, method in enumerate(
         tuner.cv_results_.get("param_forecaster__model__impute__method")

--- a/tests/test_time_series_plots.py
+++ b/tests/test_time_series_plots.py
@@ -1,6 +1,7 @@
 """Module to test time_series plotting functionality
 """
 import os
+import sys
 
 import numpy as np  # type: ignore
 import pytest
@@ -18,6 +19,9 @@ from pycaret.time_series import TSForecastingExperiment
 
 pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 os.environ["PYCARET_TESTING"] = "1"
+
+if sys.platform == "win32":
+    pytest.skip("Skipping test module on Windows", allow_module_level=True)
 
 
 ##############################

--- a/tests/test_time_series_tune_grid.py
+++ b/tests/test_time_series_tune_grid.py
@@ -7,8 +7,10 @@ from time_series_test_utils import _return_model_names
 
 from pycaret.time_series import TSForecastingExperiment
 
-pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
-
+pytestmark = [
+    pytest.mark.filterwarnings("ignore::UserWarning"),
+    pytest.mark.tuning_grid,
+]
 
 ##############################
 # Functions Start Here ####

--- a/tests/test_time_series_tune_random.py
+++ b/tests/test_time_series_tune_random.py
@@ -7,7 +7,10 @@ from time_series_test_utils import _return_model_names
 
 from pycaret.time_series import TSForecastingExperiment
 
-pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
+pytestmark = [
+    pytest.mark.filterwarnings("ignore::UserWarning"),
+    pytest.mark.tuning_random,
+]
 
 
 ##############################

--- a/tests/test_time_series_utils_plots.py
+++ b/tests/test_time_series_utils_plots.py
@@ -15,7 +15,10 @@ from pycaret.internal.plots.utils.time_series import (
     _reformat_dataframes_for_plots,
 )
 
-pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
+pytestmark = [
+    pytest.mark.filterwarnings("ignore::UserWarning"),
+    pytest.mark.plotting,
+]
 
 
 ##########################


### PR DESCRIPTION
Hi Antoni,

while working on GH-3814, we discovered the style of running specific groups of test cases by removing files from the `tests/` folder. This patch steers that detail into a different direction, by using pytest markers and pytest.skip() annotations instead. We hope you like that approach.

In this spirit, by using this style of discriminating the test cases within the CI/GHA workflow definition file, it becomes much easier to maintain.

With kind regards,
Andreas.

#### References

- https://docs.pytest.org/en/7.1.x/how-to/mark.html
- https://docs.pytest.org/en/7.1.x/example/markers.html
