### PR TITLE
Update copyright headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 PyCaret
+Copyright (c) 2024 PyCaret
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
-# Copyright (C) 2019-2020 Moez Ali <moez.ali@queensu.ca>
-# License: MIT, moez.ali@queensu.ca
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
 
 from setuptools import find_packages, setup
 


### PR DESCRIPTION
Updated the copyright header in all/applicable files to correctly reflect copyright attribution to the PyCaret project and contributors.

Main changes:
- Replaced the copyright line to 'Copyright (C) 2019-2024 PyCaret'.
- added a line to indicate the main author: 'Author: Moez Ali (moez.ali@queensu.ca)'.
- included a line to reference all contributors: 'Contributors (https://github.com/pycaret/pycaret/graphs/contributors)'.

This update complies with the PyCaret project's copyright attribution practices and provides clear author and contributor information.

Future tasks:
- Check other files to ensure consistency in copyright headers.