### PR TITLE
Fix dependency: Joblib 1.4.0 breaks PyCaret

### DIFF
--- a/pycaret/internal/memory.py
+++ b/pycaret/internal/memory.py
@@ -27,7 +27,6 @@ from joblib.memory import (
     MemorizedResult,
     Memory,
     NotMemorizedResult,
-    _format_load_msg,
     filter_args,
     format_call,
     format_signature,
@@ -35,6 +34,8 @@ from joblib.memory import (
     get_func_name,
 )
 from xxhash import xxh128 as xxh
+
+from pycaret.utils.compat import joblib_format_load_msg as _format_load_msg
 
 try:
     from math import prod

--- a/pycaret/utils/compat.py
+++ b/pycaret/utils/compat.py
@@ -1,0 +1,31 @@
+import os
+import time
+
+from joblib.logger import format_time
+
+
+def joblib_format_load_msg(func_id, args_id, timestamp=None, metadata=None):
+    """
+    Helper function to format the message when loading the results.
+    Vendorized from Joblib 1.3.2 to retain compatibility with Joblib 1.4.0.
+    """
+    signature = ""
+    try:
+        if metadata is not None:
+            args = ", ".join(
+                [
+                    "%s=%s" % (name, value)
+                    for name, value in metadata["input_args"].items()
+                ]
+            )
+            signature = "%s(%s)" % (os.path.basename(func_id), args)
+        else:
+            signature = os.path.basename(func_id)
+    except KeyError:
+        pass
+
+    if timestamp is not None:
+        ts_string = "{0: <16}".format(format_time(time.time() - timestamp))
+    else:
+        ts_string = ""
+    return "[Memory]{0}: Loading {1}".format(ts_string, str(signature))


### PR DESCRIPTION
## Problem
PyCaret uses the private function `joblib.memory._format_load_msg` from Joblib, which is no longer present in Joblib 1.4.
- https://github.com/pycaret/pycaret/issues/3959

## Solution
In order to fix the problem without much efforts, this patch vendorizes the corresponding function from Joblib without much ado.

## Evaluation
It is advisable to release this update on behalf of a bugfix release, so that downstream users will get this issue resolved quickly.

## Install
In order to use the patch instantly before upstream maintainers ran a new bugfix release, if it's important to you, you may want to use this pip package specification to install the package in an ad hoc manner, including the fixes for both dependency flaws.

```console
pip install --upgrade 'pycaret[parallel] @ git+https://github.com/crate-workbench/pycaret@fix-joblib-vendorize'
```

It also works within package metadata specifications like setup.py, setup.cfg, pyproject.toml, or requirements.txt files, with recent versions of pip, when the git command is available on the installation environment. This satisfies most workstation installations, the Google Colab runtime environment, and probably a few others where git is provided.


## Trivia

Please note this patch is not sufficient to make PyCaret work on Python 3.11.9, which also has been released recently [^1], and introduces another incompatibility. You will additionally need that patch to make it work:

- GH-3963

However, this does not impact users who did not update their Python 3.11 version yet, and others who might still be on Python 3.10 or earlier.

[^1]: That's the reason why CI still fails, see GH-3966, which summarizes both issues.