### PR TITLE
docstring adjustment on regression module

### DIFF
--- a/pycaret/regression/functional.py
+++ b/pycaret/regression/functional.py
@@ -105,9 +105,9 @@ def setup(
     Example
     -------
     >>> from pycaret.datasets import get_data
-    >>> juice = get_data('juice')
-    >>> from pycaret.classification import *
-    >>> exp_name = setup(data = juice,  target = 'Purchase')
+    >>> insurance = get_data('insurance')
+    >>> from pycaret.regression import *
+    >>> exp_name = setup(data = insurance,  target = 'charges')
 
 
     data: dataframe-like = None
@@ -2670,9 +2670,9 @@ def dashboard(
     Example
     -------
     >>> from pycaret.datasets import get_data
-    >>> juice = get_data('juice')
-    >>> from pycaret.classification import *
-    >>> exp_name = setup(data = juice,  target = 'Purchase')
+    >>> insurance = get_data('insurance')
+    >>> from pycaret.regression import *
+    >>> exp_name = setup(data = insurance,  target = 'charges')
     >>> lr = create_model('lr')
     >>> dashboard(lr)
 

--- a/pycaret/regression/oop.py
+++ b/pycaret/regression/oop.py
@@ -161,9 +161,9 @@ class RegressionExperiment(_NonTSSupervisedExperiment, Preprocessor):
         Example
         -------
         >>> from pycaret.datasets import get_data
-        >>> juice = get_data('juice')
-        >>> from pycaret.classification import *
-        >>> exp_name = setup(data = juice,  target = 'Purchase')
+        >>> insurance = get_data('insurance')
+        >>> from pycaret.regression import *
+        >>> exp_name = setup(data = insurance,  target = 'charges')
 
 
         data: dataframe-like = None
@@ -2731,9 +2731,9 @@ class RegressionExperiment(_NonTSSupervisedExperiment, Preprocessor):
         Example
         -------
         >>> from pycaret.datasets import get_data
-        >>> juice = get_data('juice')
-        >>> from pycaret.classification import *
-        >>> exp_name = setup(data = juice,  target = 'Purchase')
+        >>> insurance = get_data('insurance')
+        >>> from pycaret.regression import *
+        >>> exp_name = setup(data = insurance,  target = 'charges')
         >>> lr = create_model('lr')
         >>> dashboard(lr)
 


### PR DESCRIPTION
# Describe the changes you've made

I did adjust the docstring document example in regression module. Before it is is showing an classification example that do not reflect the module task of regression.

I changed to reflect regression example on regression data 'insurance' in both functional.py and oop.py. Removing the juice and classification module.

Before
data: Juice
model: classification
target: Purchase

After
data: insurance
mode: regression
target: charges


# Type of change

- [X] This change requires a documentation update


# How Has This Been Tested?

It just change the data example, name of data, and regression task not classification


# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have made corresponding changes to the documentation.

