### PR TITLE
api: close data source file handle during rows estimation

### DIFF
--- a/services/api/pycaret_server/api/data_sources.py
+++ b/services/api/pycaret_server/api/data_sources.py
@@ -161,7 +161,8 @@ async def upload_csv(
     try:
         sample = pd.read_csv(target, nrows=5)
         columns = [str(c) for c in sample.columns]
-        rows_est = sum(1 for _ in open(target, encoding="utf-8")) - 1
+        with open(target, encoding="utf-8") as f:
+            rows_est = sum(1 for _ in f) - 1
     except Exception as exc:  # noqa: BLE001
         target.unlink(missing_ok=True)
         raise HTTPException(status.HTTP_400_BAD_REQUEST, f"could not parse CSV: {exc}") from exc


### PR DESCRIPTION
## Summary

File handles left open when calculating row counts on uploaded CSV data sources led to potential file descriptor leaks. Addressing this, I wrapped the file read operation in a context block during immediate sampling to ensure clean resource release.

## Related issue

Fixes a resource leak identified during local static code analysis.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / tech-debt cleanup
- [ ] Docs / contributor-facing
- [ ] CI / build
- [ ] Verb migration (legacy → native)

## PR checklist

- [ ] Tests added or updated
- [x] `uv run ruff check pycaret tests` passes
- [x] `uv run ruff format --check pycaret tests` passes
- [x] `uv run pytest tests/test_core_architecture.py tests/test_datasets.py -q` passes locally
- [ ] Release-notes entry appended to `docs/revamp/release_notes_pycaret4.md`

## Notes for reviewers

Checking the ruff formatter locally showed all checks passed. Similar logic could be applied to other file uploads if dynamic reading is expanded.