### PR TITLE
Dependencies: Isolate "timeseries" dependencies into separate "extra"

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ pip install pycaret[mlops]
 # install parallel extras
 pip install pycaret[parallel]
 
+# install timeseries extras
+pip install pycaret[timeseries]
+
 # install test extras
 pip install pycaret[test]
 

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -38,3 +38,9 @@ distributed>=2024.4.1     # Python 3.11.9 breaks Dask (https://github.com/dask/d
 fugue~=0.8.0
 flask
 Werkzeug>=2.2,<3.0
+
+# Time-series
+statsmodels>=0.12.1
+sktime #sktime adds support for scikit-learn 1.5 in version sktime 0.31
+tbats>=1.1.3
+pmdarima>=2.0.4

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -43,4 +43,4 @@ Werkzeug>=2.2,<3.0
 statsmodels>=0.12.1
 sktime #sktime adds support for scikit-learn 1.5 in version sktime 0.31
 tbats>=1.1.3
-pmdarima>=2.0.4
+pmdarima>=2.0.4; python_version<'3.13'

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,9 +35,3 @@ plotly>=5.14.0
 kaleido>=0.2.1
 schemdraw==0.15  # 0.16 only supports Python >3.8
 plotly-resampler>=0.8.3.1
-
-# Time-series
-statsmodels>=0.12.1
-sktime #sktime adds support for scikit-learn 1.5 in version sktime 0.31
-tbats>=1.1.3
-pmdarima>=2.0.4

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ extras_require = {
     "tuners": required_optional.split("\n\n")[2].splitlines(),
     "mlops": required_optional.split("\n\n")[3].splitlines(),
     "parallel": required_optional.split("\n\n")[4].splitlines(),
+    "timeseries": required_optional.split("\n\n")[5].splitlines(),
     "test": required_test,
     "dev": required_dev,
 }
@@ -41,6 +42,7 @@ extras_require["full"] = (
     + extras_require["tuners"]
     + extras_require["mlops"]
     + extras_require["parallel"]
+    + extras_require["timeseries"]
     + extras_require["test"]
     + extras_require["dev"]
 )


### PR DESCRIPTION
Hi there,

this patch implements the idea to also isolate dependencies concerning "timeseries" functionality. It also defines that the pmdarima package will only be installed up until Python 3.12, because it is not available for Python 3.13, yet.

The intent is to unblock installing PyCaret on Python 3.13. Thank you in advance for looking into this. ✨ 

With kind regards,
Andreas.

## References
- https://github.com/pycaret/pycaret/issues/4121
- https://github.com/alkaline-ml/pmdarima/issues/588
