### PR TITLE
fix tests

### DIFF
--- a/pycaret/internal/preprocess/preprocessor.py
+++ b/pycaret/internal/preprocess/preprocessor.py
@@ -206,7 +206,7 @@ class Preprocessor:
 
         if df.index.duplicated().any():
             raise ValueError(
-                "Invalid value for the index parameter. There are duplicate indices "
+                "Invalid value for the index parameter. There are duplicate indices."
                 "in the dataset. Use index=False to reset the index to RangeIndex."
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
   "jinja2>=3",
   "scipy>=1.6.1,<=1.11.4",  # to fix later (
   "joblib>=1.2.0,<1.4",  # joblib<1.2.0 is vulnerable to Arbitrary Code Execution
-  "scikit-learn>1.4.0",
+  "scikit-learn>1.4.0,<1.6",
   "pyod>=1.1.3",  # 1.1.3 to support scikit-learn 1.4
   "imbalanced-learn>=0.12.0",  # >=0.12.0 to support scikit-learn 1.4
   "category-encoders>=2.4.0",

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -116,6 +116,9 @@ def test_duplicate_columns():
 def test_duplicate_indices():
     """Assert that an error is raised when there are duplicate indices."""
     data = pycaret.datasets.get_data("juice")
+    # force duplicate indices:
+    data = data.reset_index(drop=True)
+    data.index = [0] * len(data)  # all index will be 0
     with pytest.raises(ValueError, match=".*duplicate indices.*"):
         pycaret.classification.setup(
             data=data,

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -123,7 +123,7 @@ def test_duplicate_indices():
         pycaret.classification.setup(
             data=data,
             test_data=data,
-            index=True,
+            index=False,
         )
 
 


### PR DESCRIPTION
many packages are in new versions but the pycaret code has not followed these changes. You need to start over with the old packages and update the pycaret code until it supports the latest versions.

example: scikit-learn had no limitations so as the package is in version 1.6 pycaret does not pass the tests, so it is necessary to downgrade to 1.5, modify the code, for the tests to pass and only then update again to 1.6 and update the pycaret code.