### PR TITLE
BUG: Fix Anomaly_Score using raw data instead of preprocessed data in predict_model

### DIFF
--- a/packages/engine/pycaret/core/experiment.py
+++ b/packages/engine/pycaret/core/experiment.py
@@ -1619,7 +1619,7 @@ class Experiment(BaseEstimator):
             out["Anomaly"] = preds
             if hasattr(estimator, "decision_function"):
                 try:
-                    out["Anomaly_Score"] = estimator.decision_function(X)
+                    out["Anomaly_Score"] = estimator.decision_function(X_for_pred)
                 except Exception:  # pragma: no cover — defensive
                     pass
         else:


### PR DESCRIPTION
## Summary

Fixes #4216

In `predict_model`, when a bare estimator (not wrapped in a Pipeline) is passed for anomaly detection, the `decision_function` is called on raw, unpreprocessed `X` instead of `X_for_pred`. This causes the decision function to fail (e.g., on string columns, NaNs), and the exception is silently swallowed by a bare `except`, resulting in the `Anomaly_Score` column being silently dropped from predictions.

## Fix

Change `estimator.decision_function(X)` → `estimator.decision_function(X_for_pred)` so that the anomaly score is computed on the same preprocessed data used for predictions.

## Before (broken)
```python
out["Anomaly_Score"] = estimator.decision_function(X)  # raw data — crashes silently
```

## After (fixed)
```python
out["Anomaly_Score"] = estimator.decision_function(X_for_pred)  # preprocessed data
```