### PR TITLE
Reset index after concatenating train and test dataframes

### DIFF
--- a/pycaret/internal/preprocess/preprocessor.py
+++ b/pycaret/internal/preprocess/preprocessor.py
@@ -258,7 +258,7 @@ class Preprocessor:
                 self.data.index = self.index[: len(self.data)]
                 test_data.index = self.index[-len(test_data) :]
 
-            self.data = self._set_index(pd.concat([self.data, test_data]))
+            self.data = self._set_index(pd.concat([self.data, test_data]).reset_index(drop=True))
             self.idx = [
                 self.data.index[: -len(test_data)],
                 self.data.index[-len(test_data) :],


### PR DESCRIPTION
# Related Issue or bug

Info about Issue or bug

Closes #4039

# Describe the changes you've made

Simply added `.reset_index(drop=True)` after the `pd.concat` operation.  

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

NA 

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

NA

# Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

# Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
