### PR TITLE
[MNT] Update Callable import from typing to collections.abc

### DIFF
--- a/pycaret/anomaly/functional.py
+++ b/pycaret/anomaly/functional.py
@@ -1,6 +1,13 @@
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
+
 import logging
 import os
-from typing import Any, BinaryIO, Callable, Dict, List, Optional, Union
+from collections.abc import Callable
+from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 import pandas as pd
 from joblib.memory import Memory

--- a/pycaret/classification/functional.py
+++ b/pycaret/classification/functional.py
@@ -1,6 +1,13 @@
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
+
 import logging
 import os
-from typing import Any, BinaryIO, Callable, Dict, List, Optional, Union
+from collections.abc import Callable
+from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 import pandas as pd
 from joblib.memory import Memory

--- a/pycaret/classification/oop.py
+++ b/pycaret/classification/oop.py
@@ -1,9 +1,16 @@
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
+
 import datetime
 import gc
 import logging
 import re
 import time
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import Any, Dict, List, Optional, Tuple, Union
 from unittest.mock import patch
 
 import numpy as np  # type: ignore

--- a/pycaret/clustering/functional.py
+++ b/pycaret/clustering/functional.py
@@ -1,6 +1,13 @@
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
+
 import logging
 import os
-from typing import Any, BinaryIO, Callable, Dict, List, Optional, Union
+from collections.abc import Callable
+from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 import pandas as pd
 from joblib.memory import Memory

--- a/pycaret/containers/metrics/base_metric.py
+++ b/pycaret/containers/metrics/base_metric.py
@@ -1,6 +1,10 @@
+# Copyright (C) 2019-2024 PyCaret
+
 # Module: containers.metrics.base_metric
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
 # License: MIT
+
 
 from typing import Any, Dict, Optional, Union
 

--- a/pycaret/containers/metrics/clustering.py
+++ b/pycaret/containers/metrics/clustering.py
@@ -1,5 +1,8 @@
+# Copyright (C) 2019-2024 PyCaret
+
 # Module: containers.metrics.clustering
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
 # License: MIT
 
 # The purpose of this module is to serve as a central repository of clustering metrics. The `clustering` module will

--- a/pycaret/internal/logging.py
+++ b/pycaret/internal/logging.py
@@ -1,13 +1,17 @@
+# Copyright (C) 2019-2024 PyCaret
+
 # Module: internal.logging
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
 # License: MIT
 
 import logging
 import os
 import traceback
 import warnings
+from collections.abc import Callable
 from contextlib import redirect_stderr, redirect_stdout
-from typing import Callable, Optional, Union
+from typing import Optional, Union
 
 try:
     from wurlitzer import pipes

--- a/pycaret/internal/metrics.py
+++ b/pycaret/internal/metrics.py
@@ -1,6 +1,12 @@
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
+
 import traceback
 import warnings
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 from sklearn.exceptions import FitFailedWarning

--- a/pycaret/internal/patches/sklearn.py
+++ b/pycaret/internal/patches/sklearn.py
@@ -1,4 +1,11 @@
-from typing import Any, Callable
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
+
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import patch
 
 import numpy as np

--- a/pycaret/internal/pycaret_experiment/pycaret_experiment.py
+++ b/pycaret/internal/pycaret_experiment/pycaret_experiment.py
@@ -1,8 +1,15 @@
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
+
 import inspect
 import os
 import warnings
 from collections import defaultdict
-from typing import Any, BinaryIO, Callable, Dict, Optional, Union
+from collections.abc import Callable
+from typing import Any, BinaryIO, Dict, Optional, Union
 
 import cloudpickle
 import pandas as pd

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
+
 import datetime
 import gc
 import os
@@ -5,9 +11,10 @@ import time
 import traceback
 import warnings
 from abc import abstractmethod
+from collections.abc import Callable
 from copy import copy, deepcopy
 from functools import partial
-from typing import Any, BinaryIO, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, BinaryIO, Dict, List, Optional, Set, Tuple, Union
 from unittest.mock import patch
 
 import matplotlib.pyplot as plt

--- a/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
@@ -1,9 +1,16 @@
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
+
 import datetime
 import gc
 import logging
 import time
 import traceback
-from typing import Any, Callable, Dict, List, Optional, Union
+from collections.abc import Callable
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np  # type: ignore
 import pandas as pd

--- a/pycaret/parallel/fugue_backend.py
+++ b/pycaret/parallel/fugue_backend.py
@@ -1,7 +1,13 @@
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
 import random
+from collections.abc import Callable
 from math import ceil
 from threading import RLock
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import cloudpickle
 import pandas as pd

--- a/pycaret/regression/functional.py
+++ b/pycaret/regression/functional.py
@@ -1,6 +1,13 @@
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
+
 import logging
 import os
-from typing import Any, BinaryIO, Callable, Dict, List, Optional, Union
+from collections.abc import Callable
+from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 import pandas as pd
 from joblib.memory import Memory

--- a/pycaret/regression/oop.py
+++ b/pycaret/regression/oop.py
@@ -1,7 +1,14 @@
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
+
 import logging
 import re
 import time
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np  # type: ignore
 import pandas as pd

--- a/pycaret/time_series/forecasting/functional.py
+++ b/pycaret/time_series/forecasting/functional.py
@@ -1,19 +1,16 @@
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
+
 """Functional API for Time Series Forecasting Experiment
 """
 
 import logging
 import os
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    BinaryIO,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, BinaryIO, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
+
 import datetime
 import gc
 import logging
@@ -6,8 +12,9 @@ import time
 import traceback
 import warnings
 from collections import defaultdict
+from collections.abc import Callable
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd

--- a/pycaret/utils/generic.py
+++ b/pycaret/utils/generic.py
@@ -1,11 +1,17 @@
+# Copyright (C) 2019-2024 PyCaret
+# Author: Moez Ali (moez.ali@queensu.ca)
+# Contributors (https://github.com/pycaret/pycaret/graphs/contributors)
+# License: MIT
+
+
 import functools
 import inspect
 import traceback
 import warnings
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from copy import deepcopy
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
As per official documentation (https://docs.python.org/3.9/library/typing.html#typing.Callable), typing.Callable is deprecated in favour of collections.abc.Callable. This PR makes the corresponding changes in the imports.

I also updated/created the headers with references to the authors. In case there are no references to the module's author, I created the default header with author Moez Ali.

To do: module authors must update the headers with their names!