### PR TITLE
[MNT] CI: Run test workflow also on stacked PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   schedule:
     - cron: "0 5 * * *"
 


### PR DESCRIPTION
This little patch adjusts the `test` CI job to run the workflow also on stacked PRs (not just PR to `master`).
This helps when staging multiple PRs at the same time.