### PR TITLE
[MNT] isolate `pmdarima` dependency

### DIFF
--- a/pycaret/internal/tests/time_series.py
+++ b/pycaret/internal/tests/time_series.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 import statsmodels.api as sm
-from pmdarima.arima.utils import ndiffs, nsdiffs
 from statsmodels.tools.sm_exceptions import MissingDataError as SmMissingDataError
 from statsmodels.tsa.api import kpss
 from statsmodels.tsa.stattools import adfuller
@@ -599,6 +598,15 @@ def recommend_lowercase_d(data: pd.Series, **kwargs) -> int:
     int
         The differencing order to use
     """
+    try:
+        from pmdarima.arima.utils import ndiffs
+    except ImportError:
+        raise ImportError(
+            "Error in recommend_lowercase_d: "
+            "soft dependency pmdarima is required to run this function. "
+            "Please install using `pip install pmdarima`"
+        )
+
     recommended_lowercase_d = ndiffs(data, **kwargs)
     return recommended_lowercase_d
 
@@ -630,6 +638,15 @@ def recommend_uppercase_d(data: pd.Series, sp: int, **kwargs) -> int:
     int
         The differencing order to use
     """
+    try:
+        from pmdarima.arima.utils import nsdiffs
+    except ImportError:
+        raise ImportError(
+            "Error in recommend_uppercase_d: "
+            "soft dependency pmdarima is required to run this function. "
+            "Please install using `pip install pmdarima`"
+        )
+
     recommended_uppercase_d = nsdiffs(data, m=sp, **kwargs)
     return recommended_uppercase_d
 

--- a/pycaret/utils/time_series/__init__.py
+++ b/pycaret/utils/time_series/__init__.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-from pmdarima.arima.utils import ndiffs
 from sktime.param_est.seasonality import SeasonalityACF
 from sktime.transformations.series.difference import Differencer
 from sktime.utils.plotting import plot_series
@@ -241,6 +240,14 @@ def auto_detect_sp(
         (2) List of all significant seasonal periods
         (3) The number of lags used to detected seasonality
     """
+    try:
+        from pmdarima.arima.utils import ndiffs
+    except ImportError:
+        raise ImportError(
+            "Error in auto_detect_p: "
+            "soft dependency pmdarima is required to run this function. "
+            "Please install using `pip install pmdarima`"
+        )
 
     yt = y.copy()
     for i in np.arange(ndiffs(yt)):


### PR DESCRIPTION
This PR isolates `pmdarima` imports in functions, ensuring that it could be moved to a soft dependency set at some point in the future.

This is very bare-bones, probably `TSForecastingExperiment.setup` should at the start also do a dependency check.

For now, this PR illustrates how to minimally isolate a dependency inside the code base.

Fixes #4127