### PR TITLE
applymap deprecated since pandas 2.1

### DIFF
--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -336,7 +336,7 @@ class _SupervisedExperiment(_TabularExperiment):
                         if x in greater_is_worse_columns
                     ],
                 )
-                .applymap(highlight_cols, subset=["TT (Sec)"])
+                .map(highlight_cols, subset=["TT (Sec)"])
             )
         else:
             return pd.DataFrame().style

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ ipython>=5.5.0
 ipywidgets>=7.6.5
 tqdm>=4.62.0
 numpy>=1.21, <1.27
-pandas<2.2.0 #test_check_fairness_regression fails with pandas 2.2.0
+pandas<2.2.0, >=2.1.0 #Min pandas 2.1.0 #test_check_fairness_regression fails with pandas 2.2.0
 jinja2>=3
 scipy>=1.6.1,<=1.11.4 #to fix later (https://github.com/mljar/mljar-supervised/issues/691)
 joblib>=1.2.0  # joblib<1.2.0 is vulnerable to Arbitrary Code Execution (https://github.com/advisories/GHSA-6hrg-qmvc-2xh8)


### PR DESCRIPTION
Deprecated since version 2.1.0: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
See: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.applymap.html