### PR TITLE
Update scikit-plot to mljar-scikit-plot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ trio>=0.22.0,<0.25.0 #fixes problems about third-party packages, remove after ht
 
 # Plotting
 matplotlib<3.8.0 #stem(..., use_line_collection=False) is no longer supported. 
-scikit-plot>=0.3.7
+mljar-scikit-plot #this is a updated version of original scikit-plot
 # yellowbrick<=1.5, have conflict with recent matplotlib by use_line_collection error
 # should use yellowbrick>1.5 when fixed (https://github.com/DistrictDataLabs/yellowbrick/issues/1312)
 yellowbrick>=1.4


### PR DESCRIPTION
scikit-plot hasn't been updated in 6 years, so I found a fork to keep the package up to date: mljar-scikit-plot (https://github.com/mljar/mljar-scikit-plot)