### PR TITLE
Update memory.py - removing joblib._format_load_msg() usage

### DIFF
--- a/pycaret/internal/memory.py
+++ b/pycaret/internal/memory.py
@@ -27,7 +27,6 @@ from joblib.memory import (
     MemorizedResult,
     Memory,
     NotMemorizedResult,
-    _format_load_msg,
     filter_args,
     format_call,
     format_signature,
@@ -364,11 +363,6 @@ class FastMemorizedFunc(MemorizedFunc):
         else:
             try:
                 t0 = time.time()
-                if self._verbose:
-                    msg = _format_load_msg(
-                        func_id, args_id, timestamp=self.timestamp, metadata=metadata
-                    )
-
                 if not shelving:
                     # When shelving, we do not need to load the output
                     out = self.store_backend.load_item(
@@ -400,10 +394,6 @@ class FastMemorizedFunc(MemorizedFunc):
                 # PYCARET CHANGES END
                 # Memmap the output at the first call to be consistent with
                 # later calls
-                if self._verbose:
-                    msg = _format_load_msg(
-                        func_id, args_id, timestamp=self.timestamp, metadata=metadata
-                    )
                 out = self.store_backend.load_item(
                     [func_id, args_id], msg=msg, verbose=self._verbose
                 )


### PR DESCRIPTION
# Related Issue or bug

- https://github.com/pycaret/pycaret/issues/3977

# Info about Issue or bug:

- Do not use from joblib import _format_load_msg
- it's private and now removed. 

Closes #3977

# Describe the changes you've made

- removed joblib._format_load_msg() usage

# Type of change

Please delete options that are not relevant.
- [x] My code follows the code style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)