### PR TITLE
[MNT] Fix flake8 linter errors

### DIFF
--- a/pycaret/classification/oop.py
+++ b/pycaret/classification/oop.py
@@ -2711,7 +2711,7 @@ class ClassificationExperiment(_NonTSSupervisedExperiment, Preprocessor):
 
         message = (
             "optimization loop finished successfully. "
-            f"Best threshold: {result.x[0]} with {optimize}={result.fun*direction}"
+            f"Best threshold: {result.x[0]} with {optimize}={result.fun * direction}"
         )
         if verbose:
             print(message)

--- a/pycaret/internal/display/progress_bar.py
+++ b/pycaret/internal/display/progress_bar.py
@@ -116,7 +116,7 @@ class ProgressBarDisplay(DisplayComponent):
         description: str = "Processing: ",
         *,
         verbose: bool = True,
-        backend: Optional[Union[str, DisplayBackend]] = None
+        backend: Optional[Union[str, DisplayBackend]] = None,
     ) -> None:
         super().__init__(verbose=verbose, backend=backend)
         self.pbar_backend_cls: Optional[

--- a/pycaret/internal/patches/sklearn.py
+++ b/pycaret/internal/patches/sklearn.py
@@ -160,10 +160,13 @@ def fit_and_score(*args, **kwargs) -> dict:
     """
 
     def wrapper(*args, **kwargs) -> dict:
-        with patch(
-            "sklearn.model_selection._validation._MultimetricScorer",
-            MultimetricScorerPatched,
-        ), patch("sklearn.model_selection._validation._score", score(_score)):
+        with (
+            patch(
+                "sklearn.model_selection._validation._MultimetricScorer",
+                MultimetricScorerPatched,
+            ),
+            patch("sklearn.model_selection._validation._score", score(_score)),
+        ):
             return _fit_and_score(*args, **kwargs)
 
     return wrapper(*args, **kwargs)

--- a/pycaret/utils/time_series/__init__.py
+++ b/pycaret/utils/time_series/__init__.py
@@ -245,7 +245,7 @@ def auto_detect_sp(
     yt = y.copy()
     for i in np.arange(ndiffs(yt)):
         if verbose:
-            print(f"Differencing: {i+1}")
+            print(f"Differencing: {i + 1}")
         differencer = Differencer()
         yt = differencer.fit_transform(yt)
 

--- a/tests/benchmarks/test_memory_performance.py
+++ b/tests/benchmarks/test_memory_performance.py
@@ -63,7 +63,7 @@ def _test_synthetic_data(data, repeats: int = 100):
         )
     )
     print(
-        f"Original: {original_joblib_time} vs PyCaret: {pycaret_joblib_time} ({original_joblib_time-pycaret_joblib_time})"
+        f"Original: {original_joblib_time} vs PyCaret: {pycaret_joblib_time} ({original_joblib_time - pycaret_joblib_time})"
     )
     return original_joblib_time, pycaret_joblib_time
 
@@ -84,7 +84,7 @@ def _test_real_data(data_name: str, repeats: int = 20):
     )
     print(f"({data_name} {data.shape}")
     print(
-        f"({data_name}) Original: {original_joblib_time} vs PyCaret: {pycaret_joblib_time} ({original_joblib_time-pycaret_joblib_time})"
+        f"({data_name}) Original: {original_joblib_time} vs PyCaret: {pycaret_joblib_time} ({original_joblib_time - pycaret_joblib_time})"
     )
     return original_joblib_time, pycaret_joblib_time
 
@@ -154,7 +154,7 @@ def _test_e2e_timeit(
         ).repeat(repeats, 1)
     )
     print(
-        f"({data_name}) Original: {original_joblib_time} vs PyCaret: {pycaret_joblib_time} ({original_joblib_time-pycaret_joblib_time})"
+        f"({data_name}) Original: {original_joblib_time} vs PyCaret: {pycaret_joblib_time} ({original_joblib_time - pycaret_joblib_time})"
     )
     return original_joblib_time, pycaret_joblib_time
 


### PR DESCRIPTION
## Problem
CI currently fails on the linting workflow, which uses flake8, [like this](https://github.com/pycaret/pycaret/actions/runs/13234026192/job/36935724677#step:5:45):
```
pycaret/classification/oop.py:2714:72: E226 missing whitespace around arithmetic operator
pycaret/utils/time_series/__init__.py:248:37: E226 missing whitespace around arithmetic operator
tests/benchmarks/test_memory_performance.py:66:100: E226 missing whitespace around arithmetic operator
tests/benchmarks/test_memory_performance.py:87:114: E226 missing whitespace around arithmetic operator
tests/benchmarks/test_memory_performance.py:157:114: E226 missing whitespace around arithmetic operator
```

## References
- The patch includes and supersedes GH-4125.
