### PR TITLE
Upgrade old evidently api to new api

### DIFF
--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -5658,6 +5658,7 @@ class _SupervisedExperiment(_TabularExperiment):
         return filename
         """
 
+        # Todo: test if works correctly and remove commented (backup) code above
         from evidently import ColumnMapping
         from evidently.metric_preset import DataDriftPreset, TargetDriftPreset
         from evidently.report import Report

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -5630,7 +5630,7 @@ class _SupervisedExperiment(_TabularExperiment):
                 .difference(categorical_features)
                 .difference(date_features)
             )
-
+        """
         from evidently.dashboard import Dashboard
         from evidently.pipeline.column_mapping import ColumnMapping
         from evidently.tabs import CatTargetDriftTab, DataDriftTab
@@ -5655,6 +5655,30 @@ class _SupervisedExperiment(_TabularExperiment):
             filename or f"{self.exp_name_log}_{int(time.time())}_Drift_Report.html"
         )
         dashboard.save(filename)
+        return filename
+        """
+
+        from evidently import ColumnMapping
+        from evidently.metric_preset import DataDriftPreset, TargetDriftPreset
+        from evidently.report import Report
+
+        column_mapping = ColumnMapping()
+        column_mapping.target = target
+        column_mapping.prediction = None
+        column_mapping.datetime = None
+        column_mapping.numerical_features = numeric_features
+        column_mapping.categorical_features = categorical_features
+        column_mapping.datetime_features = date_features
+
+        report = Report(metrics=[DataDriftPreset(), TargetDriftPreset()])
+
+        # Generate the report filename
+        filename = f"{self.exp_name_log}_{int(time.time())}_Drift_Report.html"
+
+        # Save the report as an HTML file
+        report.save(filename)
+
+        # Return the filename
         return filename
 
     @classmethod

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -33,7 +33,7 @@ boto3>=1.24.56  # For deploy_model method
 fastapi  # For web api
 uvicorn>=0.17.6  # For web api
 m2cgen>=0.9.0  # For model conversion
-evidently
+evidently~=0.4.16
 
 # Parallel
 fugue

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,6 @@ plotly-resampler>=0.8.3.1
 
 # Time-series
 statsmodels>=0.12.1
-sktime==0.26.0 # 0.26.0 support for scikit-learn 1.4
+sktime~=0.26.0 # 0.26.0 support for scikit-learn 1.4
 tbats>=1.1.3
 pmdarima>=2.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,6 @@ plotly-resampler>=0.8.3.1
 
 # Time-series
 statsmodels>=0.12.1
-sktime>=0.26.0 # 0.26.0 support for scikit-learn 1.4
+sktime==0.26.0 # 0.26.0 support for scikit-learn 1.4
 tbats>=1.1.3
 pmdarima>=2.0.4


### PR DESCRIPTION
I recently started seeing a problem in pycaret tests, ModuleNotFoundError: No module named 'evidently.dashboard'
After investigating, I discovered that the code used in Pycaret to use evidetly is very old, so it was necessary to update the Pycaret code.
For better context: I was unable to use an old version of evidently because it forced me to change all pycaret dependencies to older versions, in other words, a conflict of dependencies was generated. The only solution is to use recent (and modern) versions

I also asked for help at https://github.com/evidentlyai/evidently/issues/1010