### PR TITLE
Custom path for logging (logs.log)

### DIFF
--- a/pycaret/internal/logging.py
+++ b/pycaret/internal/logging.py
@@ -138,7 +138,7 @@ def create_logger(
     if logger.hasHandlers():
         logger.handlers.clear()
 
-    # custom path to logs.log
+    # custom path for logging, if not given, will use local logs.log
     logPath = os.getenv("PYCARET_CUSTOM_LOGGING_PATH", "logs.log")
     path = logPath if isinstance(log, bool) else log
     ch: Optional[Union[logging.FileHandler, logging.NullHandler]] = None

--- a/pycaret/internal/logging.py
+++ b/pycaret/internal/logging.py
@@ -138,7 +138,9 @@ def create_logger(
     if logger.hasHandlers():
         logger.handlers.clear()
 
-    path = "logs.log" if isinstance(log, bool) else log
+    # custom path to logs.log
+    logPath = os.getenv("PYCARET_CUSTOM_LOGGING_PATH", "logs.log")
+    path = logPath if isinstance(log, bool) else log
     ch: Optional[Union[logging.FileHandler, logging.NullHandler]] = None
     try:
         ch = logging.FileHandler(path)


### PR DESCRIPTION
# Related Issue or bug

The logs.log file is automatically generated in the import script directory (by pycaret/internal/logging.py). This creates problems when the directory is not writable, like AWS Lambda.
I particularly have problems using it directly in the lambda with a container, as the only free directory to write to is '/tmp'.
This update is correctly saving to the desired path.
I found other reports like issue #1057.

Closes #1057

# Describe the changes you've made

I created a new variable 'logPath' and assigned it an environment variable (PYCARET_CUSTOM_LOGGING_PATH), similar to the one already used for the log level (PYCARET_CUSTOM_LOGGING_LEVEL).
I changed the name of the file ‘logs.log’ to this variable, which takes the path informed in the environment variable and if it doesn’t exist, it continues as ‘logs.log’

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

After updating the function, I ran pycaret update and provided a new path to the 'PYCARET_CUSTOM_LOGGING_PATH' environment variable.
I imported the functions 'from pycaret.regression import load_model, predict_model' and verified the log file creation as desired.

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

`NA`

# Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.