### PR TITLE
Fix dependency: Joblib 1.4.0 breaks PyCaret, so downgrade to <1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ trained_models/
 mlflow_backend.py
 demo4.py
 dask*/
-/.venv
+/.venv*
 /.devcontainer
 tmp/
 nbtest1.ipynb

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy>=1.21, <1.27
 pandas<2.2.0 #test_check_fairness_regression fails with pandas 2.2.0
 jinja2>=3
 scipy>=1.6.1,<=1.11.4 #to fix later (https://github.com/mljar/mljar-supervised/issues/691)
-joblib>=1.2.0  # joblib<1.2.0 is vulnerable to Arbitrary Code Execution (https://github.com/advisories/GHSA-6hrg-qmvc-2xh8)
+joblib>=1.2.0,<1.4  # joblib<1.2.0 is vulnerable to Arbitrary Code Execution (https://github.com/advisories/GHSA-6hrg-qmvc-2xh8)  # joblib 1.4.0 breaks PyCaret
 scikit-learn>1.4.0 #scikit-learn 1.4.0 have a bug (https://github.com/scikit-learn/scikit-learn/pull/28241)
 pyod>=1.1.3 #1.1.3 to support scikit-learn 1.4 (https://github.com/yzhao062/pyod/issues/542)
 imbalanced-learn>=0.12.0 # >=0.12.0 to support scikit-learn 1.4


### PR DESCRIPTION
## Problem
PyCaret uses the private functions `joblib.memory._format_load_msg` and `FastMemorizedFunc._get_output_identifiers` from Joblib, which are no longer present in Joblib 1.4.

- https://github.com/pycaret/pycaret/issues/3959

## Solution
In order to fix the problem without much efforts, this patch just downgrades to Joblib 1.3.x without further ado.

## Evaluation
It is advisable to release this update on behalf of a bugfix release, so that downstream users will get this issue resolved quickly.

## Install
In order to use the patch instantly before upstream maintainers ran a new bugfix release, if it's important to you, you may want to use this pip package specification to install the package in an ad hoc manner, including the fixes for both dependency flaws.

```console
pip install --upgrade 'pycaret[parallel] @ git+https://github.com/crate-workbench/pycaret@fix-joblib-downgrade'
```

It also works within package metadata specifications like `setup.py`, `setup.cfg`, `pyproject.toml`, or `requirements.txt` files, with recent versions of pip, when the git command is available on the installation environment. This satisfies most workstation installations, the Google Colab runtime environment, and probably a few others where git is provided.


## Trivia

Please note this patch is not sufficient to make PyCaret work on Python 3.11.9, which also has been released recently [^1], and introduces another incompatibility. You will additionally need that patch to make it work:

- GH-3963

However, this does not impact users who did not update their Python 3.11 version yet, and others who might still be on Python 3.10 or earlier.

[^1]: That's the reason why CI still fails, see GH-3966, which summarizes both issues.
