### PR TITLE
Fix: In parallel mode return empty list of models when no models was trained.

### DIFF
--- a/pycaret/parallel/fugue_backend.py
+++ b/pycaret/parallel/fugue_backend.py
@@ -163,7 +163,12 @@ class FugueBackend(ParallelBackend):
             as_fugue=True,
             as_local=True,
         ).as_array()
-        res = pd.concat(cloudpickle.loads(x[0]) for x in outputs)
+
+        pd_dataframe_for_models = [cloudpickle.loads(x[0]) for x in outputs]
+        if all(pd_dataframe_for_model.empty for pd_dataframe_for_model in pd_dataframe_for_models):
+            return []
+
+        res = pd.concat(pd_dataframe_for_models)
         res = res.sort_values(sort_col, ascending=asc)
         top = res.head(self._params.get("n_select", 1))
         instance._display_container.append(res.iloc[:, :-1])

--- a/tests/test_classification_parallel.py
+++ b/tests/test_classification_parallel.py
@@ -1,5 +1,6 @@
 import pycaret.classification as pc
 from pycaret.datasets import get_data
+from pycaret.parallel import FugueBackend
 
 
 def _score_dummy(y_true, y_prob, axis=0):
@@ -7,8 +8,6 @@ def _score_dummy(y_true, y_prob, axis=0):
 
 
 def test_classification_parallel():
-    from pycaret.parallel import FugueBackend
-
     pc.setup(
         data_func=lambda: get_data("juice", verbose=False),
         target="Purchase",
@@ -46,3 +45,24 @@ def test_classification_parallel():
 
     pc.compare_models(n_select=2, sort="DUMMY", parallel=be)
     pc.pull()
+
+
+def test_classification_parallel_returns_empty_models_list_when_no_model_is_trained():
+    pc.setup(
+        data_func=lambda: get_data("juice", verbose=False),
+        target="Purchase",
+        session_id=0,
+        n_jobs=1,
+        verbose=False,
+        html=False,
+    )
+
+    fconf = {
+        "fugue.rpc.server": "fugue.rpc.flask.FlaskRPCServer",
+        "fugue.rpc.flask_server.host": "localhost",
+        "fugue.rpc.flask_server.port": "3333",
+        "fugue.rpc.flask_server.timeout": "2 sec",
+    }
+
+    res = pc.compare_models(include=[], parallel=FugueBackend("dask", fconf, display_remote=True, batch_size=3, top_only=False))
+    assert (len(res) == 0)


### PR DESCRIPTION
# Related Issue or bug

Details of bug can be found here: #[[4028](https://github.com/pycaret/pycaret/issues/4028)]

Closes #[[4028](https://github.com/pycaret/pycaret/issues/4028)]

# Describe the changes you've made

I added handling a case when no model was trained (for each model pandas dataframe is empty). It should cover cases when no model was trained as well as training all models failed.

# Type of change


<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
**I am not sure**.
# How Has This Been Tested?

I added one unit test: `test_classification_parallel_returns_empty_models_list_when_no_model_is_trained`.

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

`NA`

# Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

# Screenshots
No screenshot.
