### PR TITLE
CI: Properly disable "Lock Old Threads" workflow

### DIFF
--- a/.github/workflows/lock_old_threads.yml
+++ b/.github/workflows/lock_old_threads.yml
@@ -1,9 +1,9 @@
 name: 'Lock Old Threads'
 
-# on:
-#  schedule:
-#  - cron: '45 1 * * *'
-  suspend: true
+on:
+  #schedule:
+  #- cron: '45 1 * * *'
+  workflow_dispatch:
 
 permissions:
   issues: write


### PR DESCRIPTION
## Problem
There is an erroneous GHA workflow file, introduced by c62c2bfde23.
- Invalid workflow file: `.github/workflows/lock_old_threads.yml#L5`.
  You have an error in your yaml syntax on line 5.
- Error: No event triggers defined in `on`.

## Solution
Deactivate that particular workflow by using `on: workflow_dispatch`, as [suggested](https://safjan.com/quick-ways-to-disable-github-actions-workflows-without-deletion/).
