### PR TITLE
Fix: AttributeError: 'Styler' object has no attribute 'applymap'

### DIFF
--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -336,7 +336,7 @@ class _SupervisedExperiment(_TabularExperiment):
                         if x in greater_is_worse_columns
                     ],
                 )
-                .applymap(highlight_cols, subset=["TT (Sec)"])
+                .map(highlight_cols, subset=["TT (Sec)"])
             )
         else:
             return pd.DataFrame().style


### PR DESCRIPTION
The [DataFrame.map()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.map.html#pandas.DataFrame.map) been added and [DataFrame.applymap()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.applymap.html#pandas.DataFrame.applymap) has been deprecated. [DataFrame.map()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.map.html#pandas.DataFrame.map) has the same functionality as [DataFrame.applymap()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.applymap.html#pandas.DataFrame.applymap), but the new name better communicates that this is the [DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html#pandas.DataFrame) version of [Series.map()](https://pandas.pydata.org/docs/reference/api/pandas.Series.map.html#pandas.Series.map) ([GH 52353](https://github.com/pandas-dev/pandas/issues/52353)).

Ref: https://pandas.pydata.org/docs/whatsnew/v2.1.0.html#new-dataframe-map-method-and-support-for-extensionarrays