### PR TITLE
[MNT] Bump SHAP version to 0.46.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ dependencies = [
 # users can install via "pip install pycaret[full]"
 #
 full = [
-  "shap>=0.44.0,<=0.46.0",
+  "shap>=0.44.0,<0.47.0",
   "interpret>=0.2.7",
   "umap-learn>=0.5.2",
   "pyyaml",
@@ -148,7 +148,7 @@ full = [
 ]
 
 analysis = [
-  "shap>=0.44.0,<=0.46.0",
+  "shap>=0.44.0,<0.47.0",
   "interpret>=0.2.7",
   "umap-learn>=0.5.2",
   "pyyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ dependencies = [
 # users can install via "pip install pycaret[full]"
 #
 full = [
-  "shap~=0.44.0",  # 0.44.0 fixes matplotlib use_line_collection error
+  "shap>=0.44.0",
   "interpret>=0.2.7",
   "umap-learn>=0.5.2",
   "pyyaml",
@@ -148,7 +148,7 @@ full = [
 ]
 
 analysis = [
-  "shap~=0.44.0",  # 0.44.0 fixes matplotlib use_line_collection error
+  "shap>=0.44.0",
   "interpret>=0.2.7",
   "umap-learn>=0.5.2",
   "pyyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ dependencies = [
 # users can install via "pip install pycaret[full]"
 #
 full = [
-  "shap>=0.44.0",
+  "shap>=0.44.0,<=0.46.0",
   "interpret>=0.2.7",
   "umap-learn>=0.5.2",
   "pyyaml",
@@ -148,7 +148,7 @@ full = [
 ]
 
 analysis = [
-  "shap>=0.44.0",
+  "shap>=0.44.0,<=0.46.0",
   "interpret>=0.2.7",
   "umap-learn>=0.5.2",
   "pyyaml",


### PR DESCRIPTION
Bump SHAP version to 0.46.0

Closes https://github.com/pycaret/pycaret/issues/4149