### PR TITLE
Fix dependency: Python 3.11.9 breaks Dask

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -36,6 +36,8 @@ m2cgen>=0.9.0  # For model conversion
 evidently~=0.4.16
 
 # Parallel
+dask>=2024.4.1            # Python 3.11.9 breaks Dask (https://github.com/dask/dask/issues/11038)
+distributed>=2024.4.1     # Python 3.11.9 breaks Dask (https://github.com/dask/dask/issues/11038)
 fugue
 flask
 Werkzeug>=2.2,<3.0


### PR DESCRIPTION
## Problem
The recent release of Python 3.11.9 introduced an incompatibility with current versions of Dask.

Previous versions of Dask, which is pulled in transitively via Fugue through `pycaret[parallel]`, stopped working on Python 3.11.9, so that needs an update.

## Solution
In order to fix the problem without much efforts, this patch updates to a recent version of Dask>=2024.4.1, which includes a corresponding fix.

## Evaluation
It is advisable to release this update on behalf of a bugfix release, so that downstream users will get this issue resolved quickly.

## References

- https://github.com/pycaret/pycaret/issues/3960
- https://github.com/dask/dask/issues/11038
