### PR TITLE
Fix #3977 - Update memory.py to remove "from joblib import _format_load_msg"

### DIFF
--- a/pycaret/internal/memory.py
+++ b/pycaret/internal/memory.py
@@ -27,7 +27,6 @@ from joblib.memory import (
     MemorizedResult,
     Memory,
     NotMemorizedResult,
-    _format_load_msg,
     filter_args,
     format_call,
     format_signature,
@@ -364,11 +363,6 @@ class FastMemorizedFunc(MemorizedFunc):
         else:
             try:
                 t0 = time.time()
-                if self._verbose:
-                    msg = _format_load_msg(
-                        func_id, args_id, timestamp=self.timestamp, metadata=metadata
-                    )
-
                 if not shelving:
                     # When shelving, we do not need to load the output
                     out = self.store_backend.load_item(


### PR DESCRIPTION
# Related Issue or bug
#3977

Info about Issue or bug

Closes #3977

# Describe the changes you've made

Update memory.py to remove "from joblib import _format_load_msg"

# Type of change
Bugfix, tested. 