### PR TITLE
Fix of issue #4064: Do not use collections.abc.Callable in fugue_backend.py.  Keep usage of typing.Callable instead of collections.abc.Callable until fugue is fixed.

### DIFF
--- a/pycaret/parallel/fugue_backend.py
+++ b/pycaret/parallel/fugue_backend.py
@@ -4,10 +4,9 @@
 # License: MIT
 
 import random
-from collections.abc import Callable
 from math import ceil
 from threading import RLock
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import cloudpickle
 import pandas as pd


### PR DESCRIPTION
On the [fugue side](https://github.com/fugue-project/fugue/blob/master/fugue/dataframe/function_wrapper.py#L170) `Optional[collections.abc.Callable]` is not handled. As long as it is not handled at fugue side let's use `typing.Callable` - I believe it is better to rely on deprecated feature instead of red CI tests on master. 

# Related Issue or bug

Closes [#4064 ](https://github.com/pycaret/pycaret/issues/4064)

# Describe the changes you've made

I restored usage of `typing.Callable` only in case of `fugue_backend.py`.

# Type of change

Please delete options that are not relevant.
<!--

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

At this moment on master `test_classification_parallel` fails. After my change it passes.

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA
A clear and concise description of it.

# Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

# Screenshots

NA