### PR TITLE
Make Plotting dependencies Optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ dask*/
 tmp/
 nbtest1.ipynb
 .DS_Store
+pycaret-env/

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -38,3 +38,14 @@ distributed>=2024.4.1     # Python 3.11.9 breaks Dask (https://github.com/dask/d
 fugue~=0.8.0
 flask
 Werkzeug>=2.2,<3.0
+
+# Plotting
+matplotlib<3.8.0 #stem(..., use_line_collection=False) is no longer supported. 
+mljar-scikit-plot #this is a updated version of original scikit-plot
+# yellowbrick<=1.5, have conflict with recent matplotlib by use_line_collection error
+# should use yellowbrick>1.5 when fixed (https://github.com/DistrictDataLabs/yellowbrick/issues/1312)
+yellowbrick>=1.4
+plotly>=5.14.0
+kaleido>=0.2.1
+schemdraw==0.15  # 0.16 only supports Python >3.8
+plotly-resampler>=0.8.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,17 +25,6 @@ wurlitzer; platform_system != 'Windows'
 trio>=0.22.0,<0.25.0 #fixes problems about third-party packages, remove after httpcore 1.05
 setuptools; python_version>='3.12'
 
-# Plotting
-matplotlib<3.8.0 #stem(..., use_line_collection=False) is no longer supported. 
-mljar-scikit-plot #this is a updated version of original scikit-plot
-# yellowbrick<=1.5, have conflict with recent matplotlib by use_line_collection error
-# should use yellowbrick>1.5 when fixed (https://github.com/DistrictDataLabs/yellowbrick/issues/1312)
-yellowbrick>=1.4
-plotly>=5.14.0
-kaleido>=0.2.1
-schemdraw==0.15  # 0.16 only supports Python >3.8
-plotly-resampler>=0.8.3.1
-
 # Time-series
 statsmodels>=0.12.1
 sktime #sktime adds support for scikit-learn 1.5 in version sktime 0.31

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ extras_require = {
     "tuners": required_optional.split("\n\n")[2].splitlines(),
     "mlops": required_optional.split("\n\n")[3].splitlines(),
     "parallel": required_optional.split("\n\n")[4].splitlines(),
+    "plots": required_optional.split("\n\n")[5].splitlines(),
     "test": required_test,
     "dev": required_dev,
 }
@@ -41,6 +42,7 @@ extras_require["full"] = (
     + extras_require["tuners"]
     + extras_require["mlops"]
     + extras_require["parallel"]
+    + extras_require["plots"]
     + extras_require["test"]
     + extras_require["dev"]
 )


### PR DESCRIPTION
# Related Issue or bug
This PR addresses GitHub issue #4066 about making plotting dependencies optional in PyCaret.  The plotting dependencies will no longer be installed by default saving time and space for many users who will not use PyCaret for visualization. However, they can install the plotting dependencies using the `pip install pycaret[plots]` command.

Closes #4066 

# Describe the changes you've made

- Moved over plotting dependencies from `requirements.txt` to `requirements-optional.txt`.
- Added an extra `[plots]` dependency installation option in `setup.py`.

# Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Ran PyCaret without installing `[plots]` to check it works fine for non-plotting tasks.
- Tried using plotting without the libraries, which throws errors. Specific error messages can be added to guide users to use the `pip install pycaret[plots]` command when plotting dependencies are missing.
- Installed `[plots]` and confirmed that plotting works properly.

# Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

NA

# Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

# Screenshots
NA
 