### PR TITLE
Fix ZeroDivisionError in _set_seasonal_type Method

### DIFF
--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -1232,8 +1232,17 @@ class TSForecastingExperiment(_TSSupervisedExperiment, TSForecastingPreprocessor
                         np.std(decomp_mult.resid * decomp_mult.seasonal)
                     ) ** 2
 
-                    Fs_add = np.maximum(1 - var_r_add / var_rs_add, 0)
-                    Fs_mult = np.maximum(1 - var_r_mult / var_rs_mult, 0)
+                    # added if conditions to avoid division by zero (https://github.com/pycaret/pycaret/issues/3997)
+                    Fs_add = (
+                        np.maximum(1 - var_r_add / var_rs_add, 0)
+                        if var_rs_add != 0
+                        else 0
+                    )
+                    Fs_mult = (
+                        np.maximum(1 - var_r_mult / var_rs_mult, 0)
+                        if var_rs_mult != 0
+                        else 0
+                    )
 
                     if Fs_mult > Fs_add:
                         seasonality_type = "mul"


### PR DESCRIPTION
This pull request addresses an issue in the TSForecastingExperiment class where a ZeroDivisionError could occur in the _set_seasonal_type method. The error happens during the calculation of the seasonality strength (Fs_add and Fs_mult) when the denominator is zero.

References:

Issue: [#3997](https://github.com/pycaret/pycaret/issues/3997)

# Related Issue or bug

when a time series df with same value across all timeframes are given to the setup experiment, then it throws error

Closes #3997 

# Describe the changes you've made

Added conditional checks to avoid division by zero in the _set_seasonal_type method.
The values of Fs_add and Fs_mult are now set to 0 if their respective denominators are zero.
These changes ensure that the method handles cases with zero variance in the residuals and seasonal components without causing runtime errors. The overall logic and functionality of the method remain intact.