### PR TITLE
Add one-click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ docker run -p 8888:8888 pycaret/slim
 docker run -p 8888:8888 pycaret/full
 ```
 
+## ☁️ Option 4: Self-Host in the Cloud
+Deploy in one-click with [Dome](https://app.trydome.io/signup?package=pycaret):
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=pycaret)
+
 ## 🏃‍♂️ Quickstart
 
 ### 1. Functional API


### PR DESCRIPTION
Hey!

We built this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.

After deployment, users receive a link like this, which can then be CNAME-ed to any domain:

https://13b7fadfffe31ff3c13c01566691ec4a78f664be.dome.tools

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.